### PR TITLE
[CR] logging refactor

### DIFF
--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -20,17 +20,17 @@ class TestBaseMetadata:
     def test_file_json_api_serialize(self):
         file_metadata = utils.MockFileMetadata()
         serialized = file_metadata.json_api_serialized('n0d3z')
-        link_suffix = '/v1/resources/n0d3z/providers/mock/Foo.name'
-        etag = hashlib.sha256('{}::{}'.format('mock', 'etag').encode('utf-8')).hexdigest()
+        link_suffix = '/v1/resources/n0d3z/providers/MockProvider/Foo.name'
+        etag = hashlib.sha256('{}::{}'.format('MockProvider', 'etag').encode('utf-8')).hexdigest()
 
-        assert serialized['id'] == 'mock/Foo.name'
+        assert serialized['id'] == 'MockProvider/Foo.name'
         assert serialized['type'] == 'files'
         assert serialized['attributes'] == {
             'extra': {},
             'kind': 'file',
             'name': 'Foo.name',
             'path': '/Foo.name',
-            'provider': 'mock',
+            'provider': 'MockProvider',
             'materialized': '/Foo.name',
             'etag': etag,
             'contentType': 'application/octet-stream',
@@ -47,17 +47,17 @@ class TestBaseMetadata:
     def test_folder_json_api_serialize(self):
         folder_metadata = utils.MockFolderMetadata()
         serialized = folder_metadata.json_api_serialized('n0d3z')
-        link_suffix = '/v1/resources/n0d3z/providers/mock/Bar/'
-        etag = hashlib.sha256('{}::{}'.format('mock', 'etag').encode('utf-8')).hexdigest()
+        link_suffix = '/v1/resources/n0d3z/providers/MockProvider/Bar/'
+        etag = hashlib.sha256('{}::{}'.format('MockProvider', 'etag').encode('utf-8')).hexdigest()
 
-        assert serialized['id'] == 'mock/Bar/'
+        assert serialized['id'] == 'MockProvider/Bar/'
         assert serialized['type'] == 'files'
         assert serialized['attributes'] == {
             'extra': {},
             'kind': 'folder',
             'name': 'Bar',
             'path': '/Bar/',
-            'provider': 'mock',
+            'provider': 'MockProvider',
             'materialized': '/Bar/',
             'etag': etag,
             'size': None,
@@ -74,7 +74,7 @@ class TestBaseMetadata:
         folder_metadata.children = [utils.MockFileMetadata()]
         serialized = folder_metadata.json_api_serialized('n0d3z')
         child = serialized['attributes']['children'][0]
-        etag = hashlib.sha256('{}::{}'.format('mock', 'etag').encode('utf-8')).hexdigest()
+        etag = hashlib.sha256('{}::{}'.format('MockProvider', 'etag').encode('utf-8')).hexdigest()
 
         assert len(serialized['attributes']['children']) == 1
         assert child == {
@@ -82,7 +82,7 @@ class TestBaseMetadata:
             'kind': 'file',
             'name': 'Foo.name',
             'path': '/Foo.name',
-            'provider': 'mock',
+            'provider': 'MockProvider',
             'materialized': '/Foo.name',
             'etag': etag,
             'contentType': 'application/octet-stream',

--- a/tests/server/api/v0/test_copy.py
+++ b/tests/server/api/v0/test_copy.py
@@ -97,5 +97,5 @@ class TestCopyHandler(utils.MultiProviderHandlerTestCase):
 
         self.mock_send_hook.assert_called_once_with(
             'copy',
-            utils.MockFileMetadata().serialized()
+            utils.MockFileMetadata()
         )

--- a/tests/server/api/v0/test_move.py
+++ b/tests/server/api/v0/test_move.py
@@ -97,5 +97,5 @@ class TestMoveHandler(utils.MultiProviderHandlerTestCase):
 
         self.mock_send_hook.assert_called_once_with(
             'move',
-            utils.MockFileMetadata().serialized()
+            utils.MockFileMetadata()
         )

--- a/tests/tasks/test_copy.py
+++ b/tests/tasks/test_copy.py
@@ -2,12 +2,14 @@ import sys
 import time
 import copy as cp
 import asyncio
+import hashlib
 from unittest import mock
 
 import celery
 import pytest
 
 from waterbutler import tasks  # noqa
+from waterbutler.core import utils as core_utils
 from waterbutler.core.path import WaterButlerPath
 
 import tests.utils as test_utils
@@ -24,7 +26,14 @@ def patch_backend(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def callback(monkeypatch):
-    mock_request = test_utils.MockCoroutine(return_value=test_utils.MockCoroutine(status=200))
+    mock_request = test_utils.MockCoroutine(
+        return_value=mock.Mock(
+            status=200,
+            read=test_utils.MockCoroutine(
+                return_value=b'meowmeowmeow'
+            )
+        )
+    )
     monkeypatch.setattr(copy.utils, 'send_signed_request', mock_request)
     return mock_request
 
@@ -49,6 +58,7 @@ def dest_path():
 def src_provider():
     p = test_utils.MockProvider()
     p.copy.return_value = (test_utils.MockFileMetadata(), True)
+    p.auth['callback_url'] = 'src_callback'
     return p
 
 
@@ -56,6 +66,7 @@ def src_provider():
 def dest_provider():
     p = test_utils.MockProvider()
     p.copy.return_value = (test_utils.MockFileMetadata(), True)
+    p.auth['callback_url'] = 'dest_callback'
     return p
 
 
@@ -74,10 +85,13 @@ def providers(monkeypatch, src_provider, dest_provider):
 @pytest.fixture
 def src_bundle(src_path):
     return {
+        'nid': 'mst3k',
         'path': src_path,
         'provider': {
             'name': 'src',
-            'auth': {},
+            'auth': {
+                'callback_url': '',
+            },
             'settings': {},
             'credentials': {},
         }
@@ -87,10 +101,13 @@ def src_bundle(src_path):
 @pytest.fixture
 def dest_bundle(dest_path):
     return {
+        'nid': 'fbi4u',
         'path': dest_path,
         'provider': {
             'name': 'dest',
-            'auth': {},
+            'auth': {
+                'callback_url': '',
+            },
             'settings': {},
             'credentials': {},
         }
@@ -108,7 +125,7 @@ class TestCopyTask:
         src, dest = providers
         src_bundle, dest_bundle = bundles
 
-        copy.copy(cp.deepcopy(src_bundle), cp.deepcopy(dest_bundle), '', {'auth': {}})
+        copy.copy(cp.deepcopy(src_bundle), cp.deepcopy(dest_bundle))
 
         assert src.copy.called
         src.copy.assert_called_once_with(dest, src_bundle['path'], dest_bundle['path'])
@@ -126,14 +143,14 @@ class TestCopyTask:
         src.copy.side_effect = Exception('This is a string')
 
         with pytest.raises(Exception):
-            copy.copy(cp.deepcopy(src_bundle), cp.deepcopy(dest_bundle), '', {'auth': {}})
+            copy.copy(cp.deepcopy(src_bundle), cp.deepcopy(dest_bundle))
 
         (method, url, data), _ = callback.call_args_list[0]
 
         assert src.copy.called
         src.copy.assert_called_once_with(dest, src_bundle['path'], dest_bundle['path'])
 
-        assert url == ''
+        assert url == 'src_callback'
         assert method == 'PUT'
         assert data['errors'] == ["Exception('This is a string',)"]
 
@@ -144,37 +161,54 @@ class TestCopyTask:
         metadata = test_utils.MockFileMetadata()
         src.copy.return_value = (metadata, False)
 
-        ret1, ret2 = copy.copy(cp.deepcopy(src_bundle), cp.deepcopy(dest_bundle), 'Test.com', {'auth': {'user': 'name'}})
+        ret1, ret2 = copy.copy(cp.deepcopy(src_bundle), cp.deepcopy(dest_bundle))
 
         assert (ret1, ret2) == (metadata, False)
 
-        callback.assert_called_once_with(
-            'PUT',
-            'Test.com',
-            {
-                'errors': [],
-                'action': 'copy',
-                'source': {
-                    'path': '/' + src_path.raw_path,
-                    'name': src_path.name,
-                    'materialized': str(src_path),
-                    'provider': src.NAME,
-                    'kind': 'file',
-                },
-                'destination': metadata.serialized(),
-                'auth': {'user': 'name'},
-                'time': FAKE_TIME + 60,
-                'email': False
-            }
-        )
+        (method, url, data), _ = callback.call_args_list[0]
+        assert method == 'PUT'
+        assert url == 'src_callback'
+        assert data['action'] == 'copy'
+        assert data['auth'] == {'callback_url': 'src_callback'}
+        assert data['email'] == False
+        assert data['errors'] == []
+        assert data['time'] == FAKE_TIME + 60
+
+        assert data['source'] == {
+            'nid': 'mst3k',
+            'resource': 'mst3k',
+            'path': '/' + src_path.raw_path,
+            'name': src_path.name,
+            'materialized': str(src_path),
+            'provider': src.NAME,
+            'kind': 'file',
+        }
+
+        assert data['destination'] == {
+            'nid': 'fbi4u',
+            'resource': 'fbi4u',
+            'path': metadata.path,
+            'name': metadata.name,
+            'materialized': metadata.path,
+            'provider': dest.NAME,
+            'kind': 'file',
+            'contentType': metadata.content_type,
+            'etag': hashlib.sha256(
+                '{}::{}'.format(metadata.provider, metadata.etag)
+                .encode('utf-8')
+            ).hexdigest(),
+            'extra': metadata.extra,
+            'modified': metadata.modified,
+            'size': metadata.size,
+        }
 
     def test_starttime_override(self, event_loop, providers, bundles, callback, mock_time):
         src, dest = providers
         src_bundle, dest_bundle = bundles
 
         stamp = FAKE_TIME
-        copy.copy(cp.deepcopy(src_bundle), cp.deepcopy(dest_bundle), '', {'auth': {}}, start_time=stamp-100)
-        copy.copy(cp.deepcopy(src_bundle), cp.deepcopy(dest_bundle), '', {'auth': {}}, start_time=stamp+100)
+        copy.copy(cp.deepcopy(src_bundle), cp.deepcopy(dest_bundle), start_time=stamp-100)
+        copy.copy(cp.deepcopy(src_bundle), cp.deepcopy(dest_bundle), start_time=stamp+100)
 
         (_, _, data), _ = callback.call_args_list[0]
 

--- a/tests/tasks/test_move.py
+++ b/tests/tasks/test_move.py
@@ -2,12 +2,14 @@ import sys
 import copy
 import time
 import asyncio
+import hashlib
 from unittest import mock
 
 import celery
 import pytest
 
 from waterbutler import tasks  # noqa
+from waterbutler.core import utils as core_utils
 from waterbutler.core.path import WaterButlerPath
 
 import tests.utils as test_utils
@@ -24,8 +26,15 @@ def patch_backend(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def callback(monkeypatch):
-    mock_request = test_utils.MockCoroutine(return_value=test_utils.MockCoroutine(status=200))
-    monkeypatch.setattr(move.utils, 'send_signed_request', mock_request)
+    mock_request = test_utils.MockCoroutine(
+        return_value=mock.Mock(
+            status=200,
+            read=test_utils.MockCoroutine(
+                return_value=b'meowmeowmeow'
+            )
+        )
+    )
+    monkeypatch.setattr(core_utils, 'send_signed_request', mock_request)
     return mock_request
 
 
@@ -49,6 +58,7 @@ def dest_path():
 def src_provider():
     p = test_utils.MockProvider()
     p.move.return_value = (test_utils.MockFileMetadata(), True)
+    p.auth['callback_url'] = 'src_callback'
     return p
 
 
@@ -56,6 +66,7 @@ def src_provider():
 def dest_provider():
     p = test_utils.MockProvider()
     p.move.return_value = (test_utils.MockFileMetadata(), True)
+    p.auth['callback_url'] = 'dest_callback'
     return p
 
 
@@ -74,10 +85,13 @@ def providers(monkeypatch, src_provider, dest_provider):
 @pytest.fixture
 def src_bundle(src_path):
     return {
+        'nid': 'mst3k',
         'path': src_path,
         'provider': {
             'name': 'src',
-            'auth': {},
+            'auth': {
+                'callback_url': '',
+            },
             'settings': {},
             'credentials': {},
         }
@@ -87,10 +101,13 @@ def src_bundle(src_path):
 @pytest.fixture
 def dest_bundle(dest_path):
     return {
+        'nid': 'fbi4u',
         'path': dest_path,
         'provider': {
             'name': 'dest',
-            'auth': {},
+            'auth': {
+                'callback_url': '',
+            },
             'settings': {},
             'credentials': {},
         }
@@ -108,7 +125,7 @@ class TestMoveTask:
         src, dest = providers
         src_bundle, dest_bundle = bundles
 
-        move.move(copy.deepcopy(src_bundle), copy.deepcopy(dest_bundle), '', {'auth': {}})
+        move.move(copy.deepcopy(src_bundle), copy.deepcopy(dest_bundle))
 
         assert src.move.called
         src.move.assert_called_once_with(dest, src_bundle['path'], dest_bundle['path'])
@@ -126,16 +143,16 @@ class TestMoveTask:
         src.move.side_effect = Exception('This is a string')
 
         with pytest.raises(Exception):
-            move.move(copy.deepcopy(src_bundle), copy.deepcopy(dest_bundle), '', {'auth': {}})
+            move.move(copy.deepcopy(src_bundle), copy.deepcopy(dest_bundle))
 
         (method, url, data), _ = callback.call_args_list[0]
 
         assert src.move.called
         src.move.assert_called_once_with(dest, src_bundle['path'], dest_bundle['path'])
 
-        assert url == ''
         assert method == 'PUT'
         assert data['errors'] == ["Exception('This is a string',)"]
+        assert url == 'src_callback'
 
     def test_return_values(self, event_loop, providers, bundles, callback, src_path, dest_path, mock_time):
         src, dest = providers
@@ -144,37 +161,54 @@ class TestMoveTask:
         metadata = test_utils.MockFileMetadata()
         src.move.return_value = (metadata, False)
 
-        ret1, ret2 = move.move(copy.deepcopy(src_bundle), copy.deepcopy(dest_bundle), 'Test.com', {'auth': {'user': 'name'}})
+        ret1, ret2 = move.move(copy.deepcopy(src_bundle), copy.deepcopy(dest_bundle))
 
         assert (ret1, ret2) == (metadata, False)
 
-        callback.assert_called_once_with(
-            'PUT',
-            'Test.com',
-            {
-                'errors': [],
-                'action': 'move',
-                'source': {
-                    'path': '/' + src_path.raw_path,
-                    'name': src_path.name,
-                    'materialized': str(src_path),
-                    'provider': src.NAME,
-                    'kind': 'file',
-                },
-                'destination': metadata.serialized(),
-                'auth': {'user': 'name'},
-                'time': FAKE_TIME + 60,
-                'email': False
-            }
-        )
+        (method, url, data), _ = callback.call_args_list[0]
+        assert method == 'PUT'
+        assert url == 'src_callback'
+        assert data['action'] == 'move'
+        assert data['auth'] == {'callback_url': 'src_callback'}
+        assert data['email'] == False
+        assert data['errors'] == []
+        assert data['time'] == FAKE_TIME + 60
+
+        assert data['source'] == {
+            'nid': 'mst3k',
+            'resource': 'mst3k',
+            'path': '/' + src_path.raw_path,
+            'name': src_path.name,
+            'materialized': str(src_path),
+            'provider': src.NAME,
+            'kind': 'file',
+        }
+
+        assert data['destination'] == {
+            'nid': 'fbi4u',
+            'resource': 'fbi4u',
+            'path': metadata.path,
+            'name': metadata.name,
+            'materialized': metadata.path,
+            'provider': dest.NAME,
+            'kind': 'file',
+            'contentType': metadata.content_type,
+            'etag': hashlib.sha256(
+                '{}::{}'.format(metadata.provider, metadata.etag)
+                .encode('utf-8')
+            ).hexdigest(),
+            'extra': metadata.extra,
+            'modified': metadata.modified,
+            'size': metadata.size,
+        }
 
     def test_starttime_override(self, event_loop, providers, bundles, callback, mock_time):
         src, dest = providers
         src_bundle, dest_bundle = bundles
 
         stamp = FAKE_TIME
-        move.move(copy.deepcopy(src_bundle), copy.deepcopy(dest_bundle), '', {'auth': {}}, start_time=stamp-100)
-        move.move(copy.deepcopy(src_bundle), copy.deepcopy(dest_bundle), '', {'auth': {}}, start_time=stamp+100)
+        move.move(copy.deepcopy(src_bundle), copy.deepcopy(dest_bundle), start_time=stamp-100)
+        move.move(copy.deepcopy(src_bundle), copy.deepcopy(dest_bundle), start_time=stamp+100)
 
         (_, _, data), _ = callback.call_args_list[0]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,7 +21,7 @@ class MockCoroutine(mock.Mock):
 
 
 class MockFileMetadata(metadata.BaseFileMetadata):
-    provider = 'mock'
+    provider = 'MockProvider'
     name = 'Foo.name'
     size = 1337
     etag = 'etag'
@@ -34,7 +34,7 @@ class MockFileMetadata(metadata.BaseFileMetadata):
 
 
 class MockFolderMetadata(metadata.BaseFolderMetadata):
-    provider = 'mock'
+    provider = 'MockProvider'
     name = 'Bar'
     size = 1337
     etag = 'etag'

--- a/waterbutler/auth/osf/handler.py
+++ b/waterbutler/auth/osf/handler.py
@@ -82,11 +82,14 @@ class OsfAuthHandler(auth.BaseAuthHandler):
         if view_only:
             view_only = view_only[0].decode()
 
-        return (await self.make_request(
+        payload = (await self.make_request(
             self.build_payload(bundle, cookie=cookie, view_only=view_only),
             headers,
             dict(request.cookies)
         ))
+
+        payload['auth']['callback_url'] = payload['callback_url']
+        return payload
 
     async def get(self, resource, provider, request):
         """Used for v1"""
@@ -104,7 +107,7 @@ class OsfAuthHandler(auth.BaseAuthHandler):
             # View only must go outside of the jwt
             view_only = view_only[0].decode()
 
-        return (await self.make_request(
+        payload = (await self.make_request(
             self.build_payload({
                 'nid': resource,
                 'provider': provider,
@@ -113,3 +116,6 @@ class OsfAuthHandler(auth.BaseAuthHandler):
             headers,
             dict(request.cookies)
         ))
+
+        payload['auth']['callback_url'] = payload['callback_url']
+        return payload

--- a/waterbutler/core/log_payload.py
+++ b/waterbutler/core/log_payload.py
@@ -1,0 +1,62 @@
+from waterbutler.constants import IDENTIFIER_PATHS
+from waterbutler.core.path import WaterButlerPath
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class LogPayload:
+    """Simple wrapper class to abstract the object being logged.  Expects the parent resource,
+    provider, and either a metadata or WaterButlerPath object.
+    """
+
+    def __init__(self, resource, provider, metadata=None, path=None):
+        if path is None and metadata is None:
+            raise Exception("Log payload needs either a path or metadata.")
+
+        self.resource = resource
+        self.provider = provider
+        self.metadata = metadata
+        self.path = path or WaterButlerPath.from_metadata(metadata)
+
+    def serialize(self):
+        """Turn this LogPayload into something decent for mixed company.
+
+        A serialized LogPayload will always have the following keys::
+
+            {
+              'kind': 'file', // 'file' or 'folder'
+              'materialized': '/foo/bar/baz', // 'full human-readable path'
+              'name': 'baz', // just the file or folder basename
+              'nid': 'mst3k',  // same thing as 'resource', kept for backcompat
+              'path': '/foo/bar/baz', // path of the file, differs from materialized if provider uses IDs
+              'provider': 'osfstorage', // the provider being connected to
+              'resource': 'mst3k', // the parent entity controlling access to the provider
+            }
+
+        If a metadata object is available it will also contain the `etag` and `extra` properties.
+        Metadata is `None` when the operation is a DELETE, or when constructing a source payload
+        for a move/copy operation.
+        """
+        payload = {
+            'nid': self.resource,
+            'resource': self.resource,
+        }
+        if self.metadata is None:
+            payload.update({
+                'provider': self.provider.NAME,
+                'kind': self.path.kind,
+                'path': self.path.identifier_path if self.provider.NAME in IDENTIFIER_PATHS else '/' + self.path.raw_path,
+                'name': self.path.name,
+                'materialized': self.path.materialized_path,
+            })
+        else:
+            payload.update(self.metadata.serialized())
+
+        return payload
+
+    @property
+    def auth(self):
+        """The auth object for the entity.  Contains the callback_url."""
+        return self.provider.auth

--- a/waterbutler/core/metadata.py
+++ b/waterbutler/core/metadata.py
@@ -21,6 +21,7 @@ class BaseMetadata(metaclass=abc.ABCMeta):
           "materialized": "",
           "provider": "",
           "etag": "",
+          "extra": {}
         }
     """
 

--- a/waterbutler/core/path.py
+++ b/waterbutler/core/path.py
@@ -139,6 +139,11 @@ class WaterButlerPath:
 
         return cls(path, _ids=_ids, folder=folder, **kwargs)
 
+    @classmethod
+    def from_metadata(cls, metadata, **kwargs):
+        _ids = metadata.path.rstrip('/').split('/') or []
+        return cls(metadata.materialized_path, _ids=_ids, folder=metadata.is_folder, **kwargs)
+
     def __init__(self, path, _ids=(), prepend=None, folder=None):
         self.__class__.generic_path_validation(path)
 

--- a/waterbutler/core/path.py
+++ b/waterbutler/core/path.py
@@ -88,6 +88,14 @@ class WaterButlerPath:
     is available through the `.raw_path()` method.
 
     To get a human-readable materialized path, call `str()` on the WaterButlerPath.
+
+    Representations::
+
+        path.path()
+        path.raw_path()
+        path.full_path()
+        path.materialized_path()
+
     """
 
     PART_CLASS = WaterButlerPathPart
@@ -234,6 +242,11 @@ class WaterButlerPath:
         return '/'.join([x.value for x in self._prepend_parts + self.parts[1:]]) + ('/' if self.is_dir else '')
 
     @property
+    def materialized_path(self):
+        """ Returns the user-readable unix-style path without the storage root prepended. """
+        return '/'.join([x.value for x in self.parts]) + ('/' if self.is_dir else '')
+
+    @property
     def parent(self):
         """ Returns a new WaterButlerPath that represents the parent of the current path.
 
@@ -250,7 +263,10 @@ class WaterButlerPath:
         :param _id: the id of the child entity (defaults to None)
         :param bool folder: whether or not the child is a folder (defaults to False)
         """
-        return self.__class__.from_parts(self.parts + [self.PART_CLASS(name, _id=_id)], folder=folder, prepend=self._prepend)
+        return self.__class__.from_parts(
+            self.parts + [self.PART_CLASS(name, _id=_id)],
+            folder=folder, prepend=self._prepend
+        )
 
     def increment_name(self):
         self._parts[-1].increment_name()
@@ -264,8 +280,7 @@ class WaterButlerPath:
         return isinstance(other, self.__class__) and str(self) == str(other)
 
     def __str__(self):
-        """ Returns the materialized path """
-        return '/'.join([x.value for x in self.parts]) + ('/' if self.is_dir else '')
+        return self.materialized_path
 
     def __repr__(self):
         return '{}({!r}, prepend={!r})'.format(self.__class__.__name__, self._orig_path, self._prepend)

--- a/waterbutler/core/utils.py
+++ b/waterbutler/core/utils.py
@@ -1,4 +1,5 @@
 import json
+import time
 import asyncio
 import logging
 import functools
@@ -10,6 +11,7 @@ from stevedore import driver
 
 from waterbutler import settings
 from waterbutler.core import exceptions
+from waterbutler.tasks import settings as task_settings
 from waterbutler.server import settings as server_settings
 from waterbutler.core.signing import Signer
 
@@ -101,6 +103,37 @@ async def send_signed_request(method, url, payload):
         }),
         headers={'Content-Type': 'application/json'},
     ))
+
+
+async def log_to_callback(action, source=None, destination=None, start_time=None, errors=[]):
+    log_payload = {
+        'action': action,
+        'auth': source.auth,
+        'time': time.time() + 60,
+        'errors': errors,
+    }
+
+    if start_time:
+        log_payload['email'] = time.time() - start_time > task_settings.WAIT_TIMEOUT
+
+    if action in ('move', 'copy'):
+        log_payload['source'] = source.serialize()
+        log_payload['destination'] = destination.serialize()
+    else:
+        log_payload['metadata'] = source.serialize()
+        log_payload['provider'] = log_payload['metadata']['provider']
+
+    resp = await send_signed_request('PUT', source.provider.auth['callback_url'], log_payload)
+    resp_data = await resp.read()
+
+    if resp.status // 100 != 2:
+        raise Exception(
+            'Callback for {} request failed with {!r}, got {}'.format(
+                action, resp, resp_data.decode('utf-8')
+            )
+        )
+
+    logger.info('Callback for {} request succeeded with {}'.format(action, resp_data.decode('utf-8')))
 
 
 class ZipStreamGenerator:

--- a/waterbutler/core/utils.py
+++ b/waterbutler/core/utils.py
@@ -22,13 +22,14 @@ sentry_dsn = settings.get('SENTRY_DSN', None)
 client = Client(sentry_dsn) if sentry_dsn else None
 
 
-def make_provider(name, auth, credentials, settings):
+def make_provider(name, auth, credentials, settings, **kwargs):
     """Returns an instance of :class:`waterbutler.core.provider.BaseProvider`
 
     :param str name: The name of the provider to instantiate. (s3, box, etc)
     :param dict auth:
     :param dict credentials:
     :param dict settings:
+    :param dict \*\*kwargs: currently there to absorb ``callback_url``
 
     :rtype: :class:`waterbutler.core.provider.BaseProvider`
     """

--- a/waterbutler/server/api/v0/copy.py
+++ b/waterbutler/server/api/v0/copy.py
@@ -21,8 +21,6 @@ class CopyHandler(core.BaseCrossProviderHandler):
                 'path': self.json['destination']['path'],
                 'provider': self.destination_provider.serialized()
             },
-                self.callback_url,
-                self.auth,
                 rename=self.json.get('rename'),
                 conflict=self.json.get('conflict', 'replace'),
                 start_time=time.time()
@@ -41,14 +39,12 @@ class CopyHandler(core.BaseCrossProviderHandler):
                 )
             )
 
-        metadata = metadata.serialized()
-
         if created:
             self.set_status(201)
         else:
             self.set_status(200)
 
-        self.write(metadata)
+        self.write(metadata.serialized())
 
         if self.source_provider.can_intra_copy(self.destination_provider, self.json['source']['path']):
             self._send_hook('copy', metadata)

--- a/waterbutler/server/api/v0/move.py
+++ b/waterbutler/server/api/v0/move.py
@@ -21,8 +21,6 @@ class MoveHandler(core.BaseCrossProviderHandler):
                 'path': self.json['destination']['path'],
                 'provider': self.destination_provider.serialized()
             },
-                self.callback_url,
-                self.auth,
                 rename=self.json.get('rename'),
                 conflict=self.json.get('conflict', 'replace'),
                 start_time=time.time()
@@ -42,14 +40,12 @@ class MoveHandler(core.BaseCrossProviderHandler):
                 )
             )
 
-        metadata = metadata.serialized()
-
         if created:
             self.set_status(201)
         else:
             self.set_status(200)
 
-        self.write(metadata)
+        self.write(metadata.serialized())
 
         if self.source_provider.can_intra_move(self.destination_provider, self.json['source']['path']):
             self._send_hook('move', metadata)

--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -138,6 +138,10 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
         destination = None
 
         if action in ('move', 'copy'):
+            # if provider can't intra_move or copy, then the celery task will take care of logging
+            if not getattr(self.provider, 'can_intra_' + action)(self.dest_provider, self.path):
+                return
+
             destination = LogPayload(
                 self.dest_resource,
                 self.dest_provider,

--- a/waterbutler/server/api/v1/provider/create.py
+++ b/waterbutler/server/api/v1/provider/create.py
@@ -89,17 +89,17 @@ class CreateMixin:
             self.target_path = self.path
 
     async def create_folder(self):
-        metadata = await self.provider.create_folder(self.target_path)
+        self.metadata = await self.provider.create_folder(self.target_path)
         self.set_status(201)
-        self.write({'data': metadata.json_api_serialized(self.resource)})
+        self.write({'data': self.metadata.json_api_serialized(self.resource)})
 
     async def upload_file(self):
         self.writer.write_eof()
 
-        metadata, created = await self.uploader
+        self.metadata, created = await self.uploader
         self.writer.close()
         self.wsock.close()
         if created:
             self.set_status(201)
 
-        self.write({'data': metadata.json_api_serialized(self.resource)})
+        self.write({'data': self.metadata.json_api_serialized(self.resource)})

--- a/waterbutler/server/api/v1/provider/movecopy.py
+++ b/waterbutler/server/api/v1/provider/movecopy.py
@@ -46,7 +46,7 @@ class MoveCopyMixin:
             'nid': self.dest_resource,
             'path': self.dest_path,
             'provider': self.dest_provider.serialized()
-        }, self.auth['callback_url'], self.auth)
+        })
 
     async def move_or_copy(self):
         # Force the json body to load into memory

--- a/waterbutler/tasks/copy.py
+++ b/waterbutler/tasks/copy.py
@@ -1,65 +1,47 @@
-import sys
 import time
 import logging
 
 from waterbutler.core import utils
 from waterbutler.tasks import core
-from waterbutler.tasks import settings
-from waterbutler.constants import IDENTIFIER_PATHS
+from waterbutler.core.path import WaterButlerPath
+from waterbutler.core.log_payload import LogPayload
+
 
 logger = logging.getLogger(__name__)
 
 
 @core.celery_task
-async def copy(src_bundle, dest_bundle, callback_url, auth, start_time=None, **kwargs):
+async def copy(src_bundle, dest_bundle, start_time=None, **kwargs):
     start_time = start_time or time.time()
+
     src_path, src_provider = src_bundle.pop('path'), utils.make_provider(**src_bundle.pop('provider'))
     dest_path, dest_provider = dest_bundle.pop('path'), utils.make_provider(**dest_bundle.pop('provider'))
 
-    data = {
-        'errors': [],
-        'action': 'copy',
-        'source': dict(src_bundle, **{
-            'path': src_path.identifier_path if src_provider.NAME in IDENTIFIER_PATHS else '/' + src_path.raw_path,
-            'name': src_path.name,
-            'materialized': str(src_path),
-            'provider': src_provider.NAME,
-            'kind': src_path.kind,
-        }),
-        'destination': dict(dest_bundle, **{
-            'path': dest_path.identifier_path if dest_provider.NAME in IDENTIFIER_PATHS else '/' + dest_path.raw_path,
-            'name': dest_path.name,
-            'materialized': str(dest_path),
-            'provider': dest_provider.NAME,
-            'kind': dest_path.kind,
-        }),
-        'auth': auth['auth'],
-    }
+    logger.info('Starting copying {!r}, {!r} to {!r}, {!r}'
+                .format(src_path, src_provider, dest_path, dest_provider))
 
-    logger.info('Starting copying {!r}, {!r} to {!r}, {!r}'.format(src_path, src_provider, dest_path, dest_provider))
-
+    metadata, errors = None, []
     try:
         metadata, created = await src_provider.copy(dest_provider, src_path, dest_path, **kwargs)
     except Exception as e:
         logger.error('Copy failed with error {!r}'.format(e))
-        data.update({'errors': [e.__repr__()]})
+        errors = [e.__repr__()]
         raise  # Ensure sentry sees this
     else:
         logger.info('Copy succeeded')
-        data.update({'destination': dict(src_bundle, **metadata.serialized())})
+        dest_path = WaterButlerPath.from_metadata(metadata)
     finally:
-        resp = await utils.send_signed_request('PUT', callback_url, dict(data, **{
-            'time': time.time() + 60,
-            'email': time.time() - start_time > settings.WAIT_TIMEOUT
-        }))
-        logger.info('Callback returned {!r}'.format(resp))
+        source = LogPayload(src_bundle['nid'], src_provider, path=src_path)
+        destination = LogPayload(
+            dest_bundle['nid'], dest_provider, path=dest_path, metadata=metadata
+        )
 
-        resp_data = await resp.read()
-        if resp.status // 100 != 2:
-            raise Exception(
-                'Callback failed with {!r}, got {}'.format(resp, resp_data.decode('utf-8'))
-            ) from sys.exc_info()[1]
-
-        logger.info('Callback succeeded with {}'.format(resp_data.decode('utf-8')))
+        await utils.log_to_callback(
+            'copy',
+            source=source,
+            destination=destination,
+            start_time=start_time,
+            errors=errors,
+        )
 
     return metadata, created

--- a/waterbutler/tasks/move.py
+++ b/waterbutler/tasks/move.py
@@ -1,65 +1,46 @@
-import sys
 import time
 import logging
 
 from waterbutler.core import utils
 from waterbutler.tasks import core
-from waterbutler.tasks import settings
-from waterbutler.constants import IDENTIFIER_PATHS
+from waterbutler.core.path import WaterButlerPath
+from waterbutler.core.log_payload import LogPayload
+
 
 logger = logging.getLogger(__name__)
 
 
 @core.celery_task
-async def move(src_bundle, dest_bundle, callback_url, auth, start_time=None, **kwargs):
+async def move(src_bundle, dest_bundle, start_time=None, **kwargs):
     start_time = start_time or time.time()
+
     src_path, src_provider = src_bundle.pop('path'), utils.make_provider(**src_bundle.pop('provider'))
     dest_path, dest_provider = dest_bundle.pop('path'), utils.make_provider(**dest_bundle.pop('provider'))
 
-    data = {
-        'errors': [],
-        'action': 'move',
-        'source': dict(src_bundle, **{
-            'path': src_path.identifier_path if src_provider.NAME in IDENTIFIER_PATHS else '/' + src_path.raw_path,
-            'name': src_path.name,
-            'materialized': str(src_path),
-            'provider': src_provider.NAME,
-            'kind': src_path.kind,
-        }),
-        'destination': dict(dest_bundle, **{
-            'path': dest_path.identifier_path if dest_provider.NAME in IDENTIFIER_PATHS else '/' + dest_path.raw_path,
-            'name': dest_path.name,
-            'materialized': str(dest_path),
-            'provider': dest_provider.NAME,
-            'kind': dest_path.kind,
-        }),
-        'auth': auth['auth'],
-    }
-
     logger.info('Starting moving {!r}, {!r} to {!r}, {!r}'.format(src_path, src_provider, dest_path, dest_provider))
 
+    metadata, errors = None, []
     try:
         metadata, created = await src_provider.move(dest_provider, src_path, dest_path, **kwargs)
     except Exception as e:
         logger.error('Move failed with error {!r}'.format(e))
-        data.update({'errors': [e.__repr__()]})
+        errors = [e.__repr__()]
         raise  # Ensure sentry sees this
     else:
         logger.info('Move succeeded')
-        data.update({'destination': dict(src_bundle, **metadata.serialized())})
+        dest_path = WaterButlerPath.from_metadata(metadata)
     finally:
-        resp = await utils.send_signed_request('PUT', callback_url, dict(data, **{
-            'time': time.time() + 60,
-            'email': time.time() - start_time > settings.WAIT_TIMEOUT
-        }))
-        logger.info('Callback returned {!r}'.format(resp))
+        source = LogPayload(src_bundle['nid'], src_provider, path=src_path)
+        destination = LogPayload(
+            dest_bundle['nid'], dest_provider, path=dest_path, metadata=metadata
+        )
 
-        resp_data = await resp.read()
-        if resp.status // 100 != 2:
-            raise Exception(
-                'Callback failed with {!r}, got {}'.format(resp, resp_data.decode('utf-8'))
-            ) from sys.exc_info()[1]
-
-        logger.info('Callback succeeded with {}'.format(resp_data.decode('utf-8')))
+        await utils.log_to_callback(
+            'move',
+            source=source,
+            destination=destination,
+            start_time=start_time,
+            errors=errors
+        )
 
     return metadata, created


### PR DESCRIPTION
We construct and send logging payloads in at least five different places.  Making these all behave the same is a huge pain, and we've frequently gotten it wrong in the past.  This PR collects all logging
behavior into one method and updates the server endpoints to use it.

I've added a simple LogPayload object to standardize the representation of the path and metadata objects we serialize.

[#OSF-6316]