### PR TITLE
Box Provider

### DIFF
--- a/waterbutler/providers/box/metadata.py
+++ b/waterbutler/providers/box/metadata.py
@@ -48,6 +48,12 @@ class BoxFileMetadata(BaseBoxMetadata, metadata.BaseFileMetadata):
     def content_type(self):
         return None
 
+    @property
+    def extra(self):
+        return {
+            'etag': self.raw.get('etag')
+        }
+
 
 class BoxRevision(metadata.BaseFileRevisionMetadata):
 
@@ -77,5 +83,7 @@ class BoxRevision(metadata.BaseFileRevisionMetadata):
             return self.raw.get('modified')
 
     @property
-    def revision(self):
-        return self.raw['etag']
+    def extra(self):
+        return {
+            'etag': self.raw.get('etag')
+        }

--- a/waterbutler/providers/box/metadata.py
+++ b/waterbutler/providers/box/metadata.py
@@ -85,5 +85,5 @@ class BoxRevision(metadata.BaseFileRevisionMetadata):
     @property
     def extra(self):
         return {
-            'etag': self.raw.get('etag')
+            'etag': self.raw['etag']
         }

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -30,7 +30,7 @@ class BoxProvider(provider.BaseProvider):
     def __init__(self, auth, credentials, settings):
         super().__init__(auth, credentials, settings)
         self.token = self.credentials['token']
-        self.folder = self.settings['folder_id']
+        self.folder = self.settings['folder']
 
     @property
     def default_headers(self):
@@ -56,7 +56,10 @@ class BoxProvider(provider.BaseProvider):
 
     @asyncio.coroutine
     def upload(self, stream, path, **kwargs):
-        path = BoxPath('/{}{}'.format(self.folder.lstrip('/'), path))
+        if path.split('/')[0] == '':
+            path = '/{}{}'.format(self.folder, path)
+        import ipdb; ipdb.set_trace()
+        path = BoxPath(path)
         try:
             meta = yield from self.metadata(str(path))
         except exceptions.MetadataError:

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -30,7 +30,7 @@ class BoxProvider(provider.BaseProvider):
     def __init__(self, auth, credentials, settings):
         super().__init__(auth, credentials, settings)
         self.token = self.credentials['token']
-        self.folder = self.settings['folder']
+        self.folder = self.settings['folder_id']
 
     @property
     def default_headers(self):


### PR DESCRIPTION
Purpose
=======
Add Box to the supported providers for waterbutler
Accompanies: https://github.com/CenterForOpenScience/osf.io/pull/1758

Changes
=======
* Box support added
* FormData added to utils (from @chrisseto )

Side Effects
=========
* Theoretically possible for a user to intercept outgoing requests, edit the id, and gain access to an authorizer's files that aren't in the shared directory