### PR TITLE
[CR] github: don't leave behind source file when moving

### DIFF
--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -584,7 +584,7 @@ class GitHubProvider(provider.BaseProvider):
         old_commit_tree_sha = branch_data['commit']['commit']['tree']['sha']
 
         tree = yield from self._fetch_tree(old_commit_tree_sha, recursive=True)
-        exists = any(x['path'] == dest_path.path for x in tree['tree'])
+        exists = any(x['path'] == dest_path.path.rstrip('/') for x in tree['tree'])
 
         target, keep = None, []
 
@@ -653,4 +653,4 @@ class GitHubProvider(provider.BaseProvider):
             else:
                 folder.children.append(GitHubFileTreeMetadata(item))
 
-        return folder, exists
+        return folder, not exists

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -577,7 +577,16 @@ class GitHubProvider(provider.BaseProvider):
 
     @asyncio.coroutine
     def _do_intra_move_or_copy(self, src_path, dest_path, is_copy):
-        target, branch = None, src_path.identifier[0]
+
+        # ON PATHS:
+        #   WB and GH use slightly different default conventions for their paths, so we often
+        #   have to munge our WB paths before comparison. Here is a quick overview:
+        #     WB (dirs):  wb_dir.path == 'foo/bar/'     str(wb_dir) == '/foo/bar/'
+        #     WB (file):  wb_file.path = 'foo/bar.txt'  str(wb_file) == '/foo/bar.txt'
+        #     GH (dir):   'foo/bar'
+        #     GH (file):  'foo/bar.txt'
+
+        branch = src_path.identifier[0]
         branch_data = yield from self._fetch_branch(branch)
 
         old_commit_sha = branch_data['commit']['sha']
@@ -586,26 +595,28 @@ class GitHubProvider(provider.BaseProvider):
         tree = yield from self._fetch_tree(old_commit_tree_sha, recursive=True)
         exists = any(x['path'] == dest_path.path.rstrip('/') for x in tree['tree'])
 
-        target, keep = None, []
+        blobs = [
+            item
+            for item in tree['tree']
+            if src_path.is_dir and item['path'].startswith(src_path.path) or
+            src_path.is_file and item['path'] == src_path.path
+        ]
 
-        for item in tree['tree']:
-            if item['path'] == str(src_path).strip('/'):
-                assert target is None, 'Found multiple targets'
-                target = item
-            elif item['path'].startswith(src_path.path):
-                keep.append(item)
-
-        if target is None or (src_path.is_dir and target['type'] != 'tree'):
+        if len(blobs) == 0:
             raise exceptions.NotFoundError(str(src_path))
 
+        if src_path.is_file:
+            assert len(blobs) == 1, 'Found multiple targets'
+
         if is_copy:
-            tree['tree'].append(copy.deepcopy(target))
-        elif src_path.is_dir:
-            for item in keep:
-                tree['tree'].remove(item)
+            tree['tree'].extend([copy.deepcopy(blob) for blob in blobs])
 
-        target['path'] = target['path'].replace(src_path.path.strip('/'), dest_path.path.strip('/'), 1)
+        for blob in blobs:
+            blob['path'] = blob['path'].replace(src_path.path, dest_path.path, 1)
 
+        # github infers tree contents from blob paths
+        # see: http://www.levibotelho.com/development/commit-a-file-with-the-github-api/
+        tree['tree'] = [item for item in tree['tree'] if item['type'] != 'tree']
         new_tree_data = yield from self._create_tree({'tree': tree['tree']})
         new_tree_sha = new_tree_data['sha']
 
@@ -638,7 +649,8 @@ class GitHubProvider(provider.BaseProvider):
         )
 
         if dest_path.is_file:
-            return GitHubFileTreeMetadata(target, commit=commit), not exists
+            assert len(blobs) == 1, 'Destination file should have exactly one candidate'
+            return GitHubFileTreeMetadata(blobs[0], commit=commit), not exists
 
         folder = GitHubFolderTreeMetadata({
             'path': dest_path.path.strip('/')
@@ -646,8 +658,9 @@ class GitHubProvider(provider.BaseProvider):
 
         folder.children = []
 
-        for item in keep:
-            item['path'] = item['path'].replace(src_path.path, dest_path.path, 1)
+        for item in blobs:
+            if item['path'] == src_path.path.rstrip('/'):
+                continue
             if item['type'] == 'tree':
                 folder.children.append(GitHubFolderTreeMetadata(item))
             else:


### PR DESCRIPTION
When moving files from a non-root folder in github, the source file was  being left behind.  This was because the tree entry for the source directory was left in the modified master tree, where it still contained references to the old blob/tree.  The solution was to remove all tree entries from the master tree and to allow github to infer the new tree structure from the path names of the remaining blobs.

I also included a fix for folder move/copy actions returning the wrong status code, since the changes are very closely related.

Fixes: [#OSF-4792], [#OSF-4870]