### PR TITLE
[CR] fix v0 log paths

### DIFF
--- a/tests/tasks/test_copy.py
+++ b/tests/tasks/test_copy.py
@@ -150,7 +150,7 @@ class TestCopyTask:
                 'errors': [],
                 'action': 'copy',
                 'source': {
-                    'path': src_path.path,
+                    'path': '/' + src_path.path,
                     'name': src_path.name,
                     'materialized': str(src_path),
                     'provider': src.NAME,

--- a/tests/tasks/test_move.py
+++ b/tests/tasks/test_move.py
@@ -150,7 +150,7 @@ class TestMoveTask:
                 'errors': [],
                 'action': 'move',
                 'source': {
-                    'path': src_path.path,
+                    'path': '/' + src_path.path,
                     'name': src_path.name,
                     'materialized': str(src_path),
                     'provider': src.NAME,

--- a/waterbutler/constants.py
+++ b/waterbutler/constants.py
@@ -1,3 +1,5 @@
 """Constants"""
 
 DEFAULT_CONFLICT = 'warn'
+
+IDENTIFIER_PATHS = ('box', 'osfstorage')

--- a/waterbutler/server/api/v0/core.py
+++ b/waterbutler/server/api/v0/core.py
@@ -14,6 +14,7 @@ from waterbutler.core import signing
 from waterbutler.core import exceptions
 from waterbutler.server import settings
 from waterbutler.server.auth import AuthHandler
+from waterbutler.constants import IDENTIFIER_PATHS
 from waterbutler.server import utils as server_utils
 
 
@@ -150,12 +151,18 @@ class BaseCrossProviderHandler(BaseHandler):
 
     @utils.async_retry(retries=0, backoff=5)
     def _send_hook(self, action, data):
+        src_path = None
+        if self.source_provider.NAME in IDENTIFIER_PATHS:
+            src_path = self.json['source']['path'].identifier_path
+        else:
+            src_path = '/' + self.json['source']['path'].path
+
         resp = yield from utils.send_signed_request('PUT', self.callback_url, {
             'action': action,
             'source': {
                 'nid': self.json['source']['nid'],
                 'provider': self.source_provider.NAME,
-                'path': self.json['source']['path'].path,
+                'path': src_path,
                 'name': self.json['source']['path'].name,
                 'materialized': str(self.json['source']['path']),
             },

--- a/waterbutler/server/api/v0/crud.py
+++ b/waterbutler/server/api/v0/crud.py
@@ -11,8 +11,8 @@ import tornado.platform.asyncio
 from waterbutler.core import mime_types
 from waterbutler.server import utils
 from waterbutler.server.api.v0 import core
+from waterbutler.constants import IDENTIFIER_PATHS
 from waterbutler.core.streams import RequestStreamReader
-
 
 TRUTH_MAP = {
     'true': True,
@@ -142,7 +142,7 @@ class CRUDHandler(core.BaseProviderHandler):
         self._send_hook(
             'delete',
             {
-                'path': str(self.arguments['path']),
+                'path': self.path.identifier_path if self.provider.NAME in IDENTIFIER_PATHS else '/' + self.path.path,
                 'materialized': str(self.arguments['path'])
             }
         )

--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -11,16 +11,14 @@ from waterbutler.core import exceptions
 from waterbutler.server import settings
 from waterbutler.server.api.v1 import core
 from waterbutler.server.auth import AuthHandler
+from waterbutler.constants import IDENTIFIER_PATHS
 from waterbutler.core.streams import RequestStreamReader
 from waterbutler.server.api.v1.provider.create import CreateMixin
 from waterbutler.server.api.v1.provider.metadata import MetadataMixin
 from waterbutler.server.api.v1.provider.movecopy import MoveCopyMixin
 
-
 logger = logging.getLogger(__name__)
 auth_handler = AuthHandler(settings.AUTH_HANDLERS)
-
-IDENTIFIER_PATHS = ('box', 'osfstorage')
 
 
 @tornado.web.stream_request_body

--- a/waterbutler/tasks/copy.py
+++ b/waterbutler/tasks/copy.py
@@ -4,6 +4,7 @@ import logging
 from waterbutler.core import utils
 from waterbutler.tasks import core
 from waterbutler.tasks import settings
+from waterbutler.constants import IDENTIFIER_PATHS
 
 logger = logging.getLogger(__name__)
 
@@ -18,13 +19,13 @@ def copy(src_bundle, dest_bundle, callback_url, auth, start_time=None, **kwargs)
         'errors': [],
         'action': 'copy',
         'source': dict(src_bundle, **{
-            'path': src_path.path,
+            'path': src_path.identifier_path if src_provider.NAME in IDENTIFIER_PATHS else '/' + src_path.path,
             'name': src_path.name,
             'materialized': str(src_path),
             'provider': src_provider.NAME,
         }),
         'destination': dict(dest_bundle, **{
-            'path': dest_path.path,
+            'path': dest_path.identifier_path if dest_provider.NAME in IDENTIFIER_PATHS else '/' + dest_path.path,
             'name': dest_path.name,
             'materialized': str(dest_path),
             'provider': dest_provider.NAME,

--- a/waterbutler/tasks/move.py
+++ b/waterbutler/tasks/move.py
@@ -4,6 +4,7 @@ import logging
 from waterbutler.core import utils
 from waterbutler.tasks import core
 from waterbutler.tasks import settings
+from waterbutler.constants import IDENTIFIER_PATHS
 
 logger = logging.getLogger(__name__)
 
@@ -18,12 +19,13 @@ def move(src_bundle, dest_bundle, callback_url, auth, start_time=None, **kwargs)
         'errors': [],
         'action': 'move',
         'source': dict(src_bundle, **{
-            'path': src_path.path,
+            'path': src_path.identifier_path if src_provider.NAME in IDENTIFIER_PATHS else '/' + src_path.path,
             'name': src_path.name,
             'materialized': str(src_path),
             'provider': src_provider.NAME,
         }),
         'destination': dict(dest_bundle, **{
+            'path': dest_path.identifier_path if dest_provider.NAME in IDENTIFIER_PATHS else '/' + dest_path.path,
             'path': dest_path.path,
             'name': dest_path.name,
             'materialized': str(dest_path),


### PR DESCRIPTION
The logging payloads returned by the v0 api have incorrect paths for deleted files and the source files of moves and copies. Currently, moving a file from osfstorage to box results in a source path of `$filename`, instead of `/$file_id`. Deleting a file on ID-using providers results in the path being set to the `materialized_path` instead of `/$file_id`. Moving a file from googledrive to osfstorage results in path being equal to the filename, instead of the full path relative to root.

Fixes: [#OSF-5569]