### PR TITLE
[CR] github: avoid dataloss w/ folderops in large repos

### DIFF
--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -425,7 +425,17 @@ class GitHubProvider(provider.BaseProvider):
             expects=(200, ),
             throws=exceptions.MetadataError
         )
-        return (yield from resp.json())
+        tree = yield from resp.json()
+
+        if tree['truncated']:
+            raise exceptions.ProviderError(
+                ('Some folder operations on large GitHub repositories cannot be supported without'
+                 ' data loss.  To carry out this operation, please perform it in a local git'
+                 ' repository, then push to the target repository on GitHub.'),
+                code=501
+            )
+
+        return tree
 
     @asyncio.coroutine
     def _create_tree(self, tree):


### PR DESCRIPTION
Folders (trees) in GitHub cannot be operated on directly, and must
instead be moved/renamed/deleted by manipulating the blob paths in the
master tree.  Unfortunately, GH truncates master tree listings for repos
with lots of files and does not provide a way to page through and
retrieve all entries. Any blobs omitted when updating the master tree
will be treated as deleted.  Therefore, it doesn't seem that we can
always safely perform certain folder ops on large repos, so instead we
throw a 501 Not Implemented with an explanatory message.

Fixes [#OSF-4867]