### PR TITLE
Add canDelete field to figshare extra metadata.

### DIFF
--- a/tests/providers/figshare/test_provider.py
+++ b/tests/providers/figshare/test_provider.py
@@ -340,24 +340,6 @@ class TestCRUD:
 
     @async
     @pytest.mark.aiohttpretty
-    def test_project_article_delete_public(self, project_provider, list_project_articles, article_metadata, file_metadata):
-        article_id = str(list_project_articles[0]['id'])
-        file_id = str(file_metadata['id'])
-        path = '/{0}/{1}'.format(article_id, file_id)
-        article_metadata['items'][0]['status'] = 'Public'
-        list_articles_url = project_provider.build_url('projects', project_provider.project_id, 'articles')
-        article_metadata_url = project_provider.build_url('articles', article_id)
-        article_delete_url = project_provider.build_url('articles', article_id, 'files', file_id)
-        aiohttpretty.register_json_uri('GET', list_articles_url, body=list_project_articles)
-        aiohttpretty.register_json_uri('GET', article_metadata_url, body=article_metadata)
-        aiohttpretty.register_uri('DELETE', article_delete_url)
-        with pytest.raises(exceptions.DeleteError) as exc_info:
-            yield from project_provider.delete(path)
-        assert exc_info.value.code == 403
-        assert not aiohttpretty.has_call(method='DELETE', uri=article_delete_url)
-
-    @async
-    @pytest.mark.aiohttpretty
     def test_project_delete(self, project_provider, list_project_articles, article_metadata):
         article_id = str(list_project_articles[0]['id'])
         path = '/{0}'.format(article_id)

--- a/waterbutler/providers/figshare/metadata.py
+++ b/waterbutler/providers/figshare/metadata.py
@@ -39,12 +39,23 @@ class FigshareFileMetadata(BaseFigshareMetadata, metadata.BaseMetadata):
         return None
 
     @property
+    def can_delete(self):
+        """Files can be deleted if private or if containing fileset contains
+        two or more files.
+        """
+        return (
+            self.parent['status'].lower() == 'drafts' or
+            len(self.parent.get('files', [])) > 1
+        )
+
+    @property
     def extra(self):
         return {
             'fileId': self.raw['id'],
             'articleId': self.article_id,
             'status': self.parent['status'].lower(),
             'downloadUrl': self.raw.get('download_url'),
+            'canDelete': self.can_delete,
         }
 
 

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -255,7 +255,7 @@ class FigshareArticleProvider(BaseFigshareProvider):
         )
         return (yield from resp.json())
 
-    def _serialize_item(self, item, parent=None):
+    def _serialize_item(self, item, parent):
         defined_type = item.get('defined_type')
         files = item.get('files')
         if defined_type == 'fileset':
@@ -292,12 +292,6 @@ class FigshareArticleProvider(BaseFigshareProvider):
 
     @asyncio.coroutine
     def delete(self, path, **kwargs):
-        metadata = yield from self.metadata(path)
-        if metadata['extra']['status'].lower() != 'drafts':
-            raise exceptions.DeleteError(
-                'Cannot delete public files',
-                code=http.client.FORBIDDEN,
-            )
         figshare_path = FigshareArticlePath(path)
         yield from self.make_request(
             'DELETE',


### PR DESCRIPTION
Second attempt to handle figshare deletes. Based on correspondence with the figshare lead, it is actually possible to delete public / published files, but only when the file being deleted is not the last file in the fileset. This patch adds a `canDelete` field to the figshare file metadata indicating whether the file can be deleted.