### PR TITLE
[RFR][Feature]Fix logic for setting "created" in def _folder_file_op

### DIFF
--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -199,11 +199,11 @@ class BaseProvider(metaclass=abc.ABCMeta):
 
         try:
             yield from dest_provider.delete(dest_path)
-            created = True
+            created = False
         except exceptions.ProviderError as e:
             if e.code != 404:
                 raise
-            created = False
+            created = True
 
         folder = yield from dest_provider.create_folder(dest_path)
 

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -194,6 +194,20 @@ class BaseProvider(metaclass=abc.ABCMeta):
 
     @asyncio.coroutine
     def _folder_file_op(self, func, dest_provider, src_path, dest_path, **kwargs):
+        """Recursively apply func to src/dest path.
+
+        Called from: func: copy and move if src_path.is_dir.
+
+        Calls: func: dest_provider.delete and notes result for bool: created
+               func: dest_provider.create_folder
+               func: dest_provider.revalidate_path
+               func: self.metadata
+
+        :param coroutine func: to be applied to src/dest path
+        :param *Provider dest_provider: Destination provider
+        :param *ProviderPath src_path: Source path
+        :param *ProviderPath dest_path: Destination path
+        """
         assert src_path.is_dir, 'src_path must be a directory'
         assert asyncio.iscoroutinefunction(func), 'func must be a coroutine'
 

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -29,6 +29,10 @@ from waterbutler.providers.s3.metadata import S3FileMetadataHeaders
 
 class S3Provider(provider.BaseProvider):
     """Provider for the Amazon's S3
+
+    Quirks:
+        On S3, folders are not first-class objects, but are instead inferred from the names of their children.  A regular DELETE request issued against a folder will not work unless that folder is completely empty.  To fully delete an occupied folder, we must delete all of the comprising objects.  Amazon provides a bulk delete operation to simplify this.
+        A GET prefix query against a non-existant path returns 200
     """
     NAME = 's3'
 
@@ -227,10 +231,17 @@ class S3Provider(provider.BaseProvider):
 
     @asyncio.coroutine
     def _delete_folder(self, path, **kwargs):
-        """On S3, folders are not first-class objects, but are instead inferred from the names
-        of their children.  A regular DELETE request issued against a folder will not work unless
-        that folder is completely empty.  To fully delete an occupied folder, we must delete all
-        of the comprising objects.  Amazon provides a bulk delete operation to simplify this.
+        """Query for recursive contents of folder and delete in batches of 1000
+
+        Called from: func: delete if not path.is_file
+
+        Calls: func: self._check_region
+               func: self.make_request
+               func: self.bucket.generate_url
+
+        :param *ProviderPath path: Path to be deleted
+
+        On S3, folders are not first-class objects, but are instead inferred from the names of their children.  A regular DELETE request issued against a folder will not work unless that folder is completely empty.  To fully delete an occupied folder, we must delete all of the comprising objects.  Amazon provides a bulk delete operation to simplify this.
         """
         yield from self._check_region()
 
@@ -262,6 +273,10 @@ class S3Provider(provider.BaseProvider):
             content_keys.extend([content['Key'] for content in contents])
             if len(content_keys) > 0:
                 marker = content_keys[-1]
+
+        # Query against non-existant folder does not return 404
+        if len(content_keys) == 0:
+            raise exceptions.NotFoundError(str(path))
 
         while len(content_keys) > 0:
             key_batch = content_keys[:1000]

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -31,7 +31,12 @@ class S3Provider(provider.BaseProvider):
     """Provider for the Amazon's S3
 
     Quirks:
-        On S3, folders are not first-class objects, but are instead inferred from the names of their children.  A regular DELETE request issued against a folder will not work unless that folder is completely empty.  To fully delete an occupied folder, we must delete all of the comprising objects.  Amazon provides a bulk delete operation to simplify this.
+        On S3, folders are not first-class objects, but are instead inferred
+        from the names of their children.  A regular DELETE request issued
+        against a folder will not work unless that folder is completely empty.
+        To fully delete an occupied folder, we must delete all of the comprising
+        objects.  Amazon provides a bulk delete operation to simplify this.
+
         A GET prefix query against a non-existant path returns 200
     """
     NAME = 's3'
@@ -241,7 +246,11 @@ class S3Provider(provider.BaseProvider):
 
         :param *ProviderPath path: Path to be deleted
 
-        On S3, folders are not first-class objects, but are instead inferred from the names of their children.  A regular DELETE request issued against a folder will not work unless that folder is completely empty.  To fully delete an occupied folder, we must delete all of the comprising objects.  Amazon provides a bulk delete operation to simplify this.
+        On S3, folders are not first-class objects, but are instead inferred
+        from the names of their children.  A regular DELETE request issued
+        against a folder will not work unless that folder is completely empty.
+        To fully delete an occupied folder, we must delete all of the comprising
+        objects.  Amazon provides a bulk delete operation to simplify this.
         """
         yield from self._check_region()
 
@@ -299,8 +308,8 @@ class S3Provider(provider.BaseProvider):
                 'Content-Type': 'text/xml',
             }
 
-            # We depend on a customized version of boto that can make query parameters part of
-            # the signature.
+            # We depend on a customized version of boto that can make query
+            # parameters part of the signature.
             url = self.bucket.generate_url(
                 settings.TEMP_URL_SECS,
                 'POST',
@@ -481,7 +490,8 @@ class S3Provider(provider.BaseProvider):
     def _get_bucket_region(self):
         """Bucket names are unique across all regions.
 
-        Endpoint doc: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html
+       Endpoint doc:
+       http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html
         """
         resp = yield from self.make_request(
             'GET',


### PR DESCRIPTION
## Purpose
[OSF-4895](https://openscience.atlassian.net/browse/OSF-4895)
Update so that copy operations that create new folders return HTTP 201
#OSF-4895

## Changes
Update waterbutler/core/provider.py

## Side effects
As this is a change to the base provider, may effect other providers