### PR TITLE
GitHub View URLs

### DIFF
--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -694,8 +694,7 @@ class TestMetadata:
             if item['type'] == 'dir':
                 ret.append(GitHubFolderContentMetadata(item))
             else:
-                web_view = provider._web_view(path=path)
-                ret.append(GitHubFileContentMetadata(item, web_view=web_view))
+                ret.append(GitHubFileContentMetadata(item, web_view=item['html_url']))
 
         assert result == ret
 

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -504,8 +504,7 @@ class GitHubProvider(provider.BaseProvider):
                 if item['type'] == 'dir':
                     ret.append(GitHubFolderContentMetadata(item))
                 else:
-                    web_view = self._web_view(path)
-                    ret.append(GitHubFileContentMetadata(item, web_view=web_view))
+                    ret.append(GitHubFileContentMetadata(item, web_view=item['html_url']))
             return ret
 
     @asyncio.coroutine


### PR DESCRIPTION
- Fixes incorrect GitHub view URLs from being built on the OSF files page.
- Uses GitHub's ```html_url``` as the web view URL for file metadata not retrieved from the git trees API, continues to build URLs for file metadata that is retrieved by the git trees API.