### PR TITLE
[CR] consistently handle file/folder naming conflicts

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -75,6 +75,7 @@ class MockProvider(provider.BaseProvider):
     validate_v1_path = None
     validate_path = None
     revalidate_path = None
+    can_duplicate_names = True
 
     def __init__(self, auth=None, settings=None, creds=None):
         super().__init__(auth or {}, settings or {}, creds or {})
@@ -117,6 +118,9 @@ class MockProvider1(provider.BaseProvider):
     @asyncio.coroutine
     def download(self, path, **kwargs):
         return b''
+
+    def can_duplicate_names(self):
+        return True
 
 
 class MockProvider2(MockProvider1):

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -382,6 +382,11 @@ class BaseProvider(metaclass=abc.ABCMeta):
         return lambda: self.download(path)
 
     @abc.abstractmethod
+    def can_duplicate_names(self):
+        """Returns True if a file and a folder in the same directory can have identical names."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def download(self, **kwargs):
         """Download a file from this provider.
 

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -143,6 +143,9 @@ class BoxProvider(provider.BaseProvider):
 
         return base.child(name, _id=_id, folder=folder)
 
+    def can_duplicate_names(self):
+        return False
+
     def can_intra_move(self, other, path=None):
         return self == other
 

--- a/waterbutler/providers/cloudfiles/provider.py
+++ b/waterbutler/providers/cloudfiles/provider.py
@@ -195,6 +195,9 @@ class CloudFilesProvider(provider.BaseProvider):
         endpoint = _endpoint or self.endpoint
         return provider.build_url(endpoint, self.container, *path.split('/'), **query)
 
+    def can_duplicate_names(self):
+        return False
+
     def can_intra_copy(self, dest_provider, path=None):
         return type(self) == type(dest_provider) and not getattr(path, 'is_dir', False)
 

--- a/waterbutler/providers/dataverse/provider.py
+++ b/waterbutler/providers/dataverse/provider.py
@@ -42,6 +42,9 @@ class DataverseProvider(provider.BaseProvider):
         # Need to split up the dataverse subpaths and push them into segments
         return super().build_url(*(tuple(path.split('/')) + segments), **query)
 
+    def can_duplicate_names(self):
+        return False
+
     @asyncio.coroutine
     def validate_v1_path(self, path, **kwargs):
         if path != '/' and path.endswith('/'):

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -46,6 +46,9 @@ class DropboxProvider(provider.BaseProvider):
     def validate_path(self, path, **kwargs):
         return WaterButlerPath(path, prepend=self.folder)
 
+    def can_duplicate_names(self):
+        return False
+
     @property
     def default_headers(self):
         return {

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -63,6 +63,9 @@ class BaseFigshareProvider(provider.BaseProvider):
 
         return base.child(path, folder=False)
 
+    def can_duplicate_names(self):
+        return True
+
 
 class FigshareProjectProvider(BaseFigshareProvider):
 

--- a/waterbutler/providers/filesystem/provider.py
+++ b/waterbutler/providers/filesystem/provider.py
@@ -38,6 +38,9 @@ class FileSystemProvider(provider.BaseProvider):
     def validate_path(self, path, **kwargs):
         return WaterButlerPath(path, prepend=self.folder)
 
+    def can_duplicate_names(self):
+        return False
+
     @asyncio.coroutine
     def intra_copy(self, dest_provider, src_path, dest_path):
         exists = yield from self.exists(dest_path)

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -117,6 +117,9 @@ class GitHubProvider(provider.BaseProvider):
     def revalidate_path(self, base, path, folder=False):
         return base.child(path, _id=((base.identifier[0], None)), folder=folder)
 
+    def can_duplicate_names(self):
+        return False
+
     @property
     def default_headers(self):
         return {'Authorization': 'token {}'.format(self.token)}

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -552,6 +552,12 @@ class GitHubProvider(provider.BaseProvider):
                 else:
                     raise
 
+            if isinstance(data, dict):
+                raise exceptions.MetadataError(
+                    'Could not retrieve folder "{0}"'.format(str(path)),
+                    code=404,
+                )
+
             ret = []
             for item in data:
                 if item['type'] == 'dir':

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -96,6 +96,9 @@ class GoogleDriveProvider(provider.BaseProvider):
         _id, name, mime = list(map(parts[-1].__getitem__, ('id', 'title', 'mimeType')))
         return base.child(name, _id=_id, folder='folder' in mime)
 
+    def can_duplicate_names(self):
+        return True
+
     @property
     def default_headers(self):
         return {'authorization': 'Bearer {}'.format(self.token)}

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -126,6 +126,9 @@ class OSFStorageProvider(provider.BaseProvider):
             self.settings['storage'],
         )
 
+    def can_duplicate_names(self):
+        return True
+
     def can_intra_copy(self, other, path=None):
         return isinstance(other, self.__class__)
 

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -89,6 +89,9 @@ class S3Provider(provider.BaseProvider):
     def validate_path(self, path, **kwargs):
         return WaterButlerPath(path)
 
+    def can_duplicate_names(self):
+        return True
+
     def can_intra_copy(self, dest_provider, path=None):
         return type(self) == type(dest_provider) and not getattr(path, 'is_dir', False)
 


### PR DESCRIPTION
When creating a new folder or uploading a new file in a directory via WaterButler, our conflict-handling heuristics are all over the map. Some providers (osfstorage, S3) allow a file and folder with the same name to coexist in a directory. Others do not, but behave inconsistently when encountering a conflict. For those providers, which ever entity is created first should succeed, and the following request should throw a 409 Conflict. 

Fixes: [#OSF-5226]