### PR TITLE
[Hotfix] Fixed file upload and display issues from un-inited github repos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ git+https://github.com/chrisseto/boto.git#egg=boto
 git+https://github.com/jmcarp/raven-python
 celery==3.1.17
 furl==0.4.2
+humanfriendly==1.31
 invoke==0.9.0
 oauthlib==0.7.2
 stevedore==1.2.0

--- a/waterbutler/__init__.py
+++ b/waterbutler/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.7.3'
+__version__ = '0.7.4'
 __import__('pkg_resources').declare_namespace(__name__)

--- a/waterbutler/providers/figshare/metadata.py
+++ b/waterbutler/providers/figshare/metadata.py
@@ -1,3 +1,5 @@
+import humanfriendly
+
 from waterbutler.core import metadata
 
 
@@ -8,7 +10,7 @@ class BaseFigshareMetadata:
         return 'figshare'
 
 
-class FigshareFileMetadata(BaseFigshareMetadata, metadata.BaseMetadata):
+class FigshareFileMetadata(BaseFigshareMetadata, metadata.BaseFileMetadata):
 
     def __init__(self, raw, parent, child):
         super().__init__(raw)
@@ -37,8 +39,15 @@ class FigshareFileMetadata(BaseFigshareMetadata, metadata.BaseMetadata):
         return '/{0}'.format(self.name)
 
     @property
+    def content_type(self):
+        return self.raw.get('mime_type')
+
+    @property
     def size(self):
-        return self.raw.get('size')
+        size = self.raw.get('size')
+        if type(size) == str:
+            return humanfriendly.parse_size(size)
+        return size
 
     @property
     def modified(self):

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -131,11 +131,30 @@ class GitHubProvider(provider.BaseProvider):
         assert self.name is not None
         assert self.email is not None
 
-        exists = yield from self.exists(path)
-        latest_sha = yield from self._get_latest_sha(ref=path.identifier[0])
+        try:
+            exists = yield from self.exists(path)
+        except exceptions.ProviderError as e:
+            if e.data.get('message') == 'Git Repository is empty.':
+                exists = False
+                resp = yield from self.make_request(
+                    'PUT',
+                    self.build_repo_url('contents', '.gitkeep'),
+                    data=json.dumps({
+                        'content': '',
+                        'path': '.gitkeep',
+                        'committer': self.committer,
+                        'branch': path.identifier[0],
+                        'message': 'Initial commit'
+                    }),
+                    expects=(201,),
+                    throws=exceptions.CreateFolderError
+                )
+                data = yield from resp.json()
+                latest_sha = data['commit']['sha']
+        else:
+            latest_sha = yield from self._get_latest_sha(ref=path.identifier[0])
 
         blob = yield from self._create_blob(stream)
-
         tree = yield from self._create_tree({
             'base_tree': latest_sha,
             'tree': [{
@@ -465,7 +484,13 @@ class GitHubProvider(provider.BaseProvider):
         # the operation using the git/trees api which requires a sha.
 
         if not (self._is_sha(path.identifier[0]) or recursive):
-            data = yield from self._fetch_contents(path, ref=path.identifier[0])
+            try:
+                data = yield from self._fetch_contents(path, ref=path.identifier[0])
+            except exceptions.MetadataError as e:
+                if e.data.get('message') == 'This repository is empty.':
+                    data = []
+                else:
+                    raise
 
             ret = []
             for item in data:


### PR DESCRIPTION
Github repos that have not been initialized (have no files in them) do not have lastest sha values, as a fix, if we try to commit to an un-init-ed repo, we first init it by pushing a .gitkeep using the github api to force initialization.
Treebeard also displays an error when displaying files for an un-init-ed repo, this fix makes sure to return an empty file tree from waterbutler to the osf to play nice with treebeards display
This closes OSF issue #3122 and #2976