### PR TITLE
[CR] fix v1 log payload for move/copy/rename dest

### DIFF
--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -147,11 +147,11 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
                 },
                 'destination': {
                     'nid': self.dest_resource,
-                    'kind': self.dest_path.kind,
-                    'name': self.dest_path.name,
-                    'path': self.dest_path.identifier_path if self.dest_provider.NAME in IDENTIFIER_PATHS else self.dest_path.path,
+                    'kind': self.dest_meta.kind,
+                    'name': self.dest_meta.name,
+                    'path': self.dest_meta.path,
                     'provider': self.dest_provider.NAME,
-                    'materialized': str(self.dest_path),
+                    'materialized': self.dest_meta.materialized_path,
                 }
             })
         else:

--- a/waterbutler/server/api/v1/provider/movecopy.py
+++ b/waterbutler/server/api/v1/provider/movecopy.py
@@ -105,6 +105,8 @@ class MoveCopyMixin:
                 )
             )
 
+        self.dest_meta = metadata
+
         if created:
             self.set_status(201)
         else:


### PR DESCRIPTION
The v1 logging callback for move/copy/rename actions was serializing the
parent of the target, rather than the target itself. Ex.

    mv /A/foo.txt /A/B/bar.txt
        was sending /A/B/ as dest
        should send /A/B/bar.txt as dest

    mv /foo.txt /bar.txt
        was sending / as dest
        should send /bar.txt as dest

This was creating erroneous and confusing log messages on the OSF.

Fixes: [#OSF-5431], [#OFF-68], [#OFF-69], [#OFF-70]