### PR TITLE
[CR] return 409 when trying to create a folder on a fileish path

### DIFF
--- a/tests/server/api/v1/test_create_mixin.py
+++ b/tests/server/api/v1/test_create_mixin.py
@@ -58,7 +58,8 @@ class TestValidatePut(BaseCreateMixinTest):
         with pytest.raises(exceptions.InvalidParameters) as e:
             self.mixin.validate_put()
 
-        assert e.value.message == 'Path must end with a / if kind is folder'
+        assert e.value.message == 'Path must be a folder (and end with a "/") if trying to create a subfolder'
+        assert e.value.code == client.CONFLICT
 
     def test_length_required_for_files(self):
         self.mixin.path = '/'

--- a/waterbutler/server/api/v1/provider/create.py
+++ b/waterbutler/server/api/v1/provider/create.py
@@ -29,7 +29,10 @@ class CreateMixin:
             if self.kind == 'folder':
                 self.path += '/'
         elif self.kind == 'folder':
-            raise exceptions.InvalidParameters('Path must end with a / if kind is folder')
+            raise exceptions.InvalidParameters(
+                'Path must be a folder (and end with a "/") if trying to create a subfolder',
+                code=409
+            )
 
         length = self.request.headers.get('Content-Length')
 


### PR DESCRIPTION
We had been returning 400.  All other actions,kind combos are legit.

Minor change, no JIRA ticket created.