### PR TITLE
v1: GitHubPath should propagate branch to children

### DIFF
--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -18,6 +18,7 @@ from waterbutler.core.provider import build_url
 
 from waterbutler.providers.github import GitHubProvider
 from waterbutler.providers.github import settings as github_settings
+from waterbutler.providers.github.provider import GitHubPath
 from waterbutler.providers.github.metadata import GitHubRevision
 from waterbutler.providers.github.metadata import GitHubFileTreeMetadata
 from waterbutler.providers.github.metadata import GitHubFolderTreeMetadata
@@ -468,6 +469,15 @@ class TestHelpers:
 
 
 class TestValidatePath:
+
+    def test_child_gets_branch(self):
+        parent = GitHubPath('/', _ids=[('master', None)], folder=True)
+
+        child_file = parent.child('childfile', folder=False)
+        assert child_file.identifier[0] == 'master'
+
+        child_folder = parent.child('childfolder', folder=True)
+        assert child_folder.identifier[0] == 'master'
 
     @async
     @pytest.mark.aiohttpretty

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -31,6 +31,11 @@ class GitHubPathPart(path.WaterButlerPathPart):
 class GitHubPath(path.WaterButlerPath):
     PART_CLASS = GitHubPathPart
 
+    def child(self, name, _id=None, folder=False):
+        if _id is None:
+            _id = (self.identifier[0], None)
+        return super().child(name, _id=_id, folder=folder)
+
 
 class GitHubProvider(provider.BaseProvider):
     NAME = 'github'


### PR DESCRIPTION
Every path part of a GithubPath should have an id tuple of ($branch,
$ref?).  The WaterButler Path object was not providing the branch when
creating a subentity via the child() method.  Fixed that.

Fixes [#OSF-5261].