### PR TITLE
[RFR][Feature]Fix logic for handle_name_conflict

### DIFF
--- a/waterbutler/core/path.py
+++ b/waterbutler/core/path.py
@@ -194,7 +194,11 @@ class WaterButlerPath:
 
     @property
     def identifier_path(self):
-        """ Returns the ID formatted as a path for providers that use unique ids """
+        """ Returns the ID formatted as a path for providers that use unique ids
+
+        Quirk:
+            If identifier is not set raises TypeError
+        """
         return '/' + self._parts[-1].identifier + ('/' if self.is_dir else '')
 
     @property

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -334,7 +334,6 @@ class BaseProvider(metaclass=abc.ABCMeta):
         :rtype: (WaterButlerPath, provider.metadata() or False)
         :raises: NamingConflict
         """
-        orig_name = path.parts[-1].original_value
         exists = yield from self.exists(path, **kwargs)
         if not exists or conflict == 'replace':
             return path, exists
@@ -343,15 +342,12 @@ class BaseProvider(metaclass=abc.ABCMeta):
 
         while True:
             path.increment_name()
-            my_count = path.parts[-1]._count
-            path = yield from self.revalidate_path(
+            test_path = yield from self.revalidate_path(
                 path.parent,
                 path.name,
                 folder=path.is_dir
             )
-            exist = yield from self.exists(path, **kwargs)
-            path.parts[-1]._name = orig_name
-            path.parts[-1]._count = my_count
+            exist = yield from self.exists(test_path, **kwargs)
             if not exist:
                 break
         return path, False

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -305,6 +305,14 @@ class BaseProvider(metaclass=abc.ABCMeta):
 
     @asyncio.coroutine
     def exists(self, path, **kwargs):
+        """Check for existance of WaterButlerPath
+
+        Attempt to retreive provide metadata to determine existance of
+        WaterButlerPath
+
+        :param WaterbutlerPath: path to check for
+        :rtype (provider.metadata() or False)
+        """
         try:
             return (yield from self.metadata(path, **kwargs))
         except exceptions.NotFoundError:
@@ -316,12 +324,14 @@ class BaseProvider(metaclass=abc.ABCMeta):
 
     @asyncio.coroutine
     def handle_name_conflict(self, path, conflict='replace', **kwargs):
-        """Given a name and a conflict resolution pattern determine
+        """Check WaterButlerPath and resolve conflicts
+
+        Given a WaterButlerPath and a conflict resolution pattern determine
         the correct file path to upload to and indicate if that file exists or not
 
-        :param WaterbutlerPath path: An object supporting the waterbutler path API
+        :param WaterbutlerPath: Desired path to check for conflict
         :param str conflict: replace, keep, warn
-        :rtype: (WaterButlerPath, dict or False)
+        :rtype: (WaterButlerPath, provider.metadata() or False)
         :raises: NamingConflict
         """
         orig_name = path.parts[-1].original_value


### PR DESCRIPTION
## Purpose
[OSF-5700](https://openscience.atlassian.net/browse/OSF-5700)
Update so that naming conflicts are handled correctly during move/copy

## Changes
Update waterbutler/core/provider.py

## Side effects
As this is a change to the base provider, will effect all providers
Each conflict checked for will trigger an additional revalidate call

## Also fixes
[OSF-5702](https://openscience.atlassian.net/browse/OSF-5702)
[OSF-5706](https://openscience.atlassian.net/browse/OSF-5706)

#OSF-5700 #OSF-5702 #OSF-5706