### PR TITLE
[WIP] support branches in v1 github

### DIFF
--- a/tests/providers/github/test_metadata.py
+++ b/tests/providers/github/test_metadata.py
@@ -1,0 +1,170 @@
+import re
+
+import pytest
+
+from waterbutler.providers.github.metadata import GitHubFileTreeMetadata
+from waterbutler.providers.github.metadata import GitHubFolderTreeMetadata
+from waterbutler.providers.github.metadata import GitHubFileContentMetadata
+from waterbutler.providers.github.metadata import GitHubFolderContentMetadata
+
+
+@pytest.fixture
+def file_metadata_content_endpoint():
+    return {
+        '_links': {
+            'git': 'scrubbed',
+            'html': 'scrubbed',
+            'self': 'scrubbed',
+        },
+        'download_url': 'scrubbed',
+        'git_url': 'scrubbed',
+        'html_url': 'scrubbed',
+        'name': 'epsilon',
+        'path': 'epsilon',
+        'sha': 'bd4fb614678f544acb22bac6861a21108f1e5d10',
+        'size': 15,
+        'type': 'file',
+        'url': 'scrubbed',
+    }
+
+@pytest.fixture
+def file_metadata_tree_endpoint():
+    return {
+        'mode': '100644',
+        'path': 'README.md',
+        'sha': 'd863d70539aa9fcb6b44b057221706f2ab18e341',
+        'size': 38,
+        'type': 'blob',
+        'url': 'scrubbed',
+    }
+
+@pytest.fixture
+def folder_metadata_content_endpoint():
+    return {
+        '_links': {
+            'git': 'scrubbed',
+            'html': 'scrubbed',
+            'self': 'scrubbed'
+        },
+        'download_url': None,
+        'git_url': 'scrubbed',
+        'html_url': 'scrubbed',
+        'name': 'manyfiles',
+        'path': 'manyfiles',
+        'sha': '4a16a05d8be24814483feeb9fa7f0baa37004cc3',
+        'size': 0,
+        'type': 'dir',
+        'url': 'scrubbed'
+    }
+
+@pytest.fixture
+def folder_metadata_tree_endpoint():
+    return {
+        'mode': '040000',
+        'path': 'foldera/folderb/lorch',
+        'sha': 'd564d0bc3dd917926892c55e3706cc116d5b165e',
+        'type': 'tree',
+        'url': 'scrubbed'
+    }
+
+
+class TestGitHubMetadata:
+
+    def test_build_file_metadata_from_tree(self, file_metadata_tree_endpoint):
+        try:
+            metadata = GitHubFileTreeMetadata(file_metadata_tree_endpoint)
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        assert metadata.name == 'README.md'
+        assert metadata.path == '/README.md'
+        assert metadata.modified is None
+        assert metadata.content_type is None
+        assert metadata.size == 38
+        assert metadata.etag == '/README.md::d863d70539aa9fcb6b44b057221706f2ab18e341'
+        assert metadata.extra == {
+            'fileSha': 'd863d70539aa9fcb6b44b057221706f2ab18e341',
+            'webView': None,
+        }
+        assert metadata.provider == 'github'
+
+        assert metadata.commit is None
+        assert metadata.ref is None
+        assert metadata.web_view is None
+
+    def test_build_file_metadata_from_contents(self, file_metadata_content_endpoint):
+        try:
+            metadata = GitHubFileContentMetadata(file_metadata_content_endpoint)
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        assert metadata.name == 'epsilon'
+        assert metadata.path == '/epsilon'
+        assert metadata.modified is None
+        assert metadata.content_type is None
+        assert metadata.size == 15
+        assert metadata.etag == '/epsilon::bd4fb614678f544acb22bac6861a21108f1e5d10'
+        assert metadata.extra == {
+            'fileSha': 'bd4fb614678f544acb22bac6861a21108f1e5d10',
+            'webView': None,
+        }
+        assert metadata.provider == 'github'
+
+        assert metadata.commit is None
+        assert metadata.ref is None
+        assert metadata.web_view is None
+
+    def test_build_folder_metadata_from_tree(self, folder_metadata_tree_endpoint):
+        try:
+            metadata = GitHubFolderTreeMetadata(folder_metadata_tree_endpoint)
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        assert metadata.name == 'lorch'
+        assert metadata.path == '/foldera/folderb/lorch/'
+        assert metadata.extra == {}
+        assert metadata.provider == 'github'
+
+        assert metadata.commit is None
+        assert metadata.ref is None
+
+    def test_build_folder_metadata_from_content(self, folder_metadata_content_endpoint):
+        try:
+            metadata = GitHubFolderContentMetadata(folder_metadata_content_endpoint)
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        assert metadata.name == 'manyfiles'
+        assert metadata.path == '/manyfiles/'
+        assert metadata.extra == {}
+        assert metadata.provider == 'github'
+
+        assert metadata.commit is None
+        assert metadata.ref is None
+
+    def test_file_metadata_with_ref(self, file_metadata_tree_endpoint):
+        try:
+            metadata = GitHubFileTreeMetadata(file_metadata_tree_endpoint, ref="some-branch")
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        assert metadata.name == 'README.md'
+        assert metadata.path == '/README.md'
+        assert metadata.modified is None
+        assert metadata.content_type is None
+        assert metadata.size == 38
+        assert metadata.etag == '/README.md::d863d70539aa9fcb6b44b057221706f2ab18e341'
+        assert metadata.extra == {
+            'fileSha': 'd863d70539aa9fcb6b44b057221706f2ab18e341',
+            'webView': None,
+            'ref': 'some-branch',
+        }
+        assert metadata.provider == 'github'
+
+        assert metadata.commit is None
+        assert metadata.ref == 'some-branch'
+        assert metadata.web_view is None
+
+        json_api = metadata.json_api_serialized('mst3k')
+        for actions, link in json_api['links'].items():
+            assert re.search('[?&]ref=some-branch', link)

--- a/tests/providers/github/test_path.py
+++ b/tests/providers/github/test_path.py
@@ -1,0 +1,28 @@
+import re
+
+import pytest
+
+from waterbutler.providers.github.path import GitHubPath
+
+
+class TestGitHubPath:
+
+    def test_id_accessors(self):
+        gh_path = GitHubPath('/foo', _ids=[('master', None), ('master', 'abcea54as123')])
+
+        assert gh_path.branch_ref == 'master'
+        assert gh_path.file_sha == 'abcea54as123'
+
+    def test_child_inherits_branch(self):
+        gh_parent = GitHubPath('/foo/', _ids=[('master', None), ('master', 'abcea54as123')])
+        gh_child = gh_parent.child('foo')
+
+        assert gh_child.branch_ref == 'master'
+        assert gh_child.file_sha is None
+
+    def test_child_given_explicit_branch(self):
+        gh_parent = GitHubPath('/foo/', _ids=[('master', None), ('master', 'abcea54as123')])
+        gh_child = gh_parent.child('foo', _id=('develop', '413006763'))
+
+        assert gh_child.branch_ref == 'develop'
+        assert gh_child.file_sha == '413006763'

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -768,7 +768,7 @@ class TestMetadata:
 
         assert result == GitHubFileTreeMetadata(item, web_view=web_view, commit={
             'tree': {'sha': ref}, 'author': {'date': '1970-01-02T03:04:05Z'}
-        })
+        }, ref=path.identifier[0])
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -802,9 +802,9 @@ class TestMetadata:
         ret = []
         for item in content_repo_metadata_root:
             if item['type'] == 'dir':
-                ret.append(GitHubFolderContentMetadata(item))
+                ret.append(GitHubFolderContentMetadata(item, ref=provider.default_branch))
             else:
-                ret.append(GitHubFileContentMetadata(item, web_view=item['html_url']))
+                ret.append(GitHubFileContentMetadata(item, web_view=item['html_url'], ref=provider.default_branch))
 
         assert result == ret
 

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -532,6 +532,19 @@ class TestValidatePath:
         assert wb_path_v1 == wb_path_v0
 
     @pytest.mark.asyncio
+    async def test_reject_multiargs(self, provider):
+
+        with pytest.raises(exceptions.InvalidParameters) as exc:
+            await provider.validate_v1_path('/foo', ref=['bar','baz'])
+
+        assert exc.value.code == client.BAD_REQUEST
+
+        with pytest.raises(exceptions.InvalidParameters) as exc:
+            await provider.validate_path('/foo', ref=['bar','baz'])
+
+        assert exc.value.code == client.BAD_REQUEST
+
+    @pytest.mark.asyncio
     async def test_validate_path(self, provider):
         path = await provider.validate_path('/this/is/my/path')
 

--- a/tests/tasks/test_copy.py
+++ b/tests/tasks/test_copy.py
@@ -182,6 +182,7 @@ class TestCopyTask:
             'materialized': str(src_path),
             'provider': src.NAME,
             'kind': 'file',
+            'extra': {},
         }
 
         assert data['destination'] == {

--- a/tests/tasks/test_move.py
+++ b/tests/tasks/test_move.py
@@ -182,6 +182,7 @@ class TestMoveTask:
             'materialized': str(src_path),
             'provider': src.NAME,
             'kind': 'file',
+            'extra': {},
         }
 
         assert data['destination'] == {

--- a/waterbutler/core/exceptions.py
+++ b/waterbutler/core/exceptions.py
@@ -31,8 +31,7 @@ class WaterButlerError(Exception):
 
 
 class InvalidParameters(WaterButlerError):
-    """Errors regarding incorrect
-    data being sent to a method should raise either this
+    """Errors regarding incorrect data being sent to a method should raise either this
     Exception or a subclass thereof
     """
     def __init__(self, message, code=400):

--- a/waterbutler/core/log_payload.py
+++ b/waterbutler/core/log_payload.py
@@ -50,6 +50,7 @@ class LogPayload:
                 'path': self.path.identifier_path if self.provider.NAME in IDENTIFIER_PATHS else '/' + self.path.raw_path,
                 'name': self.path.name,
                 'materialized': self.path.materialized_path,
+                'extra': self.path.extra,
             })
         else:
             payload.update(self.metadata.serialized())

--- a/waterbutler/core/path.py
+++ b/waterbutler/core/path.py
@@ -261,6 +261,11 @@ class WaterButlerPath:
             return None
         return self.__class__.from_parts(self.parts[:-1], folder=True, prepend=self._prepend)
 
+    @property
+    def extra(self):
+        """ Any extra provider-specific properties of the path. """
+        return {}
+
     def child(self, name, _id=None, folder=False):
         """ Create a child of the current WaterButlerPath, propagating prepend and id information to it.
 

--- a/waterbutler/providers/github/metadata.py
+++ b/waterbutler/providers/github/metadata.py
@@ -1,5 +1,7 @@
 import os
 
+from furl import furl
+
 from waterbutler.core import metadata
 
 
@@ -32,6 +34,16 @@ class BaseGitHubMetadata(metadata.BaseMetadata):
 
     def build_path(self, path):
         return super().build_path(path)
+
+    def _json_api_links(self, resource):
+        """Update JSON-API links to add ref, if available"""
+        links = super()._json_api_links(resource)
+
+        if self.ref is not None:
+            for action, link in links.items():
+                links[action] = furl(link).add({'ref': self.ref}).url
+
+        return links
 
 
 class BaseGitHubFileMetadata(BaseGitHubMetadata, metadata.BaseFileMetadata):

--- a/waterbutler/providers/github/path.py
+++ b/waterbutler/providers/github/path.py
@@ -26,6 +26,13 @@ class GitHubPath(path.WaterButlerPath):
         """SHA-1 of this file"""
         return self.identifier[1]
 
+    @property
+    def extra(self):
+        return dict(super().extra, **{
+            'ref': self.branch_ref,
+            'fileSha': self.file_sha,
+        })
+
     def child(self, name, _id=None, folder=False):
         """Pass current branch down to children"""
         if _id is None:

--- a/waterbutler/providers/github/path.py
+++ b/waterbutler/providers/github/path.py
@@ -1,0 +1,33 @@
+from waterbutler.core import path
+
+
+class GitHubPathPart(path.WaterButlerPathPart):
+    def increment_name(self, _id=None):
+        """Overridden to preserve branch from _id upon incrementing"""
+        self._id = _id or (self._id[0], None)
+        self._count += 1
+        return self
+
+
+class GitHubPath(path.WaterButlerPath):
+    """The ``identifier`` for GitHubPaths are tuples of ``(branch_name, file_sha)``.  Children
+    of GitHubPaths inherit their parent's ``branch_name``.  ``file_sha`` may be None if the path
+    has not yet been validated.
+    """
+    PART_CLASS = GitHubPathPart
+
+    @property
+    def branch_ref(self):
+        """Branch name or commit sha in which this file exists"""
+        return self.identifier[0]
+
+    @property
+    def file_sha(self):
+        """SHA-1 of this file"""
+        return self.identifier[1]
+
+    def child(self, name, _id=None, folder=False):
+        """Pass current branch down to children"""
+        if _id is None:
+            _id = (self.branch_ref, None)
+        return super().child(name, _id=_id, folder=folder)

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -94,6 +94,8 @@ class GitHubProvider(provider.BaseProvider):
             self.default_branch = self._repo['default_branch']
 
         branch_ref = kwargs.get('ref') or kwargs.get('branch') or self.default_branch
+        if isinstance(branch_ref, list):
+            raise exceptions.InvalidParameters('Only one ref or branch may be given.')
 
         if path == '/':
             return GitHubPath(path, _ids=[(branch_ref, '')])
@@ -119,6 +121,8 @@ class GitHubProvider(provider.BaseProvider):
 
         path = GitHubPath(path)
         branch_ref = kwargs.get('ref') or kwargs.get('branch') or self.default_branch
+        if isinstance(branch_ref, list):
+            raise exceptions.InvalidParameters('Only one ref or branch may be given.')
 
         for part in path.parts:
             part._id = (branch_ref, None)

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -99,6 +99,8 @@ class GitHubProvider(provider.BaseProvider):
             return GitHubPath(path, _ids=[(branch_ref, '')])
 
         branch_data = await self._fetch_branch(branch_ref)
+
+        # throws Not Found if path not in tree
         await self._search_tree_for_path(path, branch_data['commit']['commit']['tree']['sha'])
 
         path = GitHubPath(path)

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -3,12 +3,12 @@ import json
 
 import furl
 
-from waterbutler.core import path
 from waterbutler.core import streams
 from waterbutler.core import provider
 from waterbutler.core import exceptions
 
 from waterbutler.providers.github import settings
+from waterbutler.providers.github.path import GitHubPath
 from waterbutler.providers.github.metadata import GitHubRevision
 from waterbutler.providers.github.metadata import GitHubFileContentMetadata
 from waterbutler.providers.github.metadata import GitHubFolderContentMetadata
@@ -18,23 +18,6 @@ from waterbutler.providers.github.exceptions import GitHubUnsupportedRepoError
 
 
 GIT_EMPTY_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
-
-
-class GitHubPathPart(path.WaterButlerPathPart):
-    def increment_name(self, _id=None):
-        """Overridden to preserve branch from _id upon incrementing"""
-        self._id = _id or (self._id[0], None)
-        self._count += 1
-        return self
-
-
-class GitHubPath(path.WaterButlerPath):
-    PART_CLASS = GitHubPathPart
-
-    def child(self, name, _id=None, folder=False):
-        if _id is None:
-            _id = (self.identifier[0], None)
-        return super().child(name, _id=_id, folder=folder)
 
 
 class GitHubProvider(provider.BaseProvider):
@@ -133,7 +116,7 @@ class GitHubProvider(provider.BaseProvider):
         return path
 
     async def revalidate_path(self, base, path, folder=False):
-        return base.child(path, _id=((base.identifier[0], None)), folder=folder)
+        return base.child(path, _id=((base.branch_ref, None)), folder=folder)
 
     def can_duplicate_names(self):
         return False
@@ -178,7 +161,7 @@ class GitHubProvider(provider.BaseProvider):
         :param dict kwargs: Ignored
         '''
         data = await self.metadata(path, revision=revision)
-        file_sha = path.identifier[1] or data.extra['fileSha']
+        file_sha = path.file_sha or data.extra['fileSha']
 
         resp = await self.make_request(
             'GET',
@@ -206,7 +189,7 @@ class GitHubProvider(provider.BaseProvider):
                         'content': '',
                         'path': '.gitkeep',
                         'committer': self.committer,
-                        'branch': path.identifier[0],
+                        'branch': path.branch_ref,
                         'message': 'Initial commit'
                     }),
                     expects=(201,),
@@ -215,7 +198,7 @@ class GitHubProvider(provider.BaseProvider):
                 data = await resp.json()
                 latest_sha = data['commit']['sha']
         else:
-            latest_sha = await self._get_latest_sha(ref=path.identifier[0])
+            latest_sha = await self._get_latest_sha(ref=path.branch_ref)
 
         blob = await self._create_blob(stream)
         tree = await self._create_tree({
@@ -236,14 +219,14 @@ class GitHubProvider(provider.BaseProvider):
         })
 
         # Doesn't return anything useful
-        await self._update_ref(commit['sha'], ref=path.identifier[0])
+        await self._update_ref(commit['sha'], ref=path.branch_ref)
 
         # You're hacky
         return GitHubFileTreeMetadata({
             'path': path.path,
             'sha': blob['sha'],
             'size': stream.size,
-        }, commit=commit, ref=path.identifier[0]), not exists
+        }, commit=commit, ref=path.branch_ref), not exists
 
     async def delete(self, path, sha=None, message=None, branch=None,
                confirm_delete=0, **kwargs):
@@ -285,7 +268,7 @@ class GitHubProvider(provider.BaseProvider):
     async def revisions(self, path, sha=None, **kwargs):
         resp = await self.make_request(
             'GET',
-            self.build_repo_url('commits', path=path.path, sha=sha or path.identifier),
+            self.build_repo_url('commits', path=path.path, sha=sha or path.file_sha),
             expects=(200, ),
             throws=exceptions.RevisionsError
         )
@@ -308,7 +291,7 @@ class GitHubProvider(provider.BaseProvider):
             'content': '',
             'path': keep_path.path,
             'committer': self.committer,
-            'branch': path.identifier[0],
+            'branch': path.branch_ref,
             'message': message or settings.UPLOAD_FILE_MESSAGE
         }
 
@@ -330,11 +313,11 @@ class GitHubProvider(provider.BaseProvider):
         data['content']['name'] = path.name
         data['content']['path'] = data['content']['path'].replace('.gitkeep', '')
 
-        return GitHubFolderContentMetadata(data['content'], commit=data['commit'], ref=path.identifier[0])
+        return GitHubFolderContentMetadata(data['content'], commit=data['commit'], ref=path.branch_ref)
 
     async def _delete_file(self, path, message=None, **kwargs):
-        if path.identifier[1]:
-            sha = path.identifier
+        if path.file_sha:
+            sha = path.file_sha
         else:
             sha = (await self.metadata(path)).extra['fileSha']
 
@@ -343,7 +326,7 @@ class GitHubProvider(provider.BaseProvider):
 
         data = {
             'sha': sha,
-            'branch': path.identifier[0],
+            'branch': path.branch_ref,
             'committer': self.committer,
             'message': message or settings.DELETE_FILE_MESSAGE,
         }
@@ -359,7 +342,7 @@ class GitHubProvider(provider.BaseProvider):
         await resp.release()
 
     async def _delete_folder(self, path, message=None, **kwargs):
-        branch_data = await self._fetch_branch(path.identifier[0])
+        branch_data = await self._fetch_branch(path.branch_ref)
 
         old_commit_sha = branch_data['commit']['sha']
         old_commit_tree_sha = branch_data['commit']['commit']['tree']['sha']
@@ -449,7 +432,7 @@ class GitHubProvider(provider.BaseProvider):
         # No need to store data, rely on expects to raise exceptions
         resp = await self.make_request(
             'PATCH',
-            self.build_repo_url('git', 'refs', 'heads', path.identifier[0]),
+            self.build_repo_url('git', 'refs', 'heads', path.branch_ref),
             headers={'Content-Type': 'application/json'},
             data=json.dumps({'sha': commit_sha}),
             expects=(200, ),
@@ -463,7 +446,7 @@ class GitHubProvider(provider.BaseProvider):
         :param GitHubPath path: GitHubPath path object for folder
         :param str message: Commit message
         """
-        branch_data = await self._fetch_branch(path.identifier[0])
+        branch_data = await self._fetch_branch(path.branch_ref)
         old_commit_sha = branch_data['commit']['sha']
         tree_sha = GIT_EMPTY_SHA
         message = message or settings.DELETE_FOLDER_MESSAGE
@@ -489,7 +472,7 @@ class GitHubProvider(provider.BaseProvider):
         # No need to store data, rely on expects to raise exceptions
         await self.make_request(
             'PATCH',
-            self.build_repo_url('git', 'refs', 'heads', path.identifier[0]),
+            self.build_repo_url('git', 'refs', 'heads', path.branch_ref),
             headers={'Content-Type': 'application/json'},
             data=json.dumps({'sha': commit_sha}),
             expects=(200, ),
@@ -610,11 +593,11 @@ class GitHubProvider(provider.BaseProvider):
         return True
 
     def _web_view(self, path):
-        segments = (self.owner, self.repo, 'blob', path.identifier[0], path.path)
+        segments = (self.owner, self.repo, 'blob', path.branch_ref, path.path)
         return provider.build_url(settings.VIEW_URL, *segments)
 
     async def _metadata_folder(self, path, **kwargs):
-        ref = path.identifier[0]
+        ref = path.branch_ref
 
         try:
             # it's cool to use the contents API here because we know path is a dir and won't hit
@@ -644,7 +627,7 @@ class GitHubProvider(provider.BaseProvider):
     async def _metadata_file(self, path, revision=None, **kwargs):
         resp = await self.make_request(
             'GET',
-            self.build_repo_url('commits', path=path.path, sha=revision or path.identifier[0]),
+            self.build_repo_url('commits', path=path.path, sha=revision or path.branch_ref),
             expects=(200, ),
             throws=exceptions.MetadataError,
         )
@@ -673,7 +656,7 @@ class GitHubProvider(provider.BaseProvider):
 
         return GitHubFileTreeMetadata(
             data, commit=latest['commit'], web_view=self._web_view(path),
-            ref=path.identifier[0]
+            ref=path.branch_ref
         )
 
     async def _get_latest_sha(self, ref='master'):
@@ -708,7 +691,7 @@ class GitHubProvider(provider.BaseProvider):
         #     GH (dir):   'foo/bar'
         #     GH (file):  'foo/bar.txt'
 
-        branch = src_path.identifier[0]
+        branch = src_path.branch_ref
         branch_data = await self._fetch_branch(branch)
 
         old_commit_sha = branch_data['commit']['sha']
@@ -786,12 +769,12 @@ class GitHubProvider(provider.BaseProvider):
         if dest_path.is_file:
             assert len(blobs) == 1, 'Destination file should have exactly one candidate'
             return GitHubFileTreeMetadata(
-                blobs[0], commit=commit, ref=dest_path.identifier[0]
+                blobs[0], commit=commit, ref=dest_path.branch_ref
             ), not exists
 
         folder = GitHubFolderTreeMetadata({
             'path': dest_path.path.strip('/')
-        }, commit=commit, ref=dest_path.identifier[0])
+        }, commit=commit, ref=dest_path.branch_ref)
 
         folder.children = []
 
@@ -799,8 +782,8 @@ class GitHubProvider(provider.BaseProvider):
             if item['path'] == src_path.path.rstrip('/'):
                 continue
             if item['type'] == 'tree':
-                folder.children.append(GitHubFolderTreeMetadata(item, ref=dest_path.identifier[0]))
+                folder.children.append(GitHubFolderTreeMetadata(item, ref=dest_path.branch_ref))
             else:
-                folder.children.append(GitHubFileTreeMetadata(item, ref=dest_path.identifier[0]))
+                folder.children.append(GitHubFileTreeMetadata(item, ref=dest_path.branch_ref))
 
         return folder, not exists

--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -19,6 +19,16 @@ logger = logging.getLogger(__name__)
 auth_handler = AuthHandler(settings.AUTH_HANDLERS)
 
 
+def list_or_value(value):
+    assert isinstance(value, list)
+    if len(value) == 0:
+        return None
+    if len(value) == 1:
+        # Remove leading slashes as they break things
+        return value[0].decode('utf-8')
+    return [item.decode('utf-8') for item in value]
+
+
 @tornado.web.stream_request_body
 class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixin):
     PRE_VALIDATORS = {'put': 'prevalidate_put', 'post': 'prevalidate_post'}
@@ -31,6 +41,11 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
         # TODO Find a nicer way to handle this
         if method == 'options':
             return
+
+        self.arguments = {
+            key: list_or_value(value)
+            for key, value in self.request.query_arguments.items()
+        }
 
         self.path = self.path_kwargs['path'] or '/'
         provider = self.path_kwargs['provider']
@@ -46,7 +61,7 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
 
         self.auth = await auth_handler.get(self.resource, provider, self.request)
         self.provider = utils.make_provider(provider, self.auth['auth'], self.auth['credentials'], self.auth['settings'])
-        self.path = await self.provider.validate_v1_path(self.path)
+        self.path = await self.provider.validate_v1_path(self.path, **self.arguments)
 
         self.target_path = None
 

--- a/waterbutler/server/api/v1/provider/movecopy.py
+++ b/waterbutler/server/api/v1/provider/movecopy.py
@@ -87,7 +87,7 @@ class MoveCopyMixin:
                 self.dest_auth['settings']
             )
 
-            self.dest_path = await self.dest_provider.validate_path(self.json['path'])
+            self.dest_path = await self.dest_provider.validate_path(**self.json)
 
         if not getattr(self.provider, 'can_intra_' + action)(self.dest_provider, self.path):
             # this weird signature syntax courtesy of py3.4 not liking trailing commas on kwargs


### PR DESCRIPTION
## Purpose

The v1 WB API doesn't pass query parameters through to the providers, meaning v1 can only operate on the default branch for the connected Github repo.  We also don't return the branch in either the metadata response or the logging payload (in both v0 and v1).

## Changes

- [X] Pass query and body parameters from the v1 server to the provider.
- [X] Add the branch name or ref to the `extra` portion of the Github metadata objects under the `ref` key.
- [ ] Add a `ref` property to GithubPaths and return it in logging payloads.
- [X] Update JSON-API links in v1 responses to add the ref name

## Side effects

* The query parameter code turns multiple occurrences of a parameter into a list of each value.  Since we can only operate on one branch at a time, the provider will return a 400 Bad Request if it receives a list.

## Testing

@TomBaxter is writing a Runscope test for this (014-kakuna).

## Ticket

Resolves:
[#OSF-6152] - Add `?branch=foo` support to v1 github
[#OSF-6153] - Return branch in logging payload

Related:
[OSF-4973](https://openscience.atlassian.net/browse/OSF-4973) - the OSF ticket that discovered this
https://github.com/CenterForOpenScience/osf.io/pull/5240 - An OSF PR that needs this PR to be merged first