### PR TITLE
[CR] v1: fix move response status from osfstorage

### DIFF
--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -132,9 +132,9 @@ class OSFStorageProvider(provider.BaseProvider):
         data = yield from resp.json()
 
         if data['kind'] == 'file':
-            return OsfStorageFileMetadata(data, str(dest_path)), resp.status == 201
+            return OsfStorageFileMetadata(data, str(dest_path)), dest_path.identifier is None
 
-        return OsfStorageFolderMetadata(data, str(dest_path)), resp.status == 201
+        return OsfStorageFolderMetadata(data, str(dest_path)), dest_path.identifier is None
 
     def intra_copy(self, dest_provider, src_path, dest_path):
         if dest_path.identifier:


### PR DESCRIPTION
move/copy response status should be 201 if a new resource is created or
200 if an existing resource is overwritten.  copy was already doing
this, move now does the same

[#OSF-4755]