### PR TITLE
[CR] Update waterbutler to return JSON-API compliant 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ waterbutler-test.json, e.g.
   "SERVER_CONFIG": {
     "ADDRESS": "127.0.0.1",
     "PORT": 7777,
+    "DOMAIN": "http://127.0.0.1:7777",
     "DEBUG": true,
     "HMAC_SECRET": "changeme"
   },

--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -92,3 +92,16 @@ class TestBaseMetadata:
             'modified': 'never',
             'size': 1337,
         }
+
+    def test_file_revision_json_api_serialize(self):
+        file_revision_metadata = utils.MockFileRevisionMetadata()
+        serialized = file_revision_metadata.json_api_serialized()
+
+        assert serialized['id'] == 1
+        assert serialized['type'] == 'file_versions'
+        assert serialized['attributes'] == {
+            'extra': {},
+            'version': 1,
+            'modified': 'never',
+            'versionIdentifier': 'versions',
+        }

--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -1,0 +1,94 @@
+import pytest
+import hashlib
+
+from tests import utils
+from unittest import mock
+from tests.utils import async
+from waterbutler.core import metadata
+from waterbutler.core import exceptions
+
+
+class TestBaseMetadata:
+
+    def test_file_metadata(self):
+        file_metadata = utils.MockFileMetadata()
+
+        assert file_metadata.is_file == True
+        assert file_metadata.is_folder == False
+
+    def test_folder_metadata(self):
+        folder_metadata = utils.MockFolderMetadata()
+
+        assert folder_metadata.is_folder == True
+        assert folder_metadata.is_file == False
+
+    def test_file_json_api_serialize(self):
+        file_metadata = utils.MockFileMetadata()
+        serialized = file_metadata.json_api_serialized('n0d3z')
+        link_suffix = '/v1/resources/n0d3z/providers/mock/Foo.name'
+        etag = hashlib.sha256('{}::{}'.format('mock', 'etag').encode('utf-8')).hexdigest()
+
+        assert serialized['id'] == 'mock/Foo.name'
+        assert serialized['type'] == 'files'
+        assert serialized['attributes'] == {
+            'extra': {},
+            'kind': 'file',
+            'name': 'Foo.name',
+            'path': '/Foo.name',
+            'provider': 'mock',
+            'materialized': '/Foo.name',
+            'etag': etag,
+            'contentType': 'application/octet-stream',
+            'modified': 'never',
+            'size': 1337,
+        }
+        assert serialized['links']['new_folder'] == None
+        assert serialized['links']['move'].endswith(link_suffix)
+        assert serialized['links']['upload'].endswith(link_suffix)
+        assert serialized['links']['download'].endswith(link_suffix)
+        assert serialized['links']['delete'].endswith(link_suffix)
+
+    def test_folder_json_api_serialize(self):
+        folder_metadata = utils.MockFolderMetadata()
+        serialized = folder_metadata.json_api_serialized('n0d3z')
+        link_suffix = '/v1/resources/n0d3z/providers/mock/Bar/'
+        etag = hashlib.sha256('{}::{}'.format('mock', 'etag').encode('utf-8')).hexdigest()
+
+        assert serialized['id'] == 'mock/Bar/'
+        assert serialized['type'] == 'files'
+        assert serialized['attributes'] == {
+            'extra': {},
+            'kind': 'folder',
+            'name': 'Bar',
+            'path': '/Bar/',
+            'provider': 'mock',
+            'materialized': '/Bar/',
+            'etag': etag,
+            'size': None,
+        }
+        assert serialized['links']['new_folder'].endswith(link_suffix)
+        assert serialized['links']['move'].endswith(link_suffix)
+        assert serialized['links']['upload'].endswith(link_suffix)
+        assert serialized['links']['download'] == None
+        assert serialized['links']['delete'].endswith(link_suffix)
+
+    def test_folder_json_api_serialize(self):
+        folder_metadata = utils.MockFolderMetadata()
+        folder_metadata.children = [utils.MockFileMetadata()]
+        serialized = folder_metadata.json_api_serialized('n0d3z')
+        child = serialized['attributes']['children'][0]
+        etag = hashlib.sha256('{}::{}'.format('mock', 'etag').encode('utf-8')).hexdigest()
+
+        assert len(serialized['attributes']['children']) == 1
+        assert child == {
+            'extra': {},
+            'kind': 'file',
+            'name': 'Foo.name',
+            'path': '/Foo.name',
+            'provider': 'mock',
+            'materialized': '/Foo.name',
+            'etag': etag,
+            'contentType': 'application/octet-stream',
+            'modified': 'never',
+            'size': 1337,
+        }

--- a/tests/server/api/v1/test_create_mixin.py
+++ b/tests/server/api/v1/test_create_mixin.py
@@ -97,7 +97,8 @@ class TestCreateFolder(BaseCreateMixinTest):
     def test_created(self):
         metadata = mock.Mock()
         self.mixin.path = 'apath'
-        metadata.serialized.return_value = {'day': 'tum'}
+        self.mixin.resource = '3rqws'
+        metadata.json_api_serialized.return_value = {'day': 'tum'}
         self.mixin.provider = mock.Mock(
             create_folder=MockCoroutine(return_value=metadata)
         )
@@ -105,7 +106,7 @@ class TestCreateFolder(BaseCreateMixinTest):
         yield from self.mixin.create_folder()
 
         assert self.mixin.set_status.assert_called_once_with(201) is None
-        assert self.mixin.write.assert_called_once_with({'day': 'tum'}) is None
+        assert self.mixin.write.assert_called_once_with({'data': {'day': 'tum'}}) is None
         assert self.mixin.provider.create_folder.assert_called_once_with('apath') is None
 
 
@@ -118,8 +119,9 @@ class TestUploadFile(BaseCreateMixinTest):
 
     def test_created(self):
         metadata = mock.Mock()
+        self.mixin.resource = '3rqws'
         self.mixin.uploader = asyncio.Future()
-        metadata.serialized.return_value = {'day': 'tum'}
+        metadata.json_api_serialized.return_value = {'day': 'tum'}
         self.mixin.uploader.set_result((metadata, True))
 
         yield from self.mixin.upload_file()
@@ -127,13 +129,14 @@ class TestUploadFile(BaseCreateMixinTest):
         assert self.mixin.wsock.close.called
         assert self.mixin.writer.close.called
         assert self.mixin.set_status.assert_called_once_with(201) is None
-        assert self.mixin.write.assert_called_once_with({'day': 'tum'}) is None
+        assert self.mixin.write.assert_called_once_with({'data': {'day': 'tum'}}) is None
 
     @async
     def test_not_created(self):
         metadata = mock.Mock()
+        self.mixin.resource = '3rqws'
         self.mixin.uploader = asyncio.Future()
-        metadata.serialized.return_value = {'day': 'ta'}
+        metadata.json_api_serialized.return_value = {'day': 'ta'}
         self.mixin.uploader.set_result((metadata, False))
 
         yield from self.mixin.upload_file()
@@ -141,6 +144,6 @@ class TestUploadFile(BaseCreateMixinTest):
         assert self.mixin.wsock.close.called
         assert self.mixin.writer.close.called
         assert self.mixin.set_status.called is False
-        assert self.mixin.write.assert_called_once_with({'day': 'ta'}) is None
+        assert self.mixin.write.assert_called_once_with({'data': {'day': 'ta'}}) is None
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -55,6 +55,15 @@ class MockFolderMetadata(metadata.BaseFolderMetadata):
         super().__init__({})
 
 
+class MockFileRevisionMetadata(metadata.BaseFileRevisionMetadata):
+    version = 1
+    version_identifier = 'versions'
+    modified = 'never'
+
+    def __init__(self):
+        super().__init__({})
+
+
 class MockProvider(provider.BaseProvider):
     NAME = 'MockProvider'
     copy = None

--- a/waterbutler/core/metadata.py
+++ b/waterbutler/core/metadata.py
@@ -175,6 +175,17 @@ class BaseFileRevisionMetadata(metaclass=abc.ABCMeta):
             'versionIdentifier': self.version_identifier,
         }
 
+    def json_api_serialized(self):
+        """The JSON API serialization of revision metadata from WaterButler.
+        .. warning::
+        This method determines the output of API v1
+        """
+        return {
+            'id': self.version,
+            'type': 'file_versions',
+            'attributes': self.serialized(),
+        }
+
     @abc.abstractproperty
     def modified(self):
         raise NotImplementedError

--- a/waterbutler/server/api/v1/provider/create.py
+++ b/waterbutler/server/api/v1/provider/create.py
@@ -48,7 +48,7 @@ class CreateMixin:
     def create_folder(self):
         metadata = yield from self.provider.create_folder(self.path)
         self.set_status(201)
-        self.write(metadata.serialized())
+        self.write({'data': metadata.json_api_serialized(self.resource)})
 
     @asyncio.coroutine
     def upload_file(self):
@@ -60,4 +60,4 @@ class CreateMixin:
         if created:
             self.set_status(201)
 
-        self.write(metadata.serialized())
+        self.write({'data': metadata.json_api_serialized(self.resource)})

--- a/waterbutler/server/api/v1/provider/metadata.py
+++ b/waterbutler/server/api/v1/provider/metadata.py
@@ -108,7 +108,7 @@ class MetadataMixin:
         if asyncio.iscoroutine(result):
             result = yield from result
 
-        return self.write({'data': [r.serialized() for r in result]})
+        return self.write({'data': [r.json_api_serialized() for r in result]})
 
     @asyncio.coroutine
     def download_folder_as_zip(self):

--- a/waterbutler/server/api/v1/provider/metadata.py
+++ b/waterbutler/server/api/v1/provider/metadata.py
@@ -27,7 +27,7 @@ class MetadataMixin:
         if data.modified is not None:
             self.set_header('Last-Modified', data.modified)
         self.set_header('Content-Type', data.content_type or 'application/octet-stream')
-        self.set_header('X-Waterbutler-Metadata', json.dumps(data.serialized()))
+        self.set_header('X-Waterbutler-Metadata', json.dumps(data.json_api_serialized(self.resource)))
 
     @asyncio.coroutine
     def get_folder(self):
@@ -35,7 +35,7 @@ class MetadataMixin:
             return (yield from self.download_folder_as_zip())
 
         data = yield from self.provider.metadata(self.path)
-        return self.write({'data': [x.serialized() for x in data]})
+        return self.write({'data': [x.json_api_serialized(self.resource) for x in data]})
 
     @asyncio.coroutine
     def get_file(self):
@@ -98,7 +98,7 @@ class MetadataMixin:
         version = self.get_query_argument('version', default=None) or self.get_query_argument('revision', default=None)
 
         return self.write({
-            'data': (yield from self.provider.metadata(self.path, revision=version)).serialized()
+            'data': (yield from self.provider.metadata(self.path, revision=version)).json_api_serialized(self.resource)
         })
 
     @asyncio.coroutine

--- a/waterbutler/server/api/v1/provider/movecopy.py
+++ b/waterbutler/server/api/v1/provider/movecopy.py
@@ -100,11 +100,9 @@ class MoveCopyMixin:
                 )
             )
 
-        metadata = metadata.serialized()
-
         if created:
             self.set_status(201)
         else:
             self.set_status(200)
 
-        self.write(metadata)
+        self.write({'data': metadata.json_api_serialized(self.dest_resource)})

--- a/waterbutler/server/settings.py
+++ b/waterbutler/server/settings.py
@@ -10,6 +10,7 @@ config = settings.get('SERVER_CONFIG', {})
 
 ADDRESS = config.get('ADDRESS', '127.0.0.1')
 PORT = config.get('PORT', 7777)
+DOMAIN = config.get('DOMAIN', "http://127.0.0.1:7777")
 
 DEBUG = config.get('DEBUG', True)
 


### PR DESCRIPTION
Via: [#OSF-4667]

WaterButler was sending back responses in its own format, whereas the OSF tries to adhere to JSON-API formatted responses.  This patch updates the v1 endpoints to return JSON-API compliant responses on success.  It does **not** fix the error responses from JSON-API.  

I've also opted to drop the included '?kind=folder' query param from the `new_folder` link.  It's already documented in the BAPI docs as a required parameter, and would probably be more appropriate as a `meta` entry.  If it's still desired, it's a quick patch to put it back.

Cheers,
Fitz