### PR TITLE
[CR] box: add slash to materialized attr for folders

### DIFF
--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -463,7 +463,7 @@ class TestMetadata:
             if x['type'] == 'file':
                 expected.append(BoxFileMetadata(x, path.child(x['name'])))
             else:
-                expected.append(BoxFolderMetadata(x, path.child(x['name'])))
+                expected.append(BoxFolderMetadata(x, path.child(x['name'], folder=True)))
 
         assert result == expected
 

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -405,7 +405,7 @@ class BoxProvider(provider.BaseProvider):
             return self._serialize_item(data)
 
         return [
-            self._serialize_item(each, path.child(each['name']))
+            self._serialize_item(each, path.child(each['name'], folder=(each['type'] == 'folder')))
             for each in data['entries']
         ]
 


### PR DESCRIPTION
When a folder listing is returned from Box, any folders in the listing
are missing the expected trailing slash.  This is because the folder
metadata method was failing to set the `folder` attribute of child entities.

Fixes: [#OSF-5292]