### PR TITLE
[WIP][SVCS-62]Enable support for unexportable/undownloadable GoogleDrive files (e.g. maps, forms)

### DIFF
--- a/tests/providers/googledrive/test_provider.py
+++ b/tests/providers/googledrive/test_provider.py
@@ -110,8 +110,6 @@ def actual_folder_response():
 def _build_title_search_query(provider, entity_name, is_folder=True):
         return "title = '{}' " \
             "and trashed = false " \
-            "and mimeType != 'application/vnd.google-apps.form' " \
-            "and mimeType != 'application/vnd.google-apps.map' " \
             "and mimeType {} '{}'".format(
                 entity_name,
                 '=' if is_folder else '!=',

--- a/waterbutler/providers/googledrive/metadata.py
+++ b/waterbutler/providers/googledrive/metadata.py
@@ -86,7 +86,7 @@ class GoogleDriveFileMetadata(BaseGoogleDriveMetadata, metadata.BaseFileMetadata
 
     @property
     def is_google_doc(self):
-        return utils.is_docs_file(self.raw) is not None
+        return utils.is_docs_file(self.raw)
 
     @property
     def export_name(self):

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -228,8 +228,6 @@ class GoogleDriveProvider(provider.BaseProvider):
         queries = [
             "'{}' in parents".format(folder_id),
             'trashed = false',
-            "mimeType != 'application/vnd.google-apps.form'",
-            "mimeType != 'application/vnd.google-apps.map'",
         ]
         if title:
             queries.append("title = '{}'".format(clean_query(title)))
@@ -380,8 +378,6 @@ class GoogleDriveProvider(provider.BaseProvider):
             current_part = parts.pop(0)
             query = "title = '{}' " \
                     "and trashed = false " \
-                    "and mimeType != 'application/vnd.google-apps.form' " \
-                    "and mimeType != 'application/vnd.google-apps.map' " \
                     "and mimeType {} '{}'".format(
                         clean_query(current_part[0]),
                         '=' if current_part[1] else '!=',
@@ -401,7 +397,8 @@ class GoogleDriveProvider(provider.BaseProvider):
                 if parts:
                     raise exceptions.MetadataError('{} not found'.format(str(path)), code=http.client.NOT_FOUND)
                 name, ext = os.path.splitext(current_part[0])
-                if ext not in ('.gdoc', '.gdraw', '.gslides', '.gsheet'):
+                if ext not in ('.gdoc', '.gdraw', '.gslides', '.gsheet',
+                               '.gmap', '.gform'):
                     return ret + [{
                         'id': None,
                         'title': current_part[0],

--- a/waterbutler/providers/googledrive/utils.py
+++ b/waterbutler/providers/googledrive/utils.py
@@ -12,6 +12,18 @@ DOCS_FORMATS = [
         'type': 'image/jpeg',
     },
     {
+        'mime_type': 'application/vnd.google-apps.form',
+        'ext': '.gform',
+        'download_ext': '.jpg',
+        'type': 'image/jpeg',
+    },
+    {
+        'mime_type': 'application/vnd.google-apps.map',
+        'ext': '.gmap',
+        'download_ext': '.kmz',
+        'type': 'application/vnd.google-earth.kmz',
+    },
+    {
         'mime_type': 'application/vnd.google-apps.spreadsheet',
         'ext': '.gsheet',
         'download_ext': '.xlsx',
@@ -29,11 +41,16 @@ DOCS_DEFAULT_FORMAT = {
     'download_ext': '.pdf',
     'type': 'application/pdf',
 }
+DOCS_UNEXPORTABLE_MIMES = ['application/vnd.google-apps.map',
+                           'application/vnd.google-apps.form']
 
 
 def is_docs_file(metadata):
-    """Only Docs files have the "exportLinks" key."""
-    return metadata.get('exportLinks')
+    """Check for unexportable file types. (e.g. Maps, Forms)
+    Only Docs files have the "exportLinks" key."""
+    if metadata.get('mimeType') in DOCS_UNEXPORTABLE_MIMES or metadata.get('exportLinks'):
+        return True
+    return False
 
 
 def get_format(metadata):


### PR DESCRIPTION
## Purpose:

[SVCS-62](https://openscience.atlassian.net/browse/SVCS-62)
Enable support for unexportable/undownloadable GoogleDrive files (e.g. maps, forms)
## Changes:

update waterbutler/providers/googledrive/metadata.py def is_google_doc to handle boolean response
update  waterbutler/providers/googledrive/provider.py to stop ignoring GD maps and forms
update  waterbutler/providers/googledrive/utils.py to handle unexportable file types
## Side effects:

Requires [PR#5535](https://github.com/CenterForOpenScience/osf.io/pull/5535)

[#SVCS-62]
