### PR TITLE
Allow non-cookie cross-origin requests

### DIFF
--- a/tests/server/test_utils.py
+++ b/tests/server/test_utils.py
@@ -28,16 +28,17 @@ class MockRequest(object):
             self,
             origin=None,
             method='GET',
-            cookies=None,
+            cookies=False,
             headers=None
     ):
         self.origin = origin or ''
         self.method = method
-        self.cookies = cookies or True
+        self.cookies = cookies
         self.headers = headers or {
             'Origin': origin
         }
 
+@mock.patch('waterbutler.server.settings.CORS_ALLOW_ORIGIN', '')
 class TestCORsMixin(ServerTestCase):
 
     def setUp(self, *args, **kwargs):
@@ -62,7 +63,7 @@ class TestCORsMixin(ServerTestCase):
         for method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
             self.handler.request = MockRequest(
                 origin=origin,
-                method='GET',
+                method=method,
                 cookies=True
             )
             self.handler.set_default_headers()
@@ -75,7 +76,7 @@ class TestCORsMixin(ServerTestCase):
         for method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
             self.handler.request = MockRequest(
                 origin=origin,
-                method='GET',
+                method=method,
                 cookies=False,
                 headers=None
             )
@@ -88,12 +89,12 @@ class TestCORsMixin(ServerTestCase):
 
         for method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
             self.handler.request = MockRequest(
-                origin=origin,
-                method='GET',
+                method=method,
                 cookies=False,
                 headers={
+                    'Origin': origin,
                     'Authorization': 'asdlisdfgluiwgqruf'
                 }
             )
             self.handler.set_default_headers()
-            assert origin not in self.handler.headers['Access-Control-Allow-Origin']
+            assert origin in self.handler.headers['Access-Control-Allow-Origin']

--- a/tests/server/test_utils.py
+++ b/tests/server/test_utils.py
@@ -1,0 +1,99 @@
+import pytest
+from http import client
+from unittest import mock
+import functools
+
+import aiohttp
+
+from tornado import gen
+from tornado import testing
+from tornado import httpclient
+
+from tests import utils
+from tests.server.api.v1.utils import ServerTestCase
+
+from waterbutler.server.utils import CORsMixin
+
+class MockHandler(CORsMixin):
+
+    request = None
+    headers = {}
+
+    def set_header(self, key, value):
+        self.headers[key] = value
+
+class MockRequest(object):
+
+    def __init__(
+            self,
+            origin=None,
+            method='GET',
+            cookies=None,
+            headers=None
+    ):
+        self.origin = origin or ''
+        self.method = method
+        self.cookies = cookies or True
+        self.headers = headers or {
+            'Origin': origin
+        }
+
+class TestCORsMixin(ServerTestCase):
+
+    def setUp(self, *args, **kwargs):
+        super(TestCORsMixin, self).setUp(*args, **kwargs)
+        self.handler = MockHandler()
+
+    @testing.gen_test
+    def test_set_default_headers_options(self):
+        origin = 'http://foo.com'
+
+        self.handler.request = MockRequest(
+            origin=origin,
+            method='OPTIONS'
+        )
+        self.handler.set_default_headers()
+        assert origin == self.handler.headers['Access-Control-Allow-Origin']
+
+    @testing.gen_test
+    def test_set_default_headers_cross_origin_with_cookie(self):
+        origin = 'http://foo.com'
+
+        for method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
+            self.handler.request = MockRequest(
+                origin=origin,
+                method='GET',
+                cookies=True
+            )
+            self.handler.set_default_headers()
+            assert origin not in self.handler.headers['Access-Control-Allow-Origin']
+
+    @testing.gen_test
+    def test_set_default_headers_cross_origin_no_cookie_no_auth_header(self):
+        origin = 'http://foo.com'
+
+        for method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
+            self.handler.request = MockRequest(
+                origin=origin,
+                method='GET',
+                cookies=False,
+                headers=None
+            )
+            self.handler.set_default_headers()
+            assert origin not in self.handler.headers['Access-Control-Allow-Origin']
+
+    @testing.gen_test
+    def test_set_default_headers_cross_origin_no_cookie_but_auth_header(self):
+        origin = 'http://foo.com'
+
+        for method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
+            self.handler.request = MockRequest(
+                origin=origin,
+                method='GET',
+                cookies=False,
+                headers={
+                    'Authorization': 'asdlisdfgluiwgqruf'
+                }
+            )
+            self.handler.set_default_headers()
+            assert origin not in self.handler.headers['Access-Control-Allow-Origin']

--- a/waterbutler/server/utils.py
+++ b/waterbutler/server/utils.py
@@ -39,7 +39,7 @@ class CORsMixin:
 
     def set_default_headers(self):
         if self._cross_origin_is_allowed():
-            self.set_header('Access-Control-Allow-Origin', self.request.headers.get('Origin'))
+            self.set_header('Access-Control-Allow-Origin', self.request.headers.get('Origin', settings.CORS_ALLOW_ORIGIN))
         elif isinstance(settings.CORS_ALLOW_ORIGIN, str):
             if settings.CORS_ALLOW_ORIGIN == '*':
                 # Wild cards cannot be used with allowCredentials.

--- a/waterbutler/server/utils.py
+++ b/waterbutler/server/utils.py
@@ -30,8 +30,17 @@ def make_disposition(filename):
 
 class CORsMixin:
 
+    def _cross_origin_is_allowed(self):
+        if self.request.method == 'OPTIONS':
+            return True
+        elif not self.request.cookies and self.request.headers.get('Authorization'):
+            return True
+        return False
+
     def set_default_headers(self):
-        if isinstance(settings.CORS_ALLOW_ORIGIN, str):
+        if self._cross_origin_is_allowed():
+            self.set_header('Access-Control-Allow-Origin', self.request.headers.get('Origin'))
+        elif isinstance(settings.CORS_ALLOW_ORIGIN, str):
             if settings.CORS_ALLOW_ORIGIN == '*':
                 # Wild cards cannot be used with allowCredentials.
                 # Match Origin if its specified, makes pdfs and pdbs render properly


### PR DESCRIPTION
# Purpose

Waterbutler was not allowing cross-origin requests as a rule. We want to lessen this restriction some to allow cross-origin requests that are **not** sending cookies but are sending a bearer token.

# Changes

Add a check in `CORsMixin.set_default_headers` to check if a cross-origin request is being made under the circumstances described above. Add unit tests for the CORsMixin.