### PR TITLE
[CR] Fix cross-node logging for v1 move/copy actions

### DIFF
--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -163,6 +163,7 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
             'provider': self.provider.NAME,
         }
 
+        callback_url = None
         if action in ('move', 'copy'):
             payload.update({
                 'source': {
@@ -182,6 +183,7 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
                     'materialized': self.dest_meta.materialized_path,
                 }
             })
+            callback_url = self.dest_auth['callback_url']
         else:
             # This is adequate for everything but github
             # If extra can be included it will link to the given sha
@@ -195,8 +197,9 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
                     'provider': self.provider.NAME,
                 }
             })
+            callback_url = self.auth['callback_url']
 
-        resp = (yield from utils.send_signed_request('PUT', self.auth['callback_url'], payload))
+        resp = (yield from utils.send_signed_request('PUT', callback_url, payload))
 
         if resp.status != 200:
             data = yield from resp.read()


### PR DESCRIPTION
v1 was posting the cross-node move/copy logs to the source node's log
endpoint instead of the destination node's.  The OSF infers the
destination from the URL, rather than the payload.  This was causing
actions like `mv /A/foo /B/` to produce a message saying "`A/foo` was
moved to `A/foo`" on A.  Instead we should be logging "`A/foo` was
moved to `B/foo`" on B.

Fixes: [#OSF-5516]