### PR TITLE
[CR] s3: support periods in bucketnames for all regions

### DIFF
--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.utils import async
+from tests.utils import async, MockCoroutine
 
 import io
 import base64
@@ -46,7 +46,9 @@ def settings():
 
 @pytest.fixture
 def provider(auth, credentials, settings):
-    return S3Provider(auth, credentials, settings)
+    provider = S3Provider(auth, credentials, settings)
+    provider._check_region = MockCoroutine()
+    return provider
 
 
 @pytest.fixture
@@ -244,6 +246,13 @@ def version_metadata():
         </Version>
     </ListVersionsResult>'''
 
+def location_response(location):
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+        '{}</LocationConstraint>'
+    ).format(location)
+
 def list_objects_response(keys, truncated=False):
     response = '''<?xml version="1.0" encoding="UTF-8"?>
     <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
@@ -283,6 +292,37 @@ def bulk_delete_body(keys):
 
 def build_folder_params(path):
     return {'prefix': path.path, 'delimiter': '/'}
+
+
+class TestRegionDetection:
+
+    @async
+    @pytest.mark.aiohttpretty
+    @pytest.mark.parametrize("region_name,host", [
+        ('',               's3.amazonaws.com'),
+        ('EU',             's3-eu-west-1.amazonaws.com'),
+        ('us-west-1',      's3-us-west-1.amazonaws.com'),
+        ('us-west-2',      's3-us-west-2.amazonaws.com'),
+        ('eu-central-1',   's3-eu-central-1.amazonaws.com'),
+        ('ap-northeast-1', 's3-ap-northeast-1.amazonaws.com'),
+        ('ap-northeast-2', 's3-ap-northeast-2.amazonaws.com'),
+        ('ap-southeast-1', 's3-ap-southeast-1.amazonaws.com'),
+        ('ap-southeast-2', 's3-ap-southeast-2.amazonaws.com'),
+        ('sa-east-1',      's3-sa-east-1.amazonaws.com'),
+    ])
+    def test_region_host(self, auth, credentials, settings, region_name, host):
+        provider = S3Provider(auth, credentials, settings)
+        orig_host = provider.connection.host
+
+        region_url = provider.bucket.generate_url(
+            100,
+            'GET',
+            query_parameters={'location': ''},
+        )
+        aiohttpretty.register_uri('GET', region_url, status=200, body=location_response(region_name))
+
+        yield from provider._check_region()
+        assert provider.connection.host == host
 
 
 class TestValidatePath:

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -11,7 +11,6 @@ from boto.compat import BytesIO
 from boto.utils import compute_md5
 from boto.s3.connection import S3Connection
 from boto.s3.connection import OrdinaryCallingFormat
-from boto.s3.connection import SubdomainCallingFormat
 
 from waterbutler.core import streams
 from waterbutler.core import provider
@@ -44,21 +43,16 @@ class S3Provider(provider.BaseProvider):
         """
         super().__init__(auth, credentials, settings)
 
-        # If a bucket has capital letters in the name ordinary calling format MUST be used
-        # If a bucket has multiple dots (sub.domain.bucket) ordinary calling format MUST be used
-        if settings['bucket'] != settings['bucket'].lower() or settings['bucket'].count('.') > 0:
-            calling_format = OrdinaryCallingFormat()
-        else:
-            # if a bucket is out of the us Subdomain calling format MUST be used
-            calling_format = SubdomainCallingFormat()
-
         self.connection = S3Connection(credentials['access_key'],
-                credentials['secret_key'], calling_format=calling_format)
+                credentials['secret_key'], calling_format=OrdinaryCallingFormat())
         self.bucket = self.connection.get_bucket(settings['bucket'], validate=False)
         self.encrypt_uploads = self.settings.get('encrypt_uploads', False)
+        self.region = None
 
     @asyncio.coroutine
     def validate_v1_path(self, path, **kwargs):
+        yield from self._check_region()
+
         if path == '/':
             return WaterButlerPath(path)
 
@@ -103,6 +97,8 @@ class S3Provider(provider.BaseProvider):
         """Copy key from one S3 bucket to another. The credentials specified in
         `dest_provider` must have read access to `source.bucket`.
         """
+        yield from self._check_region()
+
         exists = yield from dest_provider.exists(dest_path)
         dest_key = dest_provider.bucket.new_key(dest_path.path)
 
@@ -132,6 +128,8 @@ class S3Provider(provider.BaseProvider):
         :rtype: :class:`waterbutler.core.streams.ResponseStreamReader`
         :raises: :class:`waterbutler.core.exceptions.DownloadError`
         """
+        yield from self._check_region()
+
         if not path.is_file:
             raise exceptions.DownloadError('No file specified for download', code=400)
 
@@ -175,6 +173,8 @@ class S3Provider(provider.BaseProvider):
 
         :rtype: dict, bool
         """
+        yield from self._check_region()
+
         path, exists = yield from self.handle_name_conflict(path, conflict=conflict)
         stream.add_writer('md5', streams.HashStreamWriter(hashlib.md5))
 
@@ -202,6 +202,7 @@ class S3Provider(provider.BaseProvider):
 
         :param str path: The path of the key to delete
         """
+        yield from self._check_region()
 
         if path.is_file:
             yield from self.make_request(
@@ -220,6 +221,7 @@ class S3Provider(provider.BaseProvider):
         that folder is completely empty.  To fully delete an occupied folder, we must delete all
         of the comprising objects.  Amazon provides a bulk delete operation to simplify this.
         """
+        yield from self._check_region()
 
         more_to_come = True
         content_keys = []
@@ -296,6 +298,8 @@ class S3Provider(provider.BaseProvider):
         :param str path: The path to a key
         :rtype list:
         """
+        yield from self._check_region()
+
         url = self.bucket.generate_url(settings.TEMP_URL_SECS, 'GET', query_parameters={'versions': ''})
         resp = yield from self.make_request(
             'GET',
@@ -323,6 +327,8 @@ class S3Provider(provider.BaseProvider):
         :param WaterButlerPath path: The path to a key or folder
         :rtype: dict or list
         """
+        yield from self._check_region()
+
         if path.is_dir:
             return (yield from self._metadata_folder(path))
 
@@ -333,6 +339,8 @@ class S3Provider(provider.BaseProvider):
         """
         :param str path: The path to create a folder at
         """
+        yield from self._check_region()
+
         WaterButlerPath.validate_folder(path)
 
         if (yield from self.exists(path)):
@@ -349,6 +357,8 @@ class S3Provider(provider.BaseProvider):
 
     @asyncio.coroutine
     def _metadata_file(self, path, revision=None):
+        yield from self._check_region()
+
         if revision == 'Latest':
             revision = None
         resp = yield from self.make_request(
@@ -367,6 +377,8 @@ class S3Provider(provider.BaseProvider):
 
     @asyncio.coroutine
     def _metadata_folder(self, path):
+        yield from self._check_region()
+
         resp = yield from self.make_request(
             'GET',
             self.bucket.generate_url(settings.TEMP_URL_SECS, 'GET'),
@@ -414,3 +426,40 @@ class S3Provider(provider.BaseProvider):
                 items.append(S3FileMetadata(content))
 
         return items
+
+    @asyncio.coroutine
+    def _check_region(self):
+        """Lookup the region via bucket name, then update the host to match.
+
+        Manually constructing the connection hostname allows us to use OrdinaryCallingFormat
+        instead of SubdomainCallingFormat, which can break on buckets with periods in their name.
+        The default region, US East (N. Virginia), is represented by the empty string and does not
+        require changing the host.  Ireland is represented by the string 'EU', with the host
+        parameter 'eu-west-1'.  All other regions return the host parameter as the region name.
+
+        Region Naming: http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+        """
+        if self.region is None:
+            self.region = yield from self._get_bucket_region()
+            if self.region == 'EU':
+                self.region = 'eu-west-1'
+
+            if self.region != '':
+                self.connection.host = self.connection.host.replace('s3.', 's3-' + self.region + '.', 1)
+
+    @asyncio.coroutine
+    def _get_bucket_region(self):
+        """Bucket names are unique across all regions.
+
+        Endpoint doc: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html
+        """
+        resp = yield from self.make_request(
+            'GET',
+            self.bucket.generate_url(settings.TEMP_URL_SECS, 'GET', query_parameters={'location': ''}),
+            expects=(200, ),
+            throws=exceptions.MetadataError,
+        )
+
+        contents = yield from resp.read_and_close()
+        parsed = xmltodict.parse(contents, strip_whitespace=False)
+        return parsed['LocationConstraint'].get('#text', '')


### PR DESCRIPTION
A bogus error message in the OSF S3 addon revealed some shenanigans
in how we handle bucket names outside the US (N. Virginia) region.
Amazon permits bucket names that follow subdomain-naming conventions
(labels separated by periods).  WB had been accessing buckets using
the subdomain calling format, which would access a bucket named 'foo'
at `https://foo.s3.amazonaws.com/`.  However, wildcard nested
subdomain certificates are deprecated, and Pythons newer than 2.7.9
will throw a certificate checking error if you try to access them.
IOW a bucket named 'foo' will still work, but a bucket named 'foo.bar'
will try to connect to `https://foo.bar.s3.amazonaws.com/` and
will fail validation.

`boto`, the library WB uses to communicate with S3, supports another
calling format that avoids this issue, the `OrdinaryCallingFormat`.
Under OCF, a call to a bucket named `foo.bar` is directed to
`https://s3.amazonaws.com/foo.bar/`, and so the certificate will pass
validation.  The catch is that buckets in regions outside US
(N. Virginia) require the request to be sent to a region-specific URL.
The OSF doesn't currently track the bucket's region, so WB has to
look it up via the S3 API.  Once we have the region, we can update the
host, and all S3 actions should succeed.

Fixes: [#OSF-5509]

References:
----

* [S3 naming conventions](http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules)
* [S3 bucket region lookup](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html)