### PR TITLE
Catch rename duplicate

### DIFF
--- a/waterbutler/constants.py
+++ b/waterbutler/constants.py
@@ -1,0 +1,3 @@
+"""Constants"""
+
+DEFAULT_CONFLICT = 'warn'

--- a/waterbutler/core/exceptions.py
+++ b/waterbutler/core/exceptions.py
@@ -115,6 +115,15 @@ class FolderNamingConflict(ProviderError):
         )
 
 
+class NamingConflict(ProviderError):
+    def __init__(self, path, name=None):
+        super().__init__(
+            'Cannot complete action: file or folder "{name}" already exists in this location'.format(
+                name=name or path.name
+            ), code=409
+        )
+
+
 class NotFoundError(ProviderError):
     def __init__(self, path):
         super().__init__(

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -324,12 +324,15 @@ class BaseProvider(metaclass=abc.ABCMeta):
         the correct file path to upload to and indicate if that file exists or not
 
         :param WaterbutlerPath path: An object supporting the waterbutler path API
-        :param str conflict: replace or keep
+        :param str conflict: replace, keep, warn
         :rtype: (WaterButlerPath, dict or False)
+        :raises: NamingConflict
         """
         exists = yield from self.exists(path, **kwargs)
-        if not exists or conflict != 'keep':
+        if not exists or conflict == 'replace':
             return path, exists
+        if conflict == 'warn':
+            raise exceptions.NamingConflict(path)
 
         while (yield from self.exists(path.increment_name(), **kwargs)):
             pass

--- a/waterbutler/server/api/v1/provider/movecopy.py
+++ b/waterbutler/server/api/v1/provider/movecopy.py
@@ -7,6 +7,7 @@ from waterbutler.core import exceptions
 from waterbutler.server import settings
 from waterbutler.server.auth import AuthHandler
 from waterbutler.core.utils import make_provider
+from waterbutler.constants import DEFAULT_CONFLICT
 
 auth_handler = AuthHandler(settings.AUTH_HANDLERS)
 
@@ -95,7 +96,7 @@ class MoveCopyMixin:
                     self.path,
                     self.dest_path,
                     rename=self.json.get('rename'),
-                    conflict=self.json.get('conflict', 'replace'),
+                    conflict=self.json.get('conflict', DEFAULT_CONFLICT),
                 )
             )
 


### PR DESCRIPTION
Returns a 409 error.

Update with a conflict default of warn. This is in the file waterbutler.constants.