### PR TITLE
[CR] fix modified timestamps from filesystem provider

### DIFF
--- a/tests/tasks/test_copy.py
+++ b/tests/tasks/test_copy.py
@@ -137,7 +137,7 @@ class TestCopyTask:
         metadata = test_utils.MockFileMetadata()
         src.copy.return_value = (metadata, False)
 
-        dt = datetime.datetime.utcfromtimestamp(60)
+        dt = datetime.datetime.utcfromtimestamp(60).replace(tzinfo=datetime.timezone.utc)
         with freezegun.freeze_time(dt):
             ret1, ret2 = copy.copy(cp.deepcopy(src_bundle), cp.deepcopy(dest_bundle), 'Test.com', {'auth': {'user': 'name'}})
 

--- a/tests/tasks/test_move.py
+++ b/tests/tasks/test_move.py
@@ -137,7 +137,7 @@ class TestMoveTask:
         metadata = test_utils.MockFileMetadata()
         src.move.return_value = (metadata, False)
 
-        dt = datetime.datetime.utcfromtimestamp(60)
+        dt = datetime.datetime.utcfromtimestamp(60).replace(tzinfo=datetime.timezone.utc)
         with freezegun.freeze_time(dt):
             ret1, ret2 = move.move(copy.deepcopy(src_bundle), copy.deepcopy(dest_bundle), 'Test.com', {'auth': {'user': 'name'}})
 

--- a/waterbutler/providers/filesystem/provider.py
+++ b/waterbutler/providers/filesystem/provider.py
@@ -119,7 +119,7 @@ class FileSystemProvider(provider.BaseProvider):
 
     def _metadata_file(self, path, file_name=''):
         full_path = path.full_path if file_name == '' else os.path.join(path.full_path, file_name)
-        modified = datetime.datetime.fromtimestamp(os.path.getmtime(full_path))
+        modified = datetime.datetime.utcfromtimestamp(os.path.getmtime(full_path)).replace(tzinfo=datetime.timezone.utc)
         return {
             'path': full_path,
             'size': os.path.getsize(full_path),


### PR DESCRIPTION
When running a local dev copy of WB, the modified timestamp returned
from file metadata was for the local time, and lacked an explicit
timezone attachment.  When the file metadata is stored in mongo, mongo
assumes it is Zulu time.  This was causing erroneous and mismatched
modified and created times for osfstorage.

This branch updates filesystem to return a utc datetime with an active
timezone object.  It also updates two tests that weren't being explicit
about their timezone.  Those tests worked fine without the tzinfo, but
we need to start being more disciplined about this.

Fixes: [#OSF-5390]