### PR TITLE
[CR] always 404 on file/folder path mismatch

### DIFF
--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -3,6 +3,7 @@ import pytest
 from tests.utils import async
 
 import io
+from http import client
 
 import aiohttpretty
 
@@ -267,6 +268,59 @@ def revisions_list_metadata():
         'offset': 0,
         'total_count': 1,
     }
+
+
+class TestValidatePath:
+
+    @async
+    @pytest.mark.aiohttpretty
+    def test_validate_v1_path_file(self, provider, file_metadata):
+        file_id = '5000948880'
+
+        good_url = provider.build_url('files', file_id, fields='id,name,path_collection')
+        bad_url = provider.build_url('folders', file_id, fields='id,name,path_collection')
+
+        aiohttpretty.register_json_uri('get', good_url, body=file_metadata['entries'][0], status=200)
+        aiohttpretty.register_uri('get', bad_url, status=404)
+
+        try:
+            wb_path_v1 = yield from provider.validate_v1_path('/' + file_id)
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            yield from provider.validate_v1_path('/' + file_id + '/')
+
+        assert exc.value.code == client.NOT_FOUND
+
+        wb_path_v0 = yield from provider.validate_path('/' + file_id)
+
+        assert wb_path_v1 == wb_path_v0
+
+    @async
+    @pytest.mark.aiohttpretty
+    def test_validate_v1_path_folder(self, provider, folder_object_metadata):
+        provider.folder = '0'
+        folder_id = '11446498'
+
+        good_url = provider.build_url('folders', folder_id, fields='id,name,path_collection')
+        bad_url = provider.build_url('files', folder_id, fields='id,name,path_collection')
+
+        aiohttpretty.register_json_uri('get', good_url, body=folder_object_metadata, status=200)
+        aiohttpretty.register_uri('get', bad_url, status=404)
+        try:
+            wb_path_v1 = yield from provider.validate_v1_path('/' + folder_id + '/')
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            yield from provider.validate_v1_path('/' + folder_id)
+
+        assert exc.value.code == client.NOT_FOUND
+
+        wb_path_v0 = yield from provider.validate_path('/' + folder_id + '/')
+
+        assert wb_path_v1 == wb_path_v0
 
 
 class TestDownload:

--- a/tests/providers/dropbox/test_provider.py
+++ b/tests/providers/dropbox/test_provider.py
@@ -3,6 +3,7 @@ import pytest
 from tests.utils import async
 
 import io
+from http import client
 
 import aiohttpretty
 
@@ -116,6 +117,52 @@ def build_folder_metadata_params(path):
 
 
 class TestValidatePath:
+
+    @async
+    @pytest.mark.aiohttpretty
+    @pytest.mark.parametrize('settings', [{'folder': '/'}])
+    def test_validate_v1_path_file(self, provider, file_metadata):
+        file_path = 'Photos/Getting_Started.pdf'
+
+        metadata_url = provider.build_url('metadata', 'auto', file_path)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=file_metadata)
+
+        try:
+            wb_path_v1 = yield from provider.validate_v1_path('/' + file_path)
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            yield from provider.validate_v1_path('/' + file_path + '/')
+
+        assert exc.value.code == client.NOT_FOUND
+
+        wb_path_v0 = yield from provider.validate_path('/' + file_path)
+
+        assert wb_path_v1 == wb_path_v0
+
+    @async
+    @pytest.mark.aiohttpretty
+    @pytest.mark.parametrize('settings', [{'folder': '/'}])
+    def test_validate_v1_path_folder(self, provider, folder_metadata):
+        folder_path = 'Photos'
+
+        metadata_url = provider.build_url('metadata', 'auto', folder_path)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=folder_metadata)
+
+        try:
+            wb_path_v1 = yield from provider.validate_v1_path('/' + folder_path + '/')
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            yield from provider.validate_v1_path('/' + folder_path)
+
+        assert exc.value.code == client.NOT_FOUND
+
+        wb_path_v0 = yield from provider.validate_path('/' + folder_path + '/')
+
+        assert wb_path_v1 == wb_path_v0
 
     @async
     def test_returns_path_obj(self, provider):

--- a/tests/providers/filesystem/test_provider.py
+++ b/tests/providers/filesystem/test_provider.py
@@ -5,6 +5,7 @@ from tests.utils import async
 import io
 import os
 import shutil
+from http import client
 
 from waterbutler.core import streams
 from waterbutler.core import metadata
@@ -47,6 +48,41 @@ def setup_filesystem(provider):
 
     with open(os.path.join(provider.folder, 'subfolder', 'nested.txt'), 'wb') as fp:
         fp.write(b'Here is my content')
+
+
+class TestValidatePath:
+
+    @async
+    def test_validate_v1_path_file(self, provider):
+        try:
+            wb_path_v1 = yield from provider.validate_v1_path('/flower.jpg')
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            yield from provider.validate_v1_path('/flower.jpg/')
+
+        assert exc.value.code == client.NOT_FOUND
+
+        wb_path_v0 = yield from provider.validate_path('/flower.jpg')
+
+        assert wb_path_v1 == wb_path_v0
+
+    @async
+    def test_validate_v1_path_folder(self, provider):
+        try:
+            wb_path_v1 = yield from provider.validate_v1_path('/subfolder/')
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            yield from provider.validate_v1_path('/subfolder')
+
+        assert exc.value.code == client.NOT_FOUND
+
+        wb_path_v0 = yield from provider.validate_path('/subfolder/')
+
+        assert wb_path_v1 == wb_path_v0
 
 
 class TestCRUD:

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -7,6 +7,7 @@ import os
 import json
 import base64
 import hashlib
+from http import client
 
 import aiohttpretty
 
@@ -467,6 +468,57 @@ class TestHelpers:
 
 
 class TestValidatePath:
+
+    @async
+    @pytest.mark.aiohttpretty
+    def test_validate_v1_path_file(self, provider, content_repo_metadata_root_file_txt):
+        blob_path = 'file.txt'
+        blob_url = provider.build_repo_url('contents', blob_path)
+        blob_query = '?ref=' + provider.default_branch
+        blob_good_url = blob_url + blob_query
+        blob_bad_url  = blob_url + '/' + blob_query
+
+        aiohttpretty.register_json_uri('GET', blob_good_url, body=content_repo_metadata_root_file_txt)
+        aiohttpretty.register_json_uri('GET', blob_bad_url, body=content_repo_metadata_root_file_txt)
+
+        try:
+            wb_path_v1 = yield from provider.validate_v1_path('/' + blob_path)
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            yield from provider.validate_v1_path('/' + blob_path + '/')
+
+        assert exc.value.code == client.NOT_FOUND
+
+        wb_path_v0 = yield from provider.validate_path('/' + blob_path)
+
+        assert wb_path_v1 == wb_path_v0
+
+    @async
+    @pytest.mark.aiohttpretty
+    def test_validate_v1_path_folder(self, provider, content_repo_metadata_root):
+        tree_path = 'folder'
+        tree_url = provider.build_repo_url('contents', tree_path)
+        tree_query = '?ref=' + provider.default_branch
+        tree_good_url = tree_url + tree_query
+        tree_bad_url  = tree_url + '/' + tree_query
+
+        aiohttpretty.register_json_uri('GET', tree_good_url, body=content_repo_metadata_root)
+        aiohttpretty.register_json_uri('GET', tree_bad_url, body=content_repo_metadata_root)
+        try:
+            wb_path_v1 = yield from provider.validate_v1_path('/' + tree_path + '/')
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            yield from provider.validate_v1_path('/' + tree_path)
+
+        assert exc.value.code == client.NOT_FOUND
+
+        wb_path_v0 = yield from provider.validate_path('/' + tree_path + '/')
+
+        assert wb_path_v1 == wb_path_v0
 
     @async
     def test_validate_path(self, provider):

--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -3,8 +3,9 @@ import pytest
 from tests.utils import async
 
 import io
-import hashlib
 import base64
+import hashlib
+from http import client
 
 import aiohttpretty
 from freezegun import freeze_time
@@ -285,6 +286,59 @@ def build_folder_params(path):
 
 
 class TestValidatePath:
+
+    @async
+    @pytest.mark.aiohttpretty
+    def test_validate_v1_path_file(self, provider, file_metadata):
+        file_path = 'foobah'
+
+        params = {'prefix': '/' + file_path + '/', 'delimiter': '/'}
+        good_metadata_url = provider.bucket.new_key('/' + file_path).generate_url(100, 'HEAD')
+        bad_metadata_url = provider.bucket.generate_url(100)
+        aiohttpretty.register_uri('HEAD', good_metadata_url, headers=file_metadata)
+        aiohttpretty.register_uri('GET', bad_metadata_url, params=params, status=404)
+
+        try:
+            wb_path_v1 = yield from provider.validate_v1_path('/' + file_path)
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            yield from provider.validate_v1_path('/' + file_path + '/')
+
+        assert exc.value.code == client.NOT_FOUND
+
+        wb_path_v0 = yield from provider.validate_path('/' + file_path)
+
+        assert wb_path_v1 == wb_path_v0
+
+    @async
+    @pytest.mark.aiohttpretty
+    def test_validate_v1_path_folder(self, provider, folder_metadata):
+        folder_path = 'Photos'
+
+        params = {'prefix': '/' + folder_path + '/', 'delimiter': '/'}
+        good_metadata_url = provider.bucket.generate_url(100)
+        bad_metadata_url = provider.bucket.new_key('/' + folder_path).generate_url(100, 'HEAD')
+        aiohttpretty.register_uri(
+            'GET', good_metadata_url, params=params,
+            body=folder_metadata, headers={'Content-Type': 'application/xml'}
+        )
+        aiohttpretty.register_uri('HEAD', bad_metadata_url, status=404)
+
+        try:
+            wb_path_v1 = yield from provider.validate_v1_path('/' + folder_path + '/')
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            yield from provider.validate_v1_path('/' + folder_path)
+
+        assert exc.value.code == client.NOT_FOUND
+
+        wb_path_v0 = yield from provider.validate_path('/' + folder_path + '/')
+
+        assert wb_path_v1 == wb_path_v0
 
     @async
     def test_normal_name(self, provider):

--- a/tests/server/api/v1/test_create_mixin.py
+++ b/tests/server/api/v1/test_create_mixin.py
@@ -108,18 +108,20 @@ class TestCreateFolder(BaseCreateMixinTest):
 
     def test_created(self):
         metadata = mock.Mock()
-        self.mixin.path = 'apath'
+        self.mixin.path = '/'
         self.mixin.resource = '3rqws'
         metadata.json_api_serialized.return_value = {'day': 'tum'}
         self.mixin.provider = mock.Mock(
             create_folder=MockCoroutine(return_value=metadata)
         )
+        target = WaterButlerPath('/apath/')
+        self.mixin.target_path = target
 
         yield from self.mixin.create_folder()
 
         assert self.mixin.set_status.assert_called_once_with(201) is None
         assert self.mixin.write.assert_called_once_with({'data': {'day': 'tum'}}) is None
-        assert self.mixin.provider.create_folder.assert_called_once_with('apath') is None
+        assert self.mixin.provider.create_folder.assert_called_once_with(target) is None
 
 
 class TestUploadFile(BaseCreateMixinTest):

--- a/tests/server/api/v1/test_create_mixin.py
+++ b/tests/server/api/v1/test_create_mixin.py
@@ -4,6 +4,7 @@ from http import client
 from unittest import mock
 
 from waterbutler.core import exceptions
+from waterbutler.core.path import WaterButlerPath
 from waterbutler.server.api.v1.provider.create import CreateMixin
 
 from tests.utils import async
@@ -26,71 +27,81 @@ class TestValidatePut(BaseCreateMixinTest):
         self.mixin.get_query_argument.return_value = 'notaferlder'
 
         with pytest.raises(exceptions.InvalidParameters) as e:
-            self.mixin.validate_put()
+            self.mixin.prevalidate_put()
 
         assert e.value.message == 'Kind must be file, folder or unspecified (interpreted as file), not notaferlder'
 
     def test_default_kind(self):
         self.mixin.path = '/'
-        self.mixin.get_query_argument.side_effect = ('file', Exception('Breakout'))
+        self.mixin.get_query_argument.return_value = 'file'
+        self.mixin.request.headers.get.side_effect = Exception('Breakout')
 
         with pytest.raises(Exception) as e:
-            self.mixin.validate_put()
+            self.mixin.prevalidate_put()
 
         assert self.mixin.kind == 'file'
         assert e.value.args == ('Breakout', )
         assert self.mixin.get_query_argument.has_call(mock.call('kind', default='file'))
 
-    def test_name_required(self):
-        self.mixin.path = '/'
-        self.mixin.get_query_argument.side_effect = ('file', Exception('name required'))
-
-        with pytest.raises(Exception) as e:
-            self.mixin.validate_put()
-
-        assert e.value.args == ('name required', )
-        assert self.mixin.get_query_argument.has_call(mock.call('name'))
-
-    def test_kind_must_be_folder(self):
-        self.mixin.path = 'adlkjf'
-        self.mixin.get_query_argument.return_value = 'folder'
-
-        with pytest.raises(exceptions.InvalidParameters) as e:
-            self.mixin.validate_put()
-
-        assert e.value.message == 'Path must be a folder (and end with a "/") if trying to create a subfolder'
-        assert e.value.code == client.CONFLICT
-
     def test_length_required_for_files(self):
         self.mixin.path = '/'
         self.mixin.request.headers = {}
-        self.mixin.get_query_argument.side_effect = ('file', 'mynerm.txt')
+        self.mixin.get_query_argument.return_value = 'file'
 
         with pytest.raises(exceptions.InvalidParameters) as e:
-            self.mixin.validate_put()
+            self.mixin.prevalidate_put()
 
-        assert self.mixin.path == '/mynerm.txt'
         assert e.value.code == client.LENGTH_REQUIRED
         assert e.value.message == 'Content-Length is required for file uploads'
 
     def test_payload_with_folder(self):
         self.mixin.path = '/'
         self.mixin.request.headers = {'Content-Length': 5000}
-        self.mixin.get_query_argument.side_effect = ('folder', 'mynerm.txt', 'file', 'mynerm.txt')
+        self.mixin.get_query_argument.return_value = 'folder'
 
         with pytest.raises(exceptions.InvalidParameters) as e:
-            self.mixin.validate_put()
+            self.mixin.prevalidate_put()
 
         assert e.value.code == client.REQUEST_ENTITY_TOO_LARGE
         assert e.value.message == 'Folder creation requests may not have a body'
 
         self.mixin.request.headers = {'Content-Length': 'notanumber'}
+        self.mixin.get_query_argument.return_value = 'file'
 
         with pytest.raises(exceptions.InvalidParameters) as e:
-            self.mixin.validate_put()
+            self.mixin.prevalidate_put()
 
         assert e.value.code == client.BAD_REQUEST
         assert e.value.message == 'Invalid Content-Length'
+
+    def test_name_required_for_dir(self):
+        self.mixin.path = WaterButlerPath('/')
+        self.mixin.get_query_argument.return_value = None
+
+        with pytest.raises(exceptions.InvalidParameters) as e:
+            self.mixin.postvalidate_put()
+
+        assert e.value.message == 'Missing required parameter \'name\''
+
+    def test_name_refused_for_file(self):
+        self.mixin.path = WaterButlerPath('/foo.txt')
+        self.mixin.get_query_argument.return_value = 'bar.txt'
+
+        with pytest.raises(exceptions.InvalidParameters) as e:
+            self.mixin.postvalidate_put()
+
+        assert e.value.message == "'name' parameter doesn't apply to actions on files"
+
+    def test_kind_must_be_folder(self):
+        self.mixin.path = WaterButlerPath('/adlkjf')
+        self.mixin.get_query_argument.return_value = None
+        self.mixin.kind = 'folder'
+
+        with pytest.raises(exceptions.InvalidParameters) as e:
+            self.mixin.postvalidate_put()
+
+        assert e.value.message == 'Path must be a folder (and end with a "/") if trying to create a subfolder'
+        assert e.value.code == client.CONFLICT
 
 
 class TestCreateFolder(BaseCreateMixinTest):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -72,6 +72,7 @@ class MockProvider(provider.BaseProvider):
     upload = None
     download = None
     metadata = None
+    validate_v1_path = None
     validate_path = None
     revalidate_path = None
 
@@ -83,13 +84,17 @@ class MockProvider(provider.BaseProvider):
         self.upload = MockCoroutine()
         self.download = MockCoroutine()
         self.metadata = MockCoroutine()
-        self.validate_path = MockCoroutine()
+        self.validate_v1_path = MockCoroutine()
         self.revalidate_path = MockCoroutine()
 
 
 class MockProvider1(provider.BaseProvider):
 
     NAME = 'MockProvider1'
+
+    @asyncio.coroutine
+    def validate_v1_path(self, path, **kwargs):
+        return self.validate_path(path, **kwargs)
 
     @asyncio.coroutine
     def validate_path(self, path, **kwargs):

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -424,6 +424,22 @@ class BaseProvider(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def validate_v1_path(self, path, **kwargs):
+        """API v1 requires that requests against folder endpoints always end with a slash, and
+        requests against files never end with a slash.  This method checks the provider's metadata
+        for the given id and throws a 404 Not Found if the implicit and explicit types don't
+        match.  This method duplicates the logic in the provider's validate_path method, but
+        validate_path must currently accomodate v0 AND v1 semantics.  After v0's retirement, this
+        method can replace validate_path.
+
+        :param str path: user-supplied path to validate
+        :rtype: :class:`waterbutler.core.path`
+        :raises: :class:`waterbutler.core.exceptions.NotFoundError`
+
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def validate_path(self, path, **kwargs):
         raise NotImplementedError
 

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -24,6 +24,10 @@ class BoxProvider(provider.BaseProvider):
         self.folder = self.settings['folder']
 
     @asyncio.coroutine
+    def validate_v1_path(self, path, **kwargs):
+        return self.validate_path(path, **kwargs)
+
+    @asyncio.coroutine
     def validate_path(self, path, **kwargs):
         if path == '/':
             return WaterButlerPath('/', _ids=[self.folder])

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -25,7 +25,36 @@ class BoxProvider(provider.BaseProvider):
 
     @asyncio.coroutine
     def validate_v1_path(self, path, **kwargs):
-        return self.validate_path(path, **kwargs)
+        if path == '/':
+            return WaterButlerPath('/', _ids=[self.folder])
+
+        obj_id = path.strip('/')
+        files_or_folders = 'folders' if path.endswith('/') else 'files'
+
+        # Box file ids must be a valid base10 number
+        if not obj_id.isdecimal():
+            raise exceptions.NotFoundError(str(path))
+
+        response = yield from self.make_request(
+            'get',
+            self.build_url(files_or_folders, obj_id, fields='id,name,path_collection'),
+            expects=(200, 404,),
+            throws=exceptions.MetadataError,
+        )
+
+        if response.status == 404:
+            raise exceptions.NotFoundError(str(path))
+
+        data = yield from response.json()
+
+        names, ids = zip(*[
+            (x['name'], x['id'])
+            for x in
+            data['path_collection']['entries'] + [data]
+        ])
+        names, ids = ('',) + names[ids.index(self.folder) + 1:], ids[ids.index(self.folder):]
+
+        return WaterButlerPath('/'.join(names), _ids=ids, folder=path.endswith('/'))
 
     @asyncio.coroutine
     def validate_path(self, path, **kwargs):

--- a/waterbutler/providers/cloudfiles/provider.py
+++ b/waterbutler/providers/cloudfiles/provider.py
@@ -48,6 +48,10 @@ class CloudFilesProvider(provider.BaseProvider):
         self.use_public = self.settings.get('use_public', True)
 
     @asyncio.coroutine
+    def validate_v1_path(self, path, **kwargs):
+        return self.validate_path(path, **kwargs)
+
+    @asyncio.coroutine
     def validate_path(self, path, **kwargs):
         return WaterButlerPath(path)
 

--- a/waterbutler/providers/dataverse/provider.py
+++ b/waterbutler/providers/dataverse/provider.py
@@ -44,6 +44,9 @@ class DataverseProvider(provider.BaseProvider):
 
     @asyncio.coroutine
     def validate_v1_path(self, path, **kwargs):
+        if path != '/' and path.endswith('/'):
+            raise exceptions.NotFoundError(str(path))
+
         return self.validate_path(path, **kwargs)
 
     @asyncio.coroutine

--- a/waterbutler/providers/dataverse/provider.py
+++ b/waterbutler/providers/dataverse/provider.py
@@ -43,6 +43,10 @@ class DataverseProvider(provider.BaseProvider):
         return super().build_url(*(tuple(path.split('/')) + segments), **query)
 
     @asyncio.coroutine
+    def validate_v1_path(self, path, **kwargs):
+        return self.validate_path(path, **kwargs)
+
+    @asyncio.coroutine
     def validate_path(self, path, revision=None, **kwargs):
         """Ensure path is in configured dataset
 

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -23,6 +23,10 @@ class DropboxProvider(provider.BaseProvider):
         self.folder = self.settings['folder']
 
     @asyncio.coroutine
+    def validate_v1_path(self, path, **kwargs):
+        return self.validate_path(path, **kwargs)
+
+    @asyncio.coroutine
     def validate_path(self, path, **kwargs):
         return WaterButlerPath(path, prepend=self.folder)
 

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -71,6 +71,10 @@ class FigshareProjectProvider(BaseFigshareProvider):
         self.project_id = self.settings['project_id']
 
     @asyncio.coroutine
+    def validate_v1_path(self, path, **kwargs):
+        return self.validate_path(path, **kwargs)
+
+    @asyncio.coroutine
     def validate_path(self, path, **kwargs):
         split = path.rstrip('/').split('/')[1:]
         wbpath = WaterButlerPath('/', _ids=(self.settings['project_id'], ), folder=True)
@@ -219,6 +223,10 @@ class FigshareArticleProvider(BaseFigshareProvider):
         super().__init__(auth, credentials, settings)
         self.article_id = self.settings['article_id']
         self.child = child
+
+    @asyncio.coroutine
+    def validate_v1_path(self, path, **kwargs):
+        return self.validate_path(path, **kwargs)
 
     @asyncio.coroutine
     def validate_path(self, path, parent=None, **kwargs):

--- a/waterbutler/providers/filesystem/provider.py
+++ b/waterbutler/providers/filesystem/provider.py
@@ -23,6 +23,10 @@ class FileSystemProvider(provider.BaseProvider):
         os.makedirs(self.folder, exist_ok=True)
 
     @asyncio.coroutine
+    def validate_v1_path(self, path, **kwargs):
+        return self.validate_path(path, **kwargs)
+
+    @asyncio.coroutine
     def validate_path(self, path, **kwargs):
         return WaterButlerPath(path, prepend=self.folder)
 

--- a/waterbutler/providers/filesystem/provider.py
+++ b/waterbutler/providers/filesystem/provider.py
@@ -24,7 +24,15 @@ class FileSystemProvider(provider.BaseProvider):
 
     @asyncio.coroutine
     def validate_v1_path(self, path, **kwargs):
-        return self.validate_path(path, **kwargs)
+        if not os.path.exists(self.folder + path):
+            raise exceptions.NotFoundError(str(path))
+
+        implicit_folder = path.endswith('/')
+        explicit_folder = os.path.isdir(self.folder + path)
+        if implicit_folder != explicit_folder:
+            raise exceptions.NotFoundError(str(path))
+
+        return WaterButlerPath(path, prepend=self.folder)
 
     @asyncio.coroutine
     def validate_path(self, path, **kwargs):

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -58,6 +58,10 @@ class GitHubProvider(provider.BaseProvider):
         self.repo = self.settings['repo']
 
     @asyncio.coroutine
+    def validate_v1_path(self, path, **kwargs):
+        return self.validate_path(path, **kwargs)
+
+    @asyncio.coroutine
     def validate_path(self, path, **kwargs):
         if not getattr(self, '_repo', None):
             self._repo = yield from self._fetch_repo()

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -45,6 +45,10 @@ class GoogleDriveProvider(provider.BaseProvider):
         self.folder = self.settings['folder']
 
     @asyncio.coroutine
+    def validate_v1_path(self, path, **kwargs):
+        return self.validate_path(path, **kwargs)
+
+    @asyncio.coroutine
     def validate_path(self, path, file_id=None, **kwargs):
         if path == '/':
             return GoogleDrivePath('/', _ids=[self.folder['id']], folder=True)

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -42,6 +42,10 @@ class OSFStorageProvider(provider.BaseProvider):
         self.archive_credentials = credentials.get('archive')
 
     @asyncio.coroutine
+    def validate_v1_path(self, path, **kwargs):
+        return self.validate_path(path, **kwargs)
+
+    @asyncio.coroutine
     def validate_path(self, path, **kwargs):
         if path == '/':
             return WaterButlerPath('/', _ids=[self.root_id], folder=True)

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -56,6 +56,10 @@ class S3Provider(provider.BaseProvider):
         self.encrypt_uploads = self.settings.get('encrypt_uploads', False)
 
     @asyncio.coroutine
+    def validate_v1_path(self, path, **kwargs):
+        return self.validate_path(path, **kwargs)
+
+    @asyncio.coroutine
     def validate_path(self, path, **kwargs):
         return WaterButlerPath(path)
 

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -57,7 +57,31 @@ class S3Provider(provider.BaseProvider):
 
     @asyncio.coroutine
     def validate_v1_path(self, path, **kwargs):
-        return self.validate_path(path, **kwargs)
+        if path == '/':
+            return WaterButlerPath(path)
+
+        implicit_folder = path.endswith('/')
+
+        if implicit_folder:
+            resp = yield from self.make_request(
+                'GET',
+                self.bucket.generate_url(settings.TEMP_URL_SECS, 'GET'),
+                params={'prefix': path, 'delimiter': '/'},
+                expects=(200, 404),
+                throws=exceptions.MetadataError,
+            )
+        else:
+            resp = yield from self.make_request(
+                'HEAD',
+                self.bucket.new_key(path).generate_url(settings.TEMP_URL_SECS, 'HEAD'),
+                expects=(200, 404),
+                throws=exceptions.MetadataError,
+            )
+
+        if resp.status == 404:
+            raise exceptions.NotFoundError(str(path))
+
+        return WaterButlerPath(path)
 
     @asyncio.coroutine
     def validate_path(self, path, **kwargs):

--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -43,7 +43,7 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
 
         self.auth = yield from auth_handler.get(self.resource, provider, self.request)
         self.provider = utils.make_provider(provider, self.auth['auth'], self.auth['credentials'], self.auth['settings'])
-        self.path = yield from self.provider.validate_path(self.path)
+        self.path = yield from self.provider.validate_v1_path(self.path)
 
         # The one special case
         if self.request.method == 'PUT' and self.path.is_file:

--- a/waterbutler/server/api/v1/provider/create.py
+++ b/waterbutler/server/api/v1/provider/create.py
@@ -6,33 +6,20 @@ from waterbutler.core import exceptions
 
 class CreateMixin:
 
-    def validate_put(self):
-        """Prevalidation for creation requests. Run BEFORE
-        the body of a request is accepted. Requests with bodies that are too large can be
-        rejected if we have not began to accept the body.
-        Validation is as follows:
+    def prevalidate_put(self):
+        """Prevalidation for creation requests. Runs BEFORE the body of a request is accepted and
+        before the path given in the url has been validated.  An early rejection here will save us
+        one or more API calls to the provider. Requests with bodies that are too large can be
+        rejected if we have not began to accept the body. Validation is as follows:
+
         1. Pull kind from query params. It must be file, folder, or not included (which defaults to file)
-        2. If path is a folder (ends with a slash) pull name from query parameters raise an exception if its not found
-            * If kind is folder a / is append to path
-        3. If path does not end with a / and kind is folder raise an exception
-        4. Ensure that content length is present for file uploads
-        5. Ensure that content length is either not present or 0 for folder creation requests
+        2. Ensure that content length is present for file uploads
+        3. Ensure that content length is either not present or 0 for folder creation requests
         """
         self.kind = self.get_query_argument('kind', default='file')
 
         if self.kind not in ('file', 'folder'):
             raise exceptions.InvalidParameters('Kind must be file, folder or unspecified (interpreted as file), not {}'.format(self.kind))
-
-        if self.path.endswith('/'):
-            name = self.get_query_argument('name')  # TODO What does this do?
-            self.path = os.path.join(self.path, name)
-            if self.kind == 'folder':
-                self.path += '/'
-        elif self.kind == 'folder':
-            raise exceptions.InvalidParameters(
-                'Path must be a folder (and end with a "/") if trying to create a subfolder',
-                code=409
-            )
 
         length = self.request.headers.get('Content-Length')
 
@@ -46,6 +33,34 @@ class CreateMixin:
                 raise exceptions.InvalidParameters('Folder creation requests may not have a body', code=413)
         except ValueError:
                 raise exceptions.InvalidParameters('Invalid Content-Length')
+
+    def postvalidate_put(self):
+        """Postvalidation for creation requests. Runs BEFORE the body of a request is accepted, but
+        after the path has been validated.  Invalid path+params combinations can be rejected here.
+        Validation is as follows:
+
+        1. If path is a folder, the name parameter must be present.
+        2. If path is a file, the name parameter must be absent.
+        3. If the entity being created is a folder, then path must be a folder as well.
+        """
+
+        self.childs_name = self.get_query_argument('name', default=None)
+
+        if self.path.is_dir and self.childs_name is None:
+            raise exceptions.InvalidParameters('Missing required parameter \'name\'')
+
+        if self.path.is_file and self.childs_name is not None:
+            raise exceptions.InvalidParameters("'name' parameter doesn't apply to actions on files")
+
+        if self.path.is_dir:
+            self.path = os.path.join(self.path, self.childs_name)
+            if self.kind == 'folder':
+                self.path += '/'
+        elif self.kind == 'folder':
+            raise exceptions.InvalidParameters(
+                'Path must be a folder (and end with a "/") if trying to create a subfolder',
+                code=409
+            )
 
     @asyncio.coroutine
     def create_folder(self):

--- a/waterbutler/server/api/v1/provider/movecopy.py
+++ b/waterbutler/server/api/v1/provider/movecopy.py
@@ -24,7 +24,13 @@ class MoveCopyMixin:
                 raise exceptions.InvalidParameters('Invalid json body')
         return self._json
 
-    def validate_post(self):
+    def prevalidate_post(self):
+        """Validate body and query parameters before spending API calls on validating path.  We
+        don't trust path yet, so I don't wanna see it being used here.  Current validations:
+
+        1. Max body size is 1Mb.
+        2. Content-Length header must be provided.
+        """
         try:
             if int(self.request.headers['Content-Length']) > 1 * MBs:
                 # There should be no JSON body > 1 megs


### PR DESCRIPTION
v1 expects folder paths to always end with a slash and file paths to never end with a slash.  However, it wasn't enforcing this and some manually-constructed tests were 500ing as a result.  It was decided
that trying to address folders as file and vice-versa should consistently produce 404s.

[#OSF-4675]