### PR TITLE
[feature-companion]Add md5 and sha256 hashes to revision and file metadata for osfstorage

### DIFF
--- a/tests/providers/osfstorage/test_provider.py
+++ b/tests/providers/osfstorage/test_provider.py
@@ -111,7 +111,9 @@ def upload_response():
         'data': {
             'downloads': 10,
             'version': 8,
-            'path': '/dfl893b1pdn11kd28b'
+            'path': '/dfl893b1pdn11kd28b',
+            'md5': 'abcdabcdabcdabcdabcdabcdabcd',
+            'sha256': '123123123123123123'
         }
     }
 
@@ -179,6 +181,8 @@ def test_provider_metadata(monkeypatch, provider, mock_folder_path):
             'kind': 'file',
             'version': 10,
             'downloads': 1,
+            'md5': '1234',
+            'sha256': '2345',
         },
         {
             'name': 'bar',
@@ -186,6 +190,8 @@ def test_provider_metadata(monkeypatch, provider, mock_folder_path):
             'kind': 'file',
             'version': 10,
             'downloads': 1,
+            'md5': '1234',
+            'sha256': '2345',
         },
         {
             'name': 'baz',
@@ -253,7 +259,7 @@ class TestUploads:
         inner_provider.move.return_value = (utils.MockFileMetadata(), True)
         inner_provider.metadata.side_effect = exceptions.MetadataError('Boom!', code=404)
 
-        aiohttpretty.register_json_uri('POST', url, status=200, body={'data': {'downloads': 10, 'version': 8, 'path': '/24601'}})
+        aiohttpretty.register_json_uri('POST', url, status=200, body={'data': {'downloads': 10, 'version': 8, 'path': '/24601', 'md5': '1234', 'sha256': '2345'}})
 
         res, created = yield from provider.upload(file_stream, path)
 
@@ -281,7 +287,7 @@ class TestUploads:
         inner_provider.move.return_value = (utils.MockFileMetadata(), True)
         inner_provider.metadata.side_effect = exceptions.MetadataError('Boom!', code=404)
 
-        aiohttpretty.register_json_uri('POST', url, status=201, body={'version': 'versionpk', 'data': {'version': 42, 'downloads': 30, 'path': '/alkjdaslke09'}})
+        aiohttpretty.register_json_uri('POST', url, status=201, body={'version': 'versionpk', 'data': {'version': 42, 'downloads': 30, 'path': '/alkjdaslke09', 'md5': 'abcd', 'sha256': 'bcde'}})
 
         monkeypatch.setattr(basepath.format('backup.main'), mock_backup)
         monkeypatch.setattr(basepath.format('parity.main'), mock_parity)

--- a/waterbutler/providers/osfstorage/metadata.py
+++ b/waterbutler/providers/osfstorage/metadata.py
@@ -48,7 +48,11 @@ class OsfStorageFileMetadata(BaseOsfStorageItemMetadata, metadata.BaseFileMetada
     def extra(self):
         return {
             'version': self.raw['version'],
-            'downloads': self.raw['downloads']
+            'downloads': self.raw['downloads'],
+            'hashes': {
+                'md5': self.raw['md5'],
+                'sha256': self.raw['sha256']
+            },
         }
 
 
@@ -75,4 +79,8 @@ class OsfStorageRevisionMetadata(BaseOsfStorageMetadata, metadata.BaseFileRevisi
         return {
             'user': self.raw['user'],
             'downloads': self.raw['downloads'],
+            'hashes': {
+                'md5': self.raw['md5'],
+                'sha256': self.raw['sha256']
+            },
         }

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -276,9 +276,11 @@ class OSFStorageProvider(provider.BaseProvider):
 
         metadata.update({
             'name': name,
+            'md5': data['data']['md5'],
             'path': data['data']['path'],
+            'sha256': data['data']['sha256'],
             'version': data['data']['version'],
-            'downloads': data['data']['downloads']
+            'downloads': data['data']['downloads'],
         })
 
         return OsfStorageFileMetadata(metadata, str(path)), created


### PR DESCRIPTION
## Purpose 
Allow API to grab md5 + sha256 hashes, and also so that the osf can grab and use them.

This accompanies OSF PR: https://github.com/CenterForOpenScience/osf.io/pull/3517 and needs to be merged together for either to work.

## Changes
md5 information is added to the metadata extra section of revision and file classes

