### PR TITLE
OSF-5505 GDrive "def empty_folder" for use in "def delete" against root

### DIFF
--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -206,6 +206,18 @@ class GoogleDriveProvider(provider.BaseProvider):
 
     @asyncio.coroutine
     def delete(self, path, **kwargs):
+        """Given a WaterButlerPath, delete that path
+
+        :param WaterButlerPath: Path to be deleted
+        :rtype: None
+        :raises: :class:`waterbutler.core.exceptions.NotFoundError`
+        :raises: :class:`waterbutler.core.exceptions.DeleteError`
+
+        Quirks:
+            If the WaterButlerPath given is for the provider root path, then
+            the contents of provider root path will be deleted. But not the
+            provider root itself.
+        """
         if not path.identifier:
             raise exceptions.NotFoundError(str(path))
 
@@ -222,6 +234,14 @@ class GoogleDriveProvider(provider.BaseProvider):
 
     @asyncio.coroutine
     def empty_folder(self, path):
+        """Given a WaterButlerPath, delete all contents of folder
+
+        :param WaterButlerPath: Folder to be emptied
+        :rtype: None
+        :raises: :class:`waterbutler.core.exceptions.NotFoundError`
+        :raises: :class:`waterbutler.core.exceptions.MetadataError`
+        :raises: :class:`waterbutler.core.exceptions.DeleteError`
+        """
         fid = path.identifier
         if not fid:
             raise exceptions.NotFoundError(str(path))

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -242,13 +242,13 @@ class GoogleDriveProvider(provider.BaseProvider):
         :raises: :class:`waterbutler.core.exceptions.MetadataError`
         :raises: :class:`waterbutler.core.exceptions.DeleteError`
         """
-        fid = path.identifier
-        if not fid:
+        file_id = path.identifier
+        if not file_id:
             raise exceptions.NotFoundError(str(path))
         resp = yield from self.make_request(
             'GET',
             self.build_url('files',
-                           q="'{}' in parents".format(fid),
+                           q="'{}' in parents".format(file_id),
                            fields='items(id)'),
             expects=(200, ),
             throws=exceptions.MetadataError)


### PR DESCRIPTION
## Purpose
[OSF-5505](https://openscience.atlassian.net/browse/OSF-5505)
Catch delete calls against provider root in GoogleDrive to prevent from actually deleting the provider root. Just delete contents of provider root

## Changes
Add def empty_folder for use by def delete in the case of root provider

## Side effects
None

#OSF-5505