### PR TITLE
[RFR][Feature]OSF-5810 GitHub create .gitkeep before emptying folder

### DIFF
--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import asyncio
+import io
 
 import furl
 
@@ -450,7 +451,17 @@ class GitHubProvider(provider.BaseProvider):
         :param str message: Commit message
         """
         meta = (yield from self.metadata(path))
+
+        # Create .gitkeep file before emptying folder
+        stream = streams.FileStreamReader(io.BytesIO(b''))
+        gitkeep_path = yield from self.validate_path('/.gitkeep')
+        yield from self.upload(stream,
+                               gitkeep_path,
+                               message)
+
         for child in meta:
+            if child.path == '/.gitkeep':
+                continue
             github_path = yield from self.validate_path(child.path)
             yield from self.delete(github_path)
 


### PR DESCRIPTION
## Purpose
[OSF-5774](https://openscience.atlassian.net/browse/OSF-5774)
Add .gitkeep file before emptying folder
currently only used for root provider delete

## Changes
update rwaterbutler/providers/github/provider.py waterbutler/providers/github/provider.py for .gitkeep

## Side effects
None

#OSF-5774