### PR TITLE
feature/file-view-urls

### DIFF
--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -448,10 +448,11 @@ class TestMetadata:
 
         file_url = provider.build_url('files', path.identifier)
         aiohttpretty.register_json_uri('GET', file_url, body=item)
+        aiohttpretty.register_json_uri('PUT', file_url, body=item)
+        view_url = yield from provider.get_shared_link(path)
 
         result = yield from provider.metadata(path)
-
-        expected = BoxFileMetadata(item, path).serialized()
+        expected = BoxFileMetadata(item, path, view_url=view_url).serialized()
         assert result == expected
         assert aiohttpretty.has_call(method='GET', uri=file_url)
 
@@ -477,6 +478,7 @@ class TestRevisions:
         revisions_url = provider.build_url('files', path.identifier, 'versions')
 
         aiohttpretty.register_json_uri('GET', file_url, body=item)
+        aiohttpretty.register_json_uri('PUT', file_url, body=item)
         aiohttpretty.register_json_uri('GET', revisions_url, body=revisions_list_metadata)
 
         result = yield from provider.revisions(path)
@@ -500,6 +502,7 @@ class TestRevisions:
         revisions_url = provider.build_url('files', path.identifier, 'versions')
 
         aiohttpretty.register_json_uri('GET', file_url, body=item)
+        aiohttpretty.register_json_uri('PUT', file_url, body=item)
         aiohttpretty.register_json_uri('GET', revisions_url, body={}, status=403)
 
         result = yield from provider.revisions(path)

--- a/tests/providers/dropbox/test_provider.py
+++ b/tests/providers/dropbox/test_provider.py
@@ -110,6 +110,15 @@ def file_metadata():
     }
 
 
+@pytest.fixture
+def shares_metadata():
+    return {
+        "url": "https://db.tt/c0mFuu1Y",
+        "expires": "Tue, 01 Jan 2030 00:00:00 +0000",
+        "visibility": "PUBLIC"
+    }
+
+
 class TestValidatePath:
 
     @async
@@ -192,10 +201,12 @@ class TestMetadata:
 
     @async
     @pytest.mark.aiohttpretty
-    def test_metadata(self, provider, folder_metadata):
+    def test_metadata(self, provider, folder_metadata, shares_metadata):
         path = yield from provider.validate_path('/')
         url = provider.build_url('metadata', 'auto', path.full_path)
+        share_link = provider.build_url('shares', 'auto', path.full_path)
         aiohttpretty.register_json_uri('GET', url, body=folder_metadata)
+        aiohttpretty.register_json_uri('POST', share_link, body=shares_metadata)
         result = yield from provider.metadata(path)
 
         assert isinstance(result, list)
@@ -206,10 +217,12 @@ class TestMetadata:
 
     @async
     @pytest.mark.aiohttpretty
-    def test_metadata_root_file(self, provider, file_metadata):
+    def test_metadata_root_file(self, provider, file_metadata, shares_metadata):
         path = WaterButlerPath('/pfile', prepend=provider.folder)
         url = provider.build_url('metadata', 'auto', path.full_path)
+        share_link = provider.build_url('shares', 'auto', path.full_path)
         aiohttpretty.register_json_uri('GET', url, body=file_metadata)
+        aiohttpretty.register_json_uri('POST', share_link, body=shares_metadata)
         result = yield from provider.metadata(path)
 
         assert isinstance(result, dict)

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -668,8 +668,10 @@ class TestMetadata:
         aiohttpretty.register_json_uri('GET', latest_sha_url, body={'object': {'sha': ref}})
 
         result = yield from provider.metadata(path)
+        item = repo_tree_metadata_root['tree'][0]
+        view_url = provider.build_view_url(path.identifier[0], path.path)
 
-        assert result == GitHubFileTreeMetadata(repo_tree_metadata_root['tree'][0]).serialized()
+        assert result == GitHubFileTreeMetadata(item, view_url=view_url).serialized()
 
     # TODO: Additional Tests
     # def test_metadata_root_file_txt_branch(self, provider, repo_metadata, branch_metadata, repo_metadata_root):

--- a/tests/providers/googledrive/test_metadata.py
+++ b/tests/providers/googledrive/test_metadata.py
@@ -29,7 +29,7 @@ def test_file_metadata_drive(basepath):
     assert parsed.size == item['fileSize']
     assert parsed.modified == item['modifiedDate']
     assert parsed.content_type == item['mimeType']
-    assert parsed.extra == {'revisionId': item['version']}
+    assert parsed.extra == {'revisionId': item['version'], 'viewUrl': item['alternateLink']}
     assert parsed.path == '/' + os.path.join(*[x.raw for x in path.parts])
     assert parsed.materialized_path == str(path)
 
@@ -46,7 +46,7 @@ def test_file_metadata_drive_slashes(basepath):
     assert parsed.size == item['fileSize']
     assert parsed.modified == item['modifiedDate']
     assert parsed.content_type == item['mimeType']
-    assert parsed.extra == {'revisionId': item['version']}
+    assert parsed.extra == {'revisionId': item['version'], 'viewUrl': item['alternateLink']}
     assert parsed.path == '/' + os.path.join(*[x.raw for x in path.parts])
     assert parsed.materialized_path == str(path)
 
@@ -57,7 +57,7 @@ def test_file_metadata_docs(basepath):
     parsed = GoogleDriveFileMetadata(item, path)
 
     assert parsed.name == item['title'] + '.gdoc'
-    assert parsed.extra == {'revisionId': item['version'], 'downloadExt': '.docx'}
+    assert parsed.extra == {'revisionId': item['version'], 'downloadExt': '.docx', 'viewUrl': item['alternateLink']}
 
 
 def test_folder_metadata():

--- a/waterbutler/providers/box/metadata.py
+++ b/waterbutler/providers/box/metadata.py
@@ -29,6 +29,10 @@ class BoxFolderMetadata(BaseBoxMetadata, metadata.BaseFolderMetadata):
 
 class BoxFileMetadata(BaseBoxMetadata, metadata.BaseFileMetadata):
 
+    def __init__(self, raw, path_obj, view_url=None):
+        super().__init__(raw, path_obj)
+        self.view_url = view_url
+
     @property
     def name(self):
         return self.raw['name']
@@ -53,6 +57,7 @@ class BoxFileMetadata(BaseBoxMetadata, metadata.BaseFileMetadata):
     def extra(self):
         return {
             'etag': self.raw.get('etag'),
+            'viewUrl': self.view_url
         }
 
     @property

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -301,6 +301,18 @@ class BoxProvider(provider.BaseProvider):
             path
         ).serialized()
 
+    @asyncio.coroutine
+    def get_shared_link(self, path):
+        resp = yield from self.make_request(
+            'PUT',
+            self.build_url('files', path.identifier),
+            data='{"shared_link": {}}',
+            expects=(200, ),
+            throws=exceptions.MetadataError,
+        )
+        data = yield from resp.json()
+        return data['shared_link']['url']
+
     def _assert_child(self, paths, target=None):
         if self.folder == 0:
             return True
@@ -336,7 +348,12 @@ class BoxProvider(provider.BaseProvider):
         if not data:
             raise exceptions.NotFoundError(str(path))
 
-        return data if raw else BoxFileMetadata(data, path).serialized()
+        if data['shared_link']:
+            # 'shared_link' key can be None if a shared link for the file does not already exist
+            view_url = data['shared_link']['url']
+        else:
+            view_url = yield from self.get_shared_link(path)
+        return data if raw else BoxFileMetadata(data, path, view_url).serialized()
 
     @asyncio.coroutine
     def _get_folder_meta(self, path, raw=False, folder=False):

--- a/waterbutler/providers/dropbox/metadata.py
+++ b/waterbutler/providers/dropbox/metadata.py
@@ -39,6 +39,10 @@ class DropboxFolderMetadata(BaseDropboxMetadata, metadata.BaseFolderMetadata):
 
 class DropboxFileMetadata(BaseDropboxMetadata, metadata.BaseFileMetadata):
 
+    def __init__(self, raw, folder, view_url=None):
+        super().__init__(raw, folder)
+        self.view_url = view_url
+
     @property
     def name(self):
         return os.path.split(self.raw['path'])[1]
@@ -62,6 +66,12 @@ class DropboxFileMetadata(BaseDropboxMetadata, metadata.BaseFileMetadata):
     @property
     def etag(self):
         return self.raw['rev']
+
+    @property
+    def extra(self):
+        return dict(super().extra, **{
+            'viewUrl': self.view_url
+        })
 
 
 # TODO dates!

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -181,6 +181,17 @@ class DropboxProvider(provider.BaseProvider):
         )
 
     @asyncio.coroutine
+    def get_share_url(self, path):
+        resp = yield from self.make_request(
+            'POST',
+            self.build_url('shares', 'auto', path.full_path),
+            expects=(200, ),
+            throws=exceptions.MetadataError,
+        )
+        data = yield from resp.json()
+        return data['url']
+
+    @asyncio.coroutine
     def metadata(self, path, **kwargs):
         resp = yield from self.make_request(
             'GET',
@@ -215,7 +226,9 @@ class DropboxProvider(provider.BaseProvider):
                 else:
                     ret.append(DropboxFileMetadata(item, self.folder).serialized())
             return ret
-        return DropboxFileMetadata(data, self.folder).serialized()
+
+        view_url = yield from self.get_share_url(path)
+        return DropboxFileMetadata(data, self.folder, view_url).serialized()
 
     @asyncio.coroutine
     def revisions(self, path, **kwargs):

--- a/waterbutler/providers/figshare/metadata.py
+++ b/waterbutler/providers/figshare/metadata.py
@@ -1,4 +1,6 @@
+from waterbutler.providers.figshare import settings
 from waterbutler.core import metadata
+from waterbutler.core.provider import build_url
 
 
 class BaseFigshareMetadata:
@@ -15,6 +17,11 @@ class FigshareFileMetadata(BaseFigshareMetadata, metadata.BaseMetadata):
         self.parent = parent
         self.article_id = parent['article_id']
         self.child = child
+
+    @property
+    def view_url(self):
+        segments = ('articles', self.parent['title'], str(self.article_id))
+        return build_url(settings.VIEW_URL, *segments)
 
     @property
     def kind(self):
@@ -66,6 +73,7 @@ class FigshareFileMetadata(BaseFigshareMetadata, metadata.BaseMetadata):
             'status': self.parent['status'].lower(),
             'downloadUrl': self.raw.get('download_url'),
             'canDelete': self.can_delete,
+            'viewUrl': self.view_url,
         }
 
 

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -11,6 +11,7 @@ from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
 
 from waterbutler.providers.figshare import metadata
+from waterbutler.providers.figshare import settings
 from waterbutler.providers.figshare import utils as figshare_utils
 
 
@@ -26,7 +27,7 @@ class FigshareProvider:
 
 class BaseFigshareProvider(provider.BaseProvider):
     NAME = 'figshare'
-    BASE_URL = 'http://api.figshare.com/v1/my_data'
+    BASE_URL = settings.BASE_URL
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/waterbutler/providers/figshare/settings.py
+++ b/waterbutler/providers/figshare/settings.py
@@ -4,3 +4,6 @@ except ImportError:
     settings = {}
 
 config = settings.get('FIGSHARE_PROVIDER_CONFIG', {})
+
+BASE_URL = config.get('BASE_URL', 'http://api.figshare.com/v1/my_data')
+VIEW_URL = config.get('VIEW_URL', 'http://figshare.com/')

--- a/waterbutler/providers/github/metadata.py
+++ b/waterbutler/providers/github/metadata.py
@@ -29,6 +29,10 @@ class BaseGitHubMetadata(metadata.BaseMetadata):
 
 class BaseGitHubFileMetadata(BaseGitHubMetadata, metadata.BaseFileMetadata):
 
+    def __init__(self, raw, folder=None, commit=None, view_url=None):
+        super().__init__(raw, folder, commit)
+        self.view_url = view_url
+
     @property
     def path(self):
         return self.build_path(self.raw['path'])
@@ -47,7 +51,10 @@ class BaseGitHubFileMetadata(BaseGitHubMetadata, metadata.BaseFileMetadata):
 
     @property
     def extra(self):
-        return dict(super().extra, fileSha=self.raw['sha'])
+        return dict(super().extra, **{
+            'fileSha': self.raw['sha'],
+            'viewUrl': self.view_url
+        })
 
 
 class BaseGitHubFolderMetadata(BaseGitHubMetadata, metadata.BaseFolderMetadata):

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -35,6 +35,7 @@ class GitHubPath(path.WaterButlerPath):
 class GitHubProvider(provider.BaseProvider):
     NAME = 'github'
     BASE_URL = settings.BASE_URL
+    VIEW_URL = settings.VIEW_URL
 
     @staticmethod
     def is_sha(ref):
@@ -90,6 +91,10 @@ class GitHubProvider(provider.BaseProvider):
     def build_repo_url(self, *segments, **query):
         segments = ('repos', self.owner, self.repo) + segments
         return self.build_url(*segments, **query)
+
+    def build_view_url(self, *segments):
+        segments = (self.owner, self.repo, 'blob') + segments
+        return provider.build_url(settings.VIEW_URL, *segments)
 
     def can_intra_move(self, other, path=None):
         return self.can_intra_copy(other, path=path)
@@ -511,6 +516,7 @@ class GitHubProvider(provider.BaseProvider):
             latest = path.identifier[0]
 
         tree = yield from self._fetch_tree(latest, recursive=True)
+        view_url = self.build_view_url(path.identifier[0], path.path)
 
         try:
             data = next(
@@ -526,7 +532,7 @@ class GitHubProvider(provider.BaseProvider):
                 code=404,
             )
 
-        return GitHubFileTreeMetadata(data).serialized()
+        return GitHubFileTreeMetadata(data, view_url=view_url).serialized()
 
     @asyncio.coroutine
     def _get_latest_sha(self, ref='master'):

--- a/waterbutler/providers/github/settings.py
+++ b/waterbutler/providers/github/settings.py
@@ -7,6 +7,7 @@ config = settings.get('GITHUB_PROVIDER_CONFIG', {})
 
 
 BASE_URL = config.get('BASE_URL', 'https://api.github.com/')
+VIEW_URL = config.get('VIEW_URL', 'https://github.com/')
 
 UPLOAD_FILE_MESSAGE = config.get('UPLOAD_FILE_MESSAGE', 'File uploaded on behalf of WaterButler')
 DELETE_FILE_MESSAGE = config.get('DELETE_FILE_MESSAGE', 'File deleted on behalf of WaterButler')

--- a/waterbutler/providers/googledrive/metadata.py
+++ b/waterbutler/providers/googledrive/metadata.py
@@ -80,6 +80,7 @@ class GoogleDriveFileMetadata(BaseGoogleDriveMetadata, metadata.BaseFileMetadata
         ret = super().extra
         if utils.is_docs_file(self.raw):
             ret['downloadExt'] = utils.get_download_extension(self.raw['exportLinks'])
+        ret['viewUrl'] = self.raw.get('alternateLink')
         return ret
 
 


### PR DESCRIPTION
#### Purpose
- Adds source_url to the extra field of the file metadata.
- Addresses [#2926](https://github.com/CenterForOpenScience/osf.io/issues/2926)
- Addons:
 - [X] GitHub: file external view link built from current metadata
 - [X] Google Drive: file external view link retrived from Google Drive API
 - [X] Figshare: file external view link built from current metadata
 - [X] Dropbox: file share link generate from Dropbox API
 - [X] Box: file share link generated from Box API
 - [X] S3: unsupported
 - [X] Dataverse: unsupported