### PR TITLE
Hotfix/box full pathname

### DIFF
--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -306,6 +306,7 @@ class TestCRUD:
         aiohttpretty.register_json_uri('GET', folder_list_url, body=folder_list_metadata)
         aiohttpretty.register_json_uri('POST', upload_url, status=201, body=file_metadata)
         metadata, created = yield from provider.upload(file_stream, str(path))
+        file_metadata['entries'][0]['fullPath'] = '/Pictures/newfile'
         expected = BoxFileMetadata(file_metadata['entries'][0], provider.folder).serialized()
 
         assert metadata == expected
@@ -326,6 +327,7 @@ class TestCRUD:
         aiohttpretty.register_json_uri('GET', folder_list_url, body=folder_list_metadata)
         aiohttpretty.register_json_uri('POST', upload_url, status=201, body=file_metadata)
         metadata, created = yield from provider.upload(file_stream, str(path))
+        file_metadata['entries'][0]['fullPath'] = '/Pictures/Stephen Curry Three Pointers'
         expected = BoxFileMetadata(file_metadata['entries'][0], provider.folder).serialized()
 
         assert metadata == expected

--- a/waterbutler/providers/box/metadata.py
+++ b/waterbutler/providers/box/metadata.py
@@ -51,7 +51,8 @@ class BoxFileMetadata(BaseBoxMetadata, metadata.BaseFileMetadata):
     @property
     def extra(self):
         return {
-            'etag': self.raw.get('etag')
+            'etag': self.raw.get('etag'),
+            'fullPath': self.raw.get('fullPath')
         }
 
 

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -68,6 +68,7 @@ class BoxProvider(provider.BaseProvider):
             created = True
             data = yield from self._send_upload(stream, name, parent_id)
 
+        data['entries'][0]['fullPath'] = self._build_full_path(data['entries'][0]['path_collection']['entries'][1:], name)
         return BoxFileMetadata(data['entries'][0], self.folder).serialized(), created
 
     @asyncio.coroutine
@@ -197,3 +198,16 @@ class BoxProvider(provider.BaseProvider):
 
     def _build_upload_url(self, *segments, **query):
         return provider.build_url(settings.BASE_UPLOAD_URL, *segments, **query)
+
+    def _build_full_path(self, entries, filename):
+        seq_id = 0
+        for item in entries:
+            if self.folder == item['id']:
+                seq_id = int(item['sequence_id'])
+
+        return '/{}/{}'.format('/'.join([
+            x['name']
+            for x in entries
+            if int(x['sequence_id']) >= seq_id]),
+            filename
+        )


### PR DESCRIPTION
Purpose
=======
Return 'fullPath' in metadata for logging purposes (upon upload)
Accompanies PR: https://github.com/CenterForOpenScience/osf.io/pull/1981

Changes
=======
'fullPath' added to metadata in upload()
Fix resulting test failures

Side Effects
=========