### PR TITLE
[RFR][Feature] OSF-5504 Require confirm_delete=1 for root folder deletes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -141,7 +141,7 @@ If a moved/copied file is overwriting an existing file, a 200 OK response will b
 ::
 
     Method:        DELETE
-    Query Params:  <none>
+    Query Params:  ?confirm_delete=1 //required for root folder delete only
     Success:       204 No Content
 
-To delete a file or folder send a DELETE request to the delete link. Nothing will be returned in the response body.
+To delete a file or folder send a DELETE request to the delete link. Nothing will be returned in the response body. As a precaution against inadvertantly deleting the root folder, the query parameter confirm_delete must be set to 1 for root folder deletes. In adition, a root folder delete does not actually delete the root folder. Instead it deletes all contents of the folder, but not the folder itself.

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -449,5 +449,5 @@ class BoxProvider(provider.BaseProvider):
         """
         meta = (yield from self.metadata(path))
         for child in meta:
-            box_path = yield from self.validate_v1_path(child.path)
+            box_path = yield from self.validate_path(child.path)
             yield from self.delete(box_path)

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -267,17 +267,21 @@ class BoxProvider(provider.BaseProvider):
         return BoxFileMetadata(data['entries'][0], path), created
 
     @asyncio.coroutine
-    def delete(self, path, **kwargs):
+    def delete(self, path, confirm_delete=0, **kwargs):
         """Delete file, folder, or provider root contents
 
         :param BoxPath path: BoxPath path object for folder
+        :param int confirm_delete: Must be 1 to confirm root folder delete
         """
         if not path.identifier:  # TODO This should be abstracted
             raise exceptions.NotFoundError(str(path))
 
         if path.is_root:
-            yield from self._delete_folder_contents(path)
-            return
+            if confirm_delete == 1:
+                yield from self._delete_folder_contents(path)
+                return
+            else:
+                raise exceptions.DeleteError('confirm_delete=1 is required for deleting root provider folder')
 
         if path.is_file:
             url = self.build_url('files', path.identifier)

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -199,14 +199,18 @@ class DropboxProvider(provider.BaseProvider):
         return DropboxFileMetadata(data, self.folder), not exists
 
     @asyncio.coroutine
-    def delete(self, path, **kwargs):
+    def delete(self, path, confirm_delete=0, **kwargs):
         """Delete file, folder, or provider root contents
 
         :param DropboxPath path: DropboxPath path object for folder
+        :param int confirm_delete: Must be 1 to confirm root folder delete
         """
         if path.is_root:
-            yield from self._delete_folder_contents(path)
-            return
+            if confirm_delete == 1:
+                yield from self._delete_folder_contents(path)
+                return
+            else:
+                raise exceptions.DeleteError('confirm_delete=1 is required for deleting root provider folder')
 
         yield from self.make_request(
             'POST',

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -324,5 +324,5 @@ class DropboxProvider(provider.BaseProvider):
         """
         meta = (yield from self.metadata(path))
         for child in meta:
-            drop_box_path = yield from self.validate_v1_path(child.path)
+            drop_box_path = yield from self.validate_path(child.path)
             yield from self.delete(drop_box_path)

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -229,19 +229,24 @@ class GitHubProvider(provider.BaseProvider):
         }, commit=commit), not exists
 
     @asyncio.coroutine
-    def delete(self, path, sha=None, message=None, branch=None, **kwargs):
+    def delete(self, path, sha=None, message=None, branch=None,
+               confirm_delete=0, **kwargs):
         """Delete file, folder, or provider root contents
 
         :param GitHubPath path: GitHubPath path object for file, folder, or root
         :param str sha: SHA-1 checksum of file/folder object
         :param str message: Commit message
         :param str branch: Repository branch
+        :param int confirm_delete: Must be 1 to confirm root folder delete
         """
         assert self.name is not None
         assert self.email is not None
 
         if path.is_root:
-            yield from self._delete_folder_contents(path)
+            if confirm_delete == 1:
+                yield from self._delete_folder_contents(path)
+            else:
+                raise exceptions.DeleteError('confirm_delete=1 is required for deleting root provider folder')
         elif path.is_dir:
             yield from self._delete_folder(path, message, **kwargs)
         else:

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -443,7 +443,7 @@ class GitHubProvider(provider.BaseProvider):
         """
         meta = (yield from self.metadata(path))
         for child in meta:
-            github_path = yield from self.validate_v1_path(child.path)
+            github_path = yield from self.validate_path(child.path)
             yield from self.delete(github_path)
 
     @asyncio.coroutine

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -205,10 +205,11 @@ class GoogleDriveProvider(provider.BaseProvider):
         return GoogleDriveFileMetadata(data, path), path.identifier is None
 
     @asyncio.coroutine
-    def delete(self, path, **kwargs):
+    def delete(self, path, confirm_delete=0, **kwargs):
         """Given a WaterButlerPath, delete that path
 
         :param WaterButlerPath: Path to be deleted
+        :param int confirm_delete: Must be 1 to confirm root folder delete
         :rtype: None
         :raises: :class:`waterbutler.core.exceptions.NotFoundError`
         :raises: :class:`waterbutler.core.exceptions.DeleteError`
@@ -222,8 +223,11 @@ class GoogleDriveProvider(provider.BaseProvider):
             raise exceptions.NotFoundError(str(path))
 
         if path.is_root:
-            yield from self._delete_folder_contents(path)
-            return
+            if confirm_delete == 1:
+                yield from self._delete_folder_contents(path)
+                return
+            else:
+                raise exceptions.DeleteError('confirm_delete=1 is required for deleting root provider folder')
 
         yield from self.make_request(
             'PUT',

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -222,7 +222,7 @@ class GoogleDriveProvider(provider.BaseProvider):
             raise exceptions.NotFoundError(str(path))
 
         if path.is_root:
-            yield from self.empty_folder(path)
+            yield from self._delete_folder_contents(path)
             return
 
         yield from self.make_request(
@@ -233,39 +233,6 @@ class GoogleDriveProvider(provider.BaseProvider):
             expects=(200, ),
             throws=exceptions.DeleteError,
         )
-
-    @asyncio.coroutine
-    def empty_folder(self, path):
-        """Given a WaterButlerPath, delete all contents of folder
-
-        :param WaterButlerPath: Folder to be emptied
-        :rtype: None
-        :raises: :class:`waterbutler.core.exceptions.NotFoundError`
-        :raises: :class:`waterbutler.core.exceptions.MetadataError`
-        :raises: :class:`waterbutler.core.exceptions.DeleteError`
-        """
-        file_id = path.identifier
-        if not file_id:
-            raise exceptions.NotFoundError(str(path))
-        resp = yield from self.make_request(
-            'GET',
-            self.build_url('files',
-                           q="'{}' in parents".format(file_id),
-                           fields='items(id)'),
-            expects=(200, ),
-            throws=exceptions.MetadataError)
-
-        try:
-            child_ids = (yield from resp.json())['items']
-        except (KeyError, IndexError):
-            raise exceptions.MetadataError('{} not found'.format(str(path)), code=http.client.NOT_FOUND)
-
-        for child in child_ids:
-            yield from self.make_request(
-                'DELETE',
-                self.build_url('files', child['id']),
-                expects=(204, ),
-                throws=exceptions.DeleteError)
 
     def _build_query(self, folder_id, title=None):
         queries = [
@@ -570,3 +537,36 @@ class GoogleDriveProvider(provider.BaseProvider):
             return (yield from self._handle_docs_versioning(path, data, raw=raw))
 
         return self._serialize_item(path, data, raw=raw)
+
+    @asyncio.coroutine
+    def _delete_folder_contents(self, path):
+        """Given a WaterButlerPath, delete all contents of folder
+
+        :param WaterButlerPath: Folder to be emptied
+        :rtype: None
+        :raises: :class:`waterbutler.core.exceptions.NotFoundError`
+        :raises: :class:`waterbutler.core.exceptions.MetadataError`
+        :raises: :class:`waterbutler.core.exceptions.DeleteError`
+        """
+        file_id = path.identifier
+        if not file_id:
+            raise exceptions.NotFoundError(str(path))
+        resp = yield from self.make_request(
+            'GET',
+            self.build_url('files',
+                           q="'{}' in parents".format(file_id),
+                           fields='items(id)'),
+            expects=(200, ),
+            throws=exceptions.MetadataError)
+
+        try:
+            child_ids = (yield from resp.json())['items']
+        except (KeyError, IndexError):
+            raise exceptions.MetadataError('{} not found'.format(str(path)), code=http.client.NOT_FOUND)
+
+        for child in child_ids:
+            yield from self.make_request(
+                'DELETE',
+                self.build_url('files', child['id']),
+                expects=(204, ),
+                throws=exceptions.DeleteError)

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -444,5 +444,5 @@ class OSFStorageProvider(provider.BaseProvider):
         """
         meta = (yield from self.metadata(path))
         for child in meta:
-            osf_path = yield from self.validate_v1_path(child.path)
+            osf_path = yield from self.validate_path(child.path)
             yield from self.delete(osf_path)

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -333,17 +333,21 @@ class OSFStorageProvider(provider.BaseProvider):
         return OsfStorageFileMetadata(metadata, str(path)), created
 
     @asyncio.coroutine
-    def delete(self, path, **kwargs):
+    def delete(self, path, confirm_delete=0, **kwargs):
         """Delete file, folder, or provider root contents
 
         :param OsfStoragePath path: path to delete
+        :param int confirm_delete: Must be 1 to confirm root folder delete
         """
         if path.identifier is None:
             raise exceptions.NotFoundError(str(path))
 
         if path.is_root:
-            yield from self._delete_folder_contents(path)
-            return
+            if confirm_delete == 1:
+                yield from self._delete_folder_contents(path)
+                return
+            else:
+                raise exceptions.DeleteError('confirm_delete=1 is required for deleting root provider folder')
 
         yield from self.make_signed_request(
             'DELETE',

--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -109,7 +109,10 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
 
     @tornado.gen.coroutine
     def delete(self, **_):
-        yield from self.provider.delete(self.path)
+        self.confirm_delete = int(self.get_query_argument('confirm_delete',
+                                                          default=0))
+        yield from self.provider.delete(self.path,
+                                        confirm_delete=self.confirm_delete)
         self.set_status(http.client.NO_CONTENT)
 
     @tornado.gen.coroutine


### PR DESCRIPTION
## Purpose
[OSF-5504](https://openscience.atlassian.net/browse/OSF-5504)
Update WaterButler to accept...
DELETE http://host:7777/v1/resources/XXXXX/providers/XXXX/?confirm_delete=1
and require it for deletion of root folder

Update providers to allow for
DELETE http://host:7777/v1/resources/XXXXX/providers/osfstorage/

## Changes
Update waterbutler/server/api/v1/provider/__init__.py to pass on confirm_delete=1 for deletes
Update def delete to check for confirm_delete=1 when deleting root folder in the following providers...
google drive
github
dropbox
box
osfstorage
Update def delete to check for path.is_root and call def _delete_folder_contents
Create def _delete_folder_contents to find and delete folder children

## Side effects
None

#OSF-5504