### PR TITLE
Add FakeAuthHandler for running waterbutler without OSF

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,33 @@ waterbutler-test.json, e.g.
     "HMAC_SECRET": "changeme"
   },
   "SERVER_CONFIG": {
-    "ADDRESS": "localhost",
+    "ADDRESS": "127.0.0.1",
     "PORT": 7777,
     "DOMAIN": "http://localhost:7777",
     "DEBUG": true,
-    "HMAC_SECRET": "changeme"
+    "HMAC_SECRET": "changeme",
+    "AUTH_HANDLERS": [ "fake" ]
   },
-  "OSF_AUTH_CONFIG": {
-      "API_URL": "http://localhost:5000/api/v1/files/auth/"
+  "FAKE_AUTH_CONFIG": {
+    "PROVIDERS": {
+      "github": {
+        "credentials": {
+            "token": "GITHUB_TOKEN"
+        },
+        "settings": {
+            "owner" : "GITHUB_USERNAME",
+            "repo": "GITHUB_REPO"
+        }
+      },
+      "dropbox": {
+        "credentials": {
+            "token": "DROPBOX_TOKEN"
+        },
+        "settings": {
+            "folder": "DROPBOX_FOLDER"
+        }
+      }
+    }
   }
 }
 ```

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     entry_points={
         'waterbutler.auth': [
             'osf = waterbutler.auth.osf:OsfAuthHandler',
+            'fake = waterbutler.auth.fake:FakeAuthHandler'
         ],
         'waterbutler.providers': [
             'cloudfiles = waterbutler.providers.cloudfiles:CloudFilesProvider',

--- a/waterbutler/auth/fake/__init__.py
+++ b/waterbutler/auth/fake/__init__.py
@@ -1,0 +1,1 @@
+from .handler import FakeAuthHandler  # noqa

--- a/waterbutler/auth/fake/handler.py
+++ b/waterbutler/auth/fake/handler.py
@@ -1,0 +1,33 @@
+
+from waterbutler.core import auth
+from waterbutler.core import exceptions
+
+from waterbutler.auth.fake import settings
+
+class FakeAuthHandler(auth.BaseAuthHandler):
+
+    async def fetch(self, resource, provider, request):
+        pass
+
+    async def get(self, resource, provider, request):
+        # part of osf website.addons.base.views.get_auth
+        #auth = {
+        #    'id': user._id,
+        #    'email': '{}@osf.io'.format(user._id),
+        #    'name': user.fullname,
+        #}
+        # just github for now
+
+        try:
+            credentials = settings.PROVIDERS[provider]['credentials']
+            provider_settings = settings.PROVIDERS[provider]['settings']
+        except KeyError:
+            raise exceptions.AuthError('Configure your fakes!', code=503)
+
+        return {
+            'auth': {},
+            'credentials': credentials,
+            'settings': provider_settings,
+            'callback_url': ''
+        }
+

--- a/waterbutler/auth/fake/settings.py
+++ b/waterbutler/auth/fake/settings.py
@@ -1,0 +1,8 @@
+try:
+    from waterbutler import settings
+except ImportError:
+    settings = {}
+
+config = settings.get('FAKE_AUTH_CONFIG', {})
+
+PROVIDERS = config.get('PROVIDERS')

--- a/waterbutler/core/auth.py
+++ b/waterbutler/core/auth.py
@@ -5,4 +5,11 @@ class BaseAuthHandler(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def fetch(self, request_handler):
+        # used by v0
         pass
+
+    @abc.abstractmethod
+    def get(self, resource, provider, request):
+        # used by v1
+        pass
+


### PR DESCRIPTION
This allows running waterbutler in a dev context without requiring OSF for authentication.

(by Abram Booth, not himicakumar, sorry for the username confusion)