### PR TITLE
[RFR][Feature][OSF-6051]GDrive: Implement paging for folder contents listing

### DIFF
--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -492,17 +492,27 @@ class GoogleDriveProvider(provider.BaseProvider):
 
     async def _folder_metadata(self, path, raw=False):
         query = self._build_query(path.identifier)
-
-        async with self.request(
-            'GET',
-            self.build_url('files', q=query, alt='json', maxResults=1000),
-            expects=(200, ),
-            throws=exceptions.MetadataError,
-        ) as resp:
-            return [
-                self._serialize_item(path.child(item['title']), item, raw=raw)
-                for item in (await resp.json())['items']
-            ]
+        built_url = self.build_url('files', q=query,
+                                   alt='json', maxResults=1000)
+        full_resp = []
+        while built_url:
+            async with self.request(
+                'GET',
+                built_url,
+                expects=(200, ),
+                throws=exceptions.MetadataError,
+            ) as resp:
+                resp_json = (await resp.json())
+                this_resp = [
+                    self._serialize_item(path.child(item['title']),
+                                         item, raw=raw)
+                    for item in resp_json['items']
+                ]
+                built_url = None
+                if 'nextLink' in resp_json.keys():
+                    built_url = resp_json['nextLink']
+                full_resp.extend(this_resp)
+        return full_resp
 
     async def _file_metadata(self, path, revision=None, raw=False):
         if revision:


### PR DESCRIPTION
## Purpose:
[OSF-6051](https://openscience.atlassian.net/browse/OSF-6051)
Enable def _folder_metadata to follow nextLinks for folders containing over 1000 files.

## Changes:
update  waterbutler/providers/googledrive/provider.py def _folder_metadata

## Side effects:
None

[#OSF-6051]