### PR TITLE
bugfix: payload_path isn't an attr, breaks logging

### DIFF
--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -175,7 +175,7 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
                     # Hack: OSF and box use identifiers to refer to files
                     'path': payload_path.identifier_path if self.provider.NAME in IDENTIFIER_PATHS else payload_path.path,
                     'name': payload_path.name,
-                    'materialized': str(self.payload_path),
+                    'materialized': str(payload_path),
                     'provider': self.provider.NAME,
                 }
             })


### PR DESCRIPTION
In v1's _send_hook() method, I was calling payload_path as an attribute, rather than the variable it is.