### PR TITLE
 [CR] Update Google Drive provider to use identifiers instead of file paths to reference files.

### DIFF
--- a/tests/providers/googledrive/test_metadata.py
+++ b/tests/providers/googledrive/test_metadata.py
@@ -23,14 +23,13 @@ def test_file_metadata_drive(basepath):
     parsed = GoogleDriveFileMetadata(item, path)
 
     assert parsed.provider == 'googledrive'
-    assert parsed.id == item['id']
     assert path.name == item['title']
     assert parsed.name == item['title']
     assert parsed.size == item['fileSize']
     assert parsed.modified == item['modifiedDate']
     assert parsed.content_type == item['mimeType']
     assert parsed.extra == {'revisionId': item['version'], 'webView': item['alternateLink']}
-    assert parsed.path == '/' + os.path.join(*[x.raw for x in path.parts])
+    assert parsed.path == '/' + item['id']
     assert parsed.materialized_path == str(path)
 
 
@@ -40,14 +39,13 @@ def test_file_metadata_drive_slashes(basepath):
     parsed = GoogleDriveFileMetadata(item, path)
 
     assert parsed.provider == 'googledrive'
-    assert parsed.id == item['id']
     assert parsed.name == item['title']
     assert parsed.name == path.name
     assert parsed.size == item['fileSize']
     assert parsed.modified == item['modifiedDate']
     assert parsed.content_type == item['mimeType']
     assert parsed.extra == {'revisionId': item['version'], 'webView': item['alternateLink']}
-    assert parsed.path == '/' + os.path.join(*[x.raw for x in path.parts])
+    assert parsed.path == '/' + item['id']
     assert parsed.materialized_path == str(path)
 
 
@@ -66,10 +64,9 @@ def test_folder_metadata():
     parsed = GoogleDriveFolderMetadata(item, path)
 
     assert parsed.provider == 'googledrive'
-    assert parsed.id == item['id']
     assert parsed.name == item['title']
     assert parsed.extra == {'revisionId': item['version']}
-    assert parsed.path == '/' + os.path.join(*[x.raw for x in path.parts]) + '/'
+    assert parsed.path == '/' + item['id'] + '/'
     assert parsed.materialized_path == str(path)
 
 
@@ -79,10 +76,9 @@ def test_folder_metadata_slash():
     parsed = GoogleDriveFolderMetadata(item, path)
 
     assert parsed.provider == 'googledrive'
-    assert parsed.id == item['id']
     assert parsed.name == item['title']
     assert parsed.extra == {'revisionId': item['version']}
-    assert parsed.path == '/' + os.path.join(*[x.raw for x in path.parts]) + '/'
+    assert parsed.path == '/' + item['id'] + '/'
     assert parsed.materialized_path == str(path)
 
 

--- a/tests/providers/googledrive/test_provider.py
+++ b/tests/providers/googledrive/test_provider.py
@@ -72,7 +72,7 @@ def search_for_parent_response():
     }
 
 @pytest.fixture
-def file_name_querry_response():
+def file_name_query_response():
     return {
         'id': '1234ideclareathumbwar',
         'mimeType': 'text/plain',
@@ -88,7 +88,7 @@ def actual_file_response():
     }
 
 @pytest.fixture
-def folder_querry_response():
+def folder_query_response():
     return {
         'id': 'whyis6afraidof7',
         'mimeType': 'application/vnd.google-apps.folder',
@@ -110,7 +110,7 @@ class TestValidatePath:
     def test_validate_v1_path_file(self, provider,
                                    actual_file_response,
                                    search_for_parent_response,
-                                   file_name_querry_response):
+                                   file_name_query_response):
         file_name = 'file.txt'
         file_id = '1234ideclarethumbwar'
 
@@ -118,7 +118,7 @@ class TestValidatePath:
             'files', file_id, 'parents', fields='items(id)')
         file_name_parent_url = provider.build_url(
             'files', file_name, 'parents', fields='items(id)')
-        file_name_querry_url = provider.build_url(
+        file_name_query_url = provider.build_url(
             'files', file_name, fields='id,title,mimeType')
         specific_url = provider.build_url('files', file_id, fields='id,title,mimeType')
 
@@ -126,8 +126,8 @@ class TestValidatePath:
                                        body=search_for_parent_response)
         aiohttpretty.register_json_uri('GET', file_name_parent_url,
                                        body=search_for_parent_response)
-        aiohttpretty.register_json_uri('GET', file_name_querry_url,
-                                       body=file_name_querry_response)
+        aiohttpretty.register_json_uri('GET', file_name_query_url,
+                                       body=file_name_query_response)
         aiohttpretty.register_json_uri('GET', specific_url, body=actual_file_response)
 
         try:
@@ -147,19 +147,19 @@ class TestValidatePath:
     @async
     @pytest.mark.aiohttpretty
     def test_validate_v1_path_folder(self, provider, folder_parent_response,
-                                     folder_querry_response):
+                                     folder_query_response):
         folder_name = 'foofolder'
         folder_id = 'whyis6afraidof7'
 
         path_id_url = provider.build_url('files', folder_id, 'parents',
                                          fields='items(id)')
-        path_querry_url = provider.build_url('files', folder_id,
+        path_query_url = provider.build_url('files', folder_id,
                                              fields='id,title,mimeType')
 
         aiohttpretty.register_json_uri('GET', path_id_url,
                                        body=folder_parent_response)
-        aiohttpretty.register_json_uri('GET', path_querry_url,
-                                       body=folder_querry_response)
+        aiohttpretty.register_json_uri('GET', path_query_url,
+                                       body=folder_query_response)
 
         try:
             wb_path_v1 = yield from provider.validate_v1_path('/' + folder_id + '/')

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -107,8 +107,6 @@ class BoxProvider(provider.BaseProvider):
         is_folder = path.endswith('/')
 
         ret = WaterButlerPath('/'.join(names), _ids=ids, folder=is_folder)
-        print('box names' + str(names))
-        print('box _ids' + str(ids))
 
         if new_name is not None:
             return (yield from self.revalidate_path(ret, new_name, folder=is_folder))

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -107,6 +107,8 @@ class BoxProvider(provider.BaseProvider):
         is_folder = path.endswith('/')
 
         ret = WaterButlerPath('/'.join(names), _ids=ids, folder=is_folder)
+        print('box names' + str(names))
+        print('box _ids' + str(ids))
 
         if new_name is not None:
             return (yield from self.revalidate_path(ret, new_name, folder=is_folder))

--- a/waterbutler/providers/googledrive/metadata.py
+++ b/waterbutler/providers/googledrive/metadata.py
@@ -5,21 +5,21 @@ from waterbutler.providers.googledrive import utils
 
 class BaseGoogleDriveMetadata(metadata.BaseMetadata):
 
-    def __init__(self, raw, path):
+    def __init__(self, raw, path_obj):
         super().__init__(raw)
-        self._path = path
+        self._path_obj = path_obj
 
     @property
     def provider(self):
         return 'googledrive'
 
-    @property
-    def path(self):
-        return '/' + self._path.raw_path
+    # @property
+    # def path(self):
+    #     return '/' + self._path.raw_path
 
     @property
     def materialized_path(self):
-        return str(self._path)
+        return str(self._path_obj)
 
     @property
     def extra(self):
@@ -28,24 +28,28 @@ class BaseGoogleDriveMetadata(metadata.BaseMetadata):
 
 class GoogleDriveFolderMetadata(BaseGoogleDriveMetadata, metadata.BaseFolderMetadata):
 
-    def __init__(self, raw, path):
-        super().__init__(raw, path)
-        self._path._is_folder = True
+    def __init__(self, raw, path_obj):
+        super().__init__(raw, path_obj)
+        self._path_obj._is_folder = True
 
-    @property
-    def id(self):
-        return self.raw['id']
+    # @property
+    # def id(self):
+    #     return self.raw['id']
 
     @property
     def name(self):
         return self.raw['title']
 
+    @property
+    def path(self):
+        return '/{}/'.format(self.raw['id'])
+
 
 class GoogleDriveFileMetadata(BaseGoogleDriveMetadata, metadata.BaseFileMetadata):
 
-    @property
-    def id(self):
-        return self.raw['id']
+    # @property
+    # def id(self):
+    #     return self.raw['id']
 
     @property
     def name(self):
@@ -54,6 +58,10 @@ class GoogleDriveFileMetadata(BaseGoogleDriveMetadata, metadata.BaseFileMetadata
             ext = utils.get_extension(self.raw)
             title += ext
         return title
+
+    @property
+    def path(self):
+        return '/{0}'.format(self.raw['id'])
 
     @property
     def size(self):
@@ -88,7 +96,7 @@ class GoogleDriveFileRevisionMetadata(GoogleDriveFileMetadata):
 
     @property
     def name(self):
-        title = self.raw.get('originalFilename', self._path.name)
+        title = self.raw.get('originalFilename', self._path_obj.name)
         if utils.is_docs_file(self.raw):
             ext = utils.get_extension(self.raw)
             title += ext
@@ -127,6 +135,14 @@ class GoogleDriveRevision(metadata.BaseFileRevisionMetadata):
     @property
     def version(self):
         return self.raw['id']
+
+    @property
+    def path(self):
+        return '/{}/'.format(self.raw['id'])
+        # try:
+        #     return '/{0}/{1}'.format(self.raw['id'], self.raw['name'])
+        # except KeyError:
+        #     return self.raw.get('path')
 
     @property
     def modified(self):

--- a/waterbutler/providers/googledrive/metadata.py
+++ b/waterbutler/providers/googledrive/metadata.py
@@ -138,11 +138,10 @@ class GoogleDriveRevision(metadata.BaseFileRevisionMetadata):
 
     @property
     def path(self):
-        return '/{}/'.format(self.raw['id'])
-        # try:
-        #     return '/{0}/{1}'.format(self.raw['id'], self.raw['name'])
-        # except KeyError:
-        #     return self.raw.get('path')
+        try:
+            return '/{0}/{1}'.format(self.raw['id'], self.raw['name'])
+        except KeyError:
+            return self.raw.get('path')
 
     @property
     def modified(self):

--- a/waterbutler/providers/googledrive/metadata.py
+++ b/waterbutler/providers/googledrive/metadata.py
@@ -13,10 +13,6 @@ class BaseGoogleDriveMetadata(metadata.BaseMetadata):
     def provider(self):
         return 'googledrive'
 
-    # @property
-    # def path(self):
-    #     return '/' + self._path.raw_path
-
     @property
     def materialized_path(self):
         return str(self._path_obj)
@@ -32,10 +28,6 @@ class GoogleDriveFolderMetadata(BaseGoogleDriveMetadata, metadata.BaseFolderMeta
         super().__init__(raw, path_obj)
         self._path_obj._is_folder = True
 
-    # @property
-    # def id(self):
-    #     return self.raw['id']
-
     @property
     def name(self):
         return self.raw['title']
@@ -46,10 +38,6 @@ class GoogleDriveFolderMetadata(BaseGoogleDriveMetadata, metadata.BaseFolderMeta
 
 
 class GoogleDriveFileMetadata(BaseGoogleDriveMetadata, metadata.BaseFileMetadata):
-
-    # @property
-    # def id(self):
-    #     return self.raw['id']
 
     @property
     def name(self):

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -51,7 +51,15 @@ class GoogleDriveProvider(provider.BaseProvider):
 
         implicit_folder = path.endswith('/')
         parts = yield from self._resolve_path_to_ids(path)
-        explicit_folder = parts[-1]['mimeType'] == self.FOLDER_MIME_TYPE
+        if parts == 'reval':
+            v1reval = yield from self.revalidate_path(
+                GoogleDrivePath('/', _ids=[self.folder]),
+                path,
+                folder=implicit_folder
+            )
+            explicit_folder = v1reval._is_folder
+        else:
+            explicit_folder = parts[-1]['mimeType'] == self.FOLDER_MIME_TYPE
         if implicit_folder != explicit_folder:
             raise exceptions.NotFoundError(str(path))
 

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -58,6 +58,9 @@ class GoogleDriveProvider(provider.BaseProvider):
                 folder=implicit_folder
             )
             explicit_folder = v1reval._is_folder
+            if implicit_folder != explicit_folder:
+                raise exceptions.NotFoundError(str(path))
+            return(v1reval)
         else:
             explicit_folder = parts[-1]['mimeType'] == self.FOLDER_MIME_TYPE
         if implicit_folder != explicit_folder:

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -72,7 +72,6 @@ class GoogleDriveProvider(provider.BaseProvider):
 
         parts = yield from self._resolve_path_to_ids(path)
         if parts == 'reval':
-            print('###### reval invoked')
             return (yield from self.revalidate_path(
                 GoogleDrivePath('/', _ids=[self.folder]),
                 path,

--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -19,7 +19,7 @@ from waterbutler.server.api.v1.provider.movecopy import MoveCopyMixin
 logger = logging.getLogger(__name__)
 auth_handler = AuthHandler(settings.AUTH_HANDLERS)
 
-IDENTIFIER_PATHS = ('box', 'osfstorage')
+IDENTIFIER_PATHS = ('box', 'osfstorage', 'googledrive')
 
 
 @tornado.web.stream_request_body


### PR DESCRIPTION
## Purpose
Update Google Drive provider to use identifiers instead of file paths to reference files.

## Changes
* Update metadata.py to use id instead of path
* Update provider.py to use id instead of path
  * def validate_path
  * def revalidate_path
  * def upload
  * def create_folder
  * def _resolve_path_to_ids
* Update api/v1/provider/__init__.py to add googledrive to IDENTIFIER_PATHS tuple
* Update test_metadata.py to reflect changes in metadata.py
* Update test_provider.py to reflect changes in provider.py

## Side Effects - Caution Required
**This change will likely require a migration strategy!**
Data stored in mongo storedfilenode.find({ "provider" : "googledrive" }) may need to be migrated.
