### PR TITLE
[RFR][Feature]OSF-5838 add check for exists before deleting def _delete_folder

### DIFF
--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -397,7 +397,10 @@ class GitHubProvider(provider.BaseProvider):
             tree_sha = GIT_EMPTY_SHA
         else:
             # Delete the folder from the tree cast to list iterator over all values
+            current_tree = tree['tree']
             tree['tree'] = list(filter(lambda x: x['path'] != tree['target'], tree['tree']))
+            if current_tree == tree['tree']:
+                raise exceptions.NotFoundError(str(path))
 
             tree_data = yield from self._create_tree({'tree': tree['tree']})
             tree_sha = tree_data['sha']


### PR DESCRIPTION
## Purpose
[OSF-5838](https://openscience.atlassian.net/browse/OSF-5838)
Make sure move to non-existent folder returns 201 
Return NotFound error when attempting to delete a folder that does not exist

## Changes
update waterbutler/providers/github/provider.py "def _delete_folder" to return NotFound error when folder to delete does not exist

## Side effects
None

#OSF-5838