### PR TITLE
[CR] repair logging for Waterbutler delete/create actions

### DIFF
--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -571,3 +571,4 @@ class TestCreateFolder:
         assert resp.name == '50 shades of nope'
         assert resp.path == '/{}/'.format(folder_object_metadata['id'])
         assert isinstance(resp, BoxFolderMetadata)
+        assert path.identifier_path == '/' + folder_object_metadata['id'] + '/'

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -297,7 +297,10 @@ class BoxProvider(provider.BaseProvider):
         if resp.status == 409:
             raise exceptions.FolderNamingConflict(str(path))
 
-        return BoxFolderMetadata((yield from resp.json()), path)
+        resp_json = yield from resp.json()
+        # save new folder's id into the WaterButlerPath object. logs will need it later.
+        path._parts[-1]._id = resp_json['id']
+        return BoxFolderMetadata(resp_json, path)
 
     def _assert_child(self, paths, target=None):
         if self.folder == 0:

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -357,10 +357,10 @@ class OSFStorageProvider(provider.BaseProvider):
             expects=(201, )
         )
 
-        return OsfStorageFolderMetadata(
-            (yield from resp.json())['data'],
-            str(path)
-        )
+        resp_json = yield from resp.json()
+        # save new folder's id into the WaterButlerPath object. logs will need it later.
+        path._parts[-1]._id = resp_json['data']['path'].strip('/')
+        return OsfStorageFolderMetadata(resp_json['data'], str(path))
 
     @asyncio.coroutine
     def _item_metadata(self, path, revision=None):

--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -132,6 +132,7 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
             'action': action,
             'time': time.time() + 60,
             'auth': self.auth['auth'],
+            'provider': self.provider.NAME,
         }
 
         if action in ('move', 'copy'):


### PR DESCRIPTION
Problem
--

Create and delete actions via WaterButler v1 API are not being logged by the OSF.  Example:

I issue a PUT against the WB v1 API to create a new folder, "pr-example", under osfstorage:

![screen shot 2015-11-10 at 6 07 24 pm](https://cloud.githubusercontent.com/assets/86835/11078862/69c048a2-87d6-11e5-8134-b479c26f0a2b.png)

... and it succeeds.  But when I visit the node's page, I can see the folder in the file browser, but no entry in the node logs:

![screen shot 2015-11-10 at 6 08 13 pm](https://cloud.githubusercontent.com/assets/86835/11078887/9286f998-87d6-11e5-996d-ce51569a7a10.png)

The same is true for delete actions.

Testing
--

Run create folder, create file, and delete actions against waterbutler.  All actions should show up in the node logs on the OSF side.

Fixes: [#OSF-5148]