### PR TITLE
OSF-5503 modify GD provider to use trash instead of deleting.

### DIFF
--- a/tests/providers/googledrive/test_provider.py
+++ b/tests/providers/googledrive/test_provider.py
@@ -6,6 +6,7 @@ import io
 from http import client
 
 import aiohttpretty
+from json import dumps
 
 from waterbutler.core import streams
 from waterbutler.core import exceptions
@@ -105,9 +106,12 @@ class TestValidatePath:
         file_name = 'file.txt'
         file_id = '1234ideclarethumbwar'
 
+        query = "title = '{}' " \
+                "and trashed = false " \
+                "and mimeType != 'application/vnd.google-apps.form'".format(file_name)
         query_url = provider.build_url(
             'files', provider.folder['id'], 'children',
-            q="title = '{}'".format(file_name), fields='items(id)'
+            q=query, fields='items(id)'
         )
         specific_url = provider.build_url('files', file_id, fields='id,title,mimeType')
 
@@ -135,9 +139,12 @@ class TestValidatePath:
         folder_name = 'foofolder'
         folder_id = 'whyis6afraidof7'
 
+        query = "title = '{}' " \
+                "and trashed = false " \
+                "and mimeType != 'application/vnd.google-apps.form'".format(folder_name)
         query_url = provider.build_url(
             'files', provider.folder['id'], 'children',
-            q="title = '{}'".format(folder_name), fields='items(id)'
+            q=query, fields='items(id)'
         )
         specific_url = provider.build_url('files', folder_id, fields='id,title,mimeType')
 
@@ -319,25 +326,34 @@ class TestCRUD:
         item = fixtures.list_file['items'][0]
         path = WaterButlerPath('/birdie.jpg', _ids=(None, item['id']))
         delete_url = provider.build_url('files', item['id'])
-        aiohttpretty.register_uri('DELETE', delete_url, status=204)
+        del_url_body = dumps({'labels': {'trashed': 'true'}})
+        aiohttpretty.register_uri('PUT',
+                                  delete_url,
+                                  body=del_url_body,
+                                  status=200)
 
         result = yield from provider.delete(path)
 
         assert result is None
-        assert aiohttpretty.has_call(method='DELETE', uri=delete_url)
+        assert aiohttpretty.has_call(method='PUT', uri=delete_url)
 
     @async
     @pytest.mark.aiohttpretty
     def test_delete_folder(self, provider):
         item = fixtures.folder_metadata
-        delete_url = provider.build_url('files', item['id'])
+        del_url = provider.build_url('files', item['id'])
+        del_url_body = dumps({'labels': {'trashed': 'true'}})
+
         path = WaterButlerPath('/foobar/', _ids=('doesntmatter', item['id']))
 
-        aiohttpretty.register_uri('DELETE', delete_url, status=204)
+        aiohttpretty.register_uri('PUT',
+                                  del_url,
+                                  body=del_url_body,
+                                  status=200)
 
         result = yield from provider.delete(path)
 
-        assert aiohttpretty.has_call(method='DELETE', uri=delete_url)
+        assert aiohttpretty.has_call(method='PUT', uri=del_url)
 
     @async
     @pytest.mark.aiohttpretty

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -389,7 +389,6 @@ class GoogleDriveProvider(provider.BaseProvider):
                 expects=(200, ),
                 throws=exceptions.MetadataError,
             )
-            presp = yield from resp.json()
 
             try:
                 item_id = (yield from resp.json())['items'][0]['id']
@@ -467,7 +466,6 @@ class GoogleDriveProvider(provider.BaseProvider):
                 expects=(200, ),
                 throws=exceptions.MetadataError,
             )
-            presp = yield from p_resp.json()
             parents.append((yield from p_resp.json()))
         return parents
 

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -210,9 +210,12 @@ class GoogleDriveProvider(provider.BaseProvider):
             raise exceptions.NotFoundError(str(path))
 
         yield from self.make_request(
-            'DELETE',
+            'PUT',
             self.build_url('files', path.identifier),
-            expects=(204, ),
+            data=json.dumps({'labels': {
+                'trashed': 'true'}}),
+            headers={'Content-Type': 'application/json'},
+            expects=(200, ),
             throws=exceptions.DeleteError,
         )
 
@@ -343,9 +346,13 @@ class GoogleDriveProvider(provider.BaseProvider):
         item_id = parent_id or self.folder['id']
 
         while parts:
+            query = self._build_query(path.identifier)
             resp = yield from self.make_request(
                 'GET',
-                self.build_url('files', item_id, 'children', q="title = '{}'".format(parts.pop(0))),
+                self.build_url('files',
+                               item_id,
+                               'children',
+                               q=query),
                 expects=(200, ),
                 throws=exceptions.MetadataError,
             )
@@ -368,13 +375,21 @@ class GoogleDriveProvider(provider.BaseProvider):
 
         while parts:
             current_part = parts.pop(0)
+            query = "title = '{}' " \
+                    "and trashed = false " \
+                    "and mimeType != 'application/vnd.google-apps.form'".format(clean_query(current_part))
 
             resp = yield from self.make_request(
                 'GET',
-                self.build_url('files', item_id, 'children', q="title = '{}'".format(clean_query(current_part)), fields='items(id)'),
+                self.build_url('files',
+                               item_id,
+                               'children',
+                               q=query,
+                               fields='items(id)'),
                 expects=(200, ),
                 throws=exceptions.MetadataError,
             )
+            presp = yield from resp.json()
 
             try:
                 item_id = (yield from resp.json())['items'][0]['id']
@@ -446,10 +461,13 @@ class GoogleDriveProvider(provider.BaseProvider):
         for parent in (yield from resp.json())['items']:
             p_resp = yield from self.make_request(
                 'GET',
-                self.build_url('files', parent['id'], fields='id,title'),
+                self.build_url('files',
+                               parent['id'],
+                               fields='id,title,labels/trashed'),
                 expects=(200, ),
                 throws=exceptions.MetadataError,
             )
+            presp = yield from p_resp.json()
             parents.append((yield from p_resp.json()))
         return parents
 


### PR DESCRIPTION
## Purpose
[OSF-5503](https://openscience.atlassian.net/browse/OSF-5503)
Update GoogleDrive provider to use trash instead of deleting files/folders

## Changes
Update def delete to set labels:trashed to true , instead of deleting files/folders
Update all searches to ignore files/folders with  labels:trashed = true

## Side effects
Files/Folders will not be deleted from GoogleDrive, which may or may not be what the user is expecting.
User Doc might need to be updated to remind users that their files/folders are in the trash

#OSF-5503