### PR TITLE
[CR] fix broken tests from aiohttpretty upgrade

### DIFF
--- a/tests/providers/dropbox/test_provider.py
+++ b/tests/providers/dropbox/test_provider.py
@@ -111,6 +111,10 @@ def file_metadata():
     }
 
 
+def build_folder_metadata_params(path):
+    return {'root': 'auto', 'path': path.full_path}
+
+
 class TestValidatePath:
 
     @async
@@ -236,8 +240,9 @@ class TestCreateFolder:
     def test_already_exists(self, provider):
         path = WaterButlerPath('/newfolder/', prepend=provider.folder)
         url = provider.build_url('fileops', 'create_folder')
+        params = build_folder_metadata_params(path)
 
-        aiohttpretty.register_json_uri('POST', url, status=403, body={
+        aiohttpretty.register_json_uri('POST', url, params=params, status=403, body={
             'error': 'because a file or folder already exists at path'
         })
 
@@ -252,8 +257,9 @@ class TestCreateFolder:
     def test_forbidden(self, provider):
         path = WaterButlerPath('/newfolder/', prepend=provider.folder)
         url = provider.build_url('fileops', 'create_folder')
+        params = build_folder_metadata_params(path)
 
-        aiohttpretty.register_json_uri('POST', url, status=403, body={
+        aiohttpretty.register_json_uri('POST', url, params=params, status=403, body={
             'error': 'because I hate you'
         })
 
@@ -268,8 +274,9 @@ class TestCreateFolder:
     def test_raises_on_errors(self, provider):
         path = WaterButlerPath('/newfolder/', prepend=provider.folder)
         url = provider.build_url('fileops', 'create_folder')
+        params = build_folder_metadata_params(path)
 
-        aiohttpretty.register_json_uri('POST', url, status=418, body={})
+        aiohttpretty.register_json_uri('POST', url, params=params, status=418, body={})
 
         with pytest.raises(exceptions.CreateFolderError) as e:
             yield from provider.create_folder(path)
@@ -282,8 +289,9 @@ class TestCreateFolder:
         file_metadata['path'] = '/newfolder'
         path = WaterButlerPath('/newfolder/', prepend=provider.folder)
         url = provider.build_url('fileops', 'create_folder')
+        params = build_folder_metadata_params(path)
 
-        aiohttpretty.register_json_uri('POST', url, status=200, body=file_metadata)
+        aiohttpretty.register_json_uri('POST', url, params=params, status=200, body=file_metadata)
 
         resp = yield from provider.create_folder(path)
 

--- a/tests/providers/osfstorage/test_provider.py
+++ b/tests/providers/osfstorage/test_provider.py
@@ -152,11 +152,14 @@ def test_download(monkeypatch, provider_and_mock, osf_response, mock_path):
 @pytest.mark.aiohttpretty
 def test_delete(monkeypatch, provider, mock_path):
     path = WaterButlerPath('/unrelatedpath', _ids=('Doesntmatter', 'another'))
-    aiohttpretty.register_uri('DELETE', 'https://waterbutler.io/another/', status_code=200)
+    params = {'user': 'cat'}
+    base_url = provider.build_url(path.identifier)
+    url = provider.build_signed_url('DELETE', base_url, params=params)
+    aiohttpretty.register_uri('DELETE', url, params=params, status_code=200)
 
     yield from provider.delete(path)
 
-    assert aiohttpretty.has_call(method='DELETE', uri='https://waterbutler.io/another/', check_params=False)
+    assert aiohttpretty.has_call(method='DELETE', uri=url, check_params=False)
 
 
 @async

--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -621,7 +621,7 @@ class TestOperations:
             assert hasattr(item, 'version')
             assert hasattr(item, 'version_identifier')
 
-        assert aiohttpretty.has_call(method='GET', uri=url)
+        assert aiohttpretty.has_call(method='GET', uri=url, params=params)
 
     def test_equality(self, provider):
         assert provider.can_intra_copy(provider)

--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -6,6 +6,7 @@ import io
 import hashlib
 
 import aiohttpretty
+from freezegun import freeze_time
 
 from waterbutler.core import streams
 from waterbutler.core import metadata
@@ -275,6 +276,7 @@ class TestValidatePath:
         assert not path.is_root
 
 
+@freeze_time('2015-10-31 12:00:01')
 class TestCRUD:
 
     @async
@@ -401,6 +403,7 @@ class TestCRUD:
         assert ret_url == url
 
 
+@freeze_time('2015-10-31 12:00:01')
 class TestMetadata:
 
     @async
@@ -505,6 +508,7 @@ class TestMetadata:
         assert aiohttpretty.has_call(method='HEAD', uri=metadata_url)
 
 
+@freeze_time('2015-10-31 12:00:01')
 class TestCreateFolder:
 
     @async
@@ -581,6 +585,7 @@ class TestCreateFolder:
         assert resp.path == '/doesntalreadyexists/'
 
 
+@freeze_time('2015-10-31 12:00:01')
 class TestOperations:
 
     # @async

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -163,8 +163,7 @@ class OSFStorageProvider(provider.BaseProvider):
 
         return OsfStorageFolderMetadata(data, str(dest_path)), dest_path.identifier is None
 
-    @asyncio.coroutine
-    def make_signed_request(self, method, url, data=None, params=None, ttl=100, **kwargs):
+    def build_signed_url(self, method, url, data=None, params=None, ttl=100, **kwargs):
         signer = signing.Signer(settings.HMAC_SECRET, settings.HMAC_ALGORITHM)
         if method.upper() in QUERY_METHODS:
             signed = signing.sign_data(signer, params or {}, ttl=ttl)
@@ -180,6 +179,11 @@ class OSFStorageProvider(provider.BaseProvider):
             elif url[url.rfind('?') - 1] != '/':
                 url = url.replace('?', '/?')
 
+        return url
+
+    @asyncio.coroutine
+    def make_signed_request(self, method, url, data=None, params=None, ttl=100, **kwargs):
+        url = self.build_signed_url(method, url, data=data, params=params, ttl=ttl, **kwargs)
         return (yield from self.make_request(method, url, data=data, params=params, **kwargs))
 
     @asyncio.coroutine


### PR DESCRIPTION
This CR fixes broken tests in the osfstorage, dropbox, and s3 providers, related to the [changes in commit b5b742cb](https://github.com/CenterForOpenScience/aiohttpretty/commit/b5b742cba4e3d1e6b883f122f2b621219a781833) in aiohttpretty.

To test this, run `pip install -U -r dev-requirements` in the WB directory to get the most recent version of aiohttpretty.  Then run `invoke test` and behold all the lovely failures.  Then checkout this PR, rerun the tests, and wallow in an enchanting sea of passing green.