### PR TITLE
[RFR][Feature]Fix handle_name_conflict to handle empty list out of func: exists OSF5701

### DIFF
--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -254,6 +254,8 @@ class BaseProvider(metaclass=abc.ABCMeta):
         :param WaterButlerPath dest_path: The path that is being copied to or into
         :param str rename: The desired name of the resulting path, may be incremented
         :param str conflict: The conflict resolution strategy, replace or keep
+
+        Returns: WaterButlerPath dest_path: The path of the desired result.
         """
         if src_path.is_dir and dest_path.is_file:
             # Cant copy a directory to a file
@@ -325,7 +327,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
         :raises: NamingConflict
         """
         exists = yield from self.exists(path, **kwargs)
-        if not exists or conflict == 'replace':
+        if (not exists and not exists == []) or conflict == 'replace':
             return path, exists
         if conflict == 'warn':
             raise exceptions.NamingConflict(path)


### PR DESCRIPTION
## Purpose: 
Fix issue [OSF-5701](https://openscience.atlassian.net/browse/OSF-5701) causing unintended deletion of folders.

## Change:
Properly handle empty list.

waterbutler/core/provider.py def handle_name_conflict was treating empty folders the same as non-existant folders.

## Aslo fixes
[OSF-5703](https://openscience.atlassian.net/browse/OSF-5703)
[OSF-5704](https://openscience.atlassian.net/browse/OSF-5704)
[OSF-5705](https://openscience.atlassian.net/browse/OSF-5705)

#OSF-5701 #OSF-5703 #OSF-5704 #OSF-5705