### PR TITLE
[RFR][Feature][OSF-6071]Box: Implement paging for folder contents listing

### DIFF
--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -450,8 +450,8 @@ class TestMetadata:
         path = WaterButlerPath('/', _ids=(provider.folder, ))
 
         list_url = provider.build_url('folders', provider.folder, 'items',
-                                      fields='id,name,size,modified_at,etag',
-                                      limit=1000)
+                                      fields='id,name,size,modified_at,etag,total_count',
+                                      offset=0, limit=1000)
 
         aiohttpretty.register_json_uri('GET', list_url, body=folder_list_metadata)
 

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -407,7 +407,7 @@ class BoxProvider(provider.BaseProvider):
             full_resp = []
         while page_count < page_total:
             url = self.build_url('folders', path.identifier, 'items',
-                                 fields='id,name,size,modified_at, etag,total_count',
+                                 fields='id,name,size,modified_at,etag,total_count',
                                  offset=(page_count * limit),
                                  limit=limit)
             async with self.request(


### PR DESCRIPTION
## Purpose:
[OSF-6071](https://openscience.atlassian.net/browse/OSF-6071)
Allow for retrieving folder listings for folders with more the 1000 children (Box's current limit)

## Changes:
update  waterbutler/providers/box/provider.py for greater then 1000 children in folder

## Side effects:
None

## TODO
I need access to a premium Box account in order to test revisions

[#OSF-6071]