### PR TITLE
[feature] Allow new S3 keys to be encrypted

### DIFF
--- a/waterbutler/providers/s3/metadata.py
+++ b/waterbutler/providers/s3/metadata.py
@@ -46,7 +46,7 @@ class S3FileMetadataHeaders(S3Metadata, metadata.BaseFileMetadata):
     def extra(self):
         return {
             'md5': self.raw['ETAG'].replace('"', ''),
-            'encryption': self.raw['X-AMZ-SERVER-SIDE-ENCRYPTION']
+            'encryption': self.raw.get('X-AMZ-SERVER-SIDE-ENCRYPTION', '')
         }
 
 

--- a/waterbutler/providers/s3/metadata.py
+++ b/waterbutler/providers/s3/metadata.py
@@ -45,7 +45,8 @@ class S3FileMetadataHeaders(S3Metadata, metadata.BaseFileMetadata):
     @property
     def extra(self):
         return {
-            'md5': self.raw['ETAG'].replace('"', '')
+            'md5': self.raw['ETAG'].replace('"', ''),
+            'encryption': self.raw['X-AMZ-SERVER-SIDE-ENCRYPTION']
         }
 
 

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -145,7 +145,11 @@ class S3Provider(provider.BaseProvider):
 
         resp = yield from self.make_request(
             'PUT',
-            self.bucket.new_key(path.path).generate_url(settings.TEMP_URL_SECS, 'PUT'),
+            self.bucket.new_key(path.name).generate_url(
+                settings.TEMP_URL_SECS,
+                'PUT',
+                encrypt_key=self.settings.get('encrypt_uploads', False)
+            ),
             data=stream,
             headers={'Content-Length': str(stream.size)},
             expects=(200, 201, ),


### PR DESCRIPTION
## Purpose:
Allow users to encrypt (at rest) new keys uploaded to S3.

## Changes:
- Pulls encrypt_uploads bool from settings and modifies PUT header accordingly

## Side Effects:
Files will optionally be encrypted on Amazon's cloud servers.

## Notes:
- Depends on [osf.io sister PR](https://github.com/CenterForOpenScience/osf.io/pull/3533).
- boto's ability to tell if a key is encrypted (on the server) is [currently broken](https://github.com/boto/boto/issues/3269). I am looking into the bug as well as a way to check whether a key is encrypted (on the server) via the rest API.
  - Not an immediate issue now as everything is handled on the AWS side of things.