### PR TITLE
if no Origin header passed, don't set CORS headers

### DIFF
--- a/tests/server/test_utils.py
+++ b/tests/server/test_utils.py
@@ -1,15 +1,8 @@
 import pytest
-from http import client
 from unittest import mock
-import functools
 
-import aiohttp
-
-from tornado import gen
 from tornado import testing
-from tornado import httpclient
 
-from tests import utils
 from tests.server.api.v1.utils import ServerTestCase
 
 from waterbutler.server.utils import CORsMixin
@@ -26,17 +19,14 @@ class MockRequest(object):
 
     def __init__(
             self,
-            origin=None,
             method='GET',
             cookies=False,
-            headers=None
+            headers={}
     ):
-        self.origin = origin or ''
         self.method = method
         self.cookies = cookies
-        self.headers = headers or {
-            'Origin': origin
-        }
+        self.headers = headers
+
 
 @mock.patch('waterbutler.server.settings.CORS_ALLOW_ORIGIN', '')
 class TestCORsMixin(ServerTestCase):
@@ -50,8 +40,54 @@ class TestCORsMixin(ServerTestCase):
         origin = 'http://foo.com'
 
         self.handler.request = MockRequest(
-            origin=origin,
-            method='OPTIONS'
+            method='OPTIONS',
+            headers={
+                'Origin': origin,
+            }
+        )
+        self.handler.set_default_headers()
+        assert origin == self.handler.headers['Access-Control-Allow-Origin']
+
+    @testing.gen_test
+    def test_set_default_headers_options_no_cookie_but_auth_header(self):
+        origin = 'http://foo.com'
+
+        self.handler.request = MockRequest(
+            method='OPTIONS',
+            cookies=False,
+            headers={
+                'Origin': origin,
+                'Authorization': 'fooo'
+            }
+        )
+        self.handler.set_default_headers()
+        assert origin == self.handler.headers['Access-Control-Allow-Origin']
+
+    @testing.gen_test
+    def test_set_default_headers_options_has_cookie_and_auth_header(self):
+        origin = 'http://foo.com'
+
+        self.handler.request = MockRequest(
+            method='OPTIONS',
+            cookies=True,
+            headers={
+                'Origin': origin,
+                'Authorization': 'fooo'
+            }
+        )
+        self.handler.set_default_headers()
+        assert origin == self.handler.headers['Access-Control-Allow-Origin']
+
+    @testing.gen_test
+    def test_set_default_headers_options_has_cookie_no_auth_header(self):
+        origin = 'http://foo.com'
+
+        self.handler.request = MockRequest(
+            method='OPTIONS',
+            cookies=True,
+            headers={
+                'Origin': origin,
+            }
         )
         self.handler.set_default_headers()
         assert origin == self.handler.headers['Access-Control-Allow-Origin']
@@ -60,11 +96,13 @@ class TestCORsMixin(ServerTestCase):
     def test_set_default_headers_cross_origin_with_cookie(self):
         origin = 'http://foo.com'
 
-        for method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
+        for method in ('HEAD', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
             self.handler.request = MockRequest(
-                origin=origin,
                 method=method,
-                cookies=True
+                cookies=True,
+                headers={
+                    'Origin': origin,
+                }
             )
             self.handler.set_default_headers()
             assert origin not in self.handler.headers['Access-Control-Allow-Origin']
@@ -73,12 +111,30 @@ class TestCORsMixin(ServerTestCase):
     def test_set_default_headers_cross_origin_no_cookie_no_auth_header(self):
         origin = 'http://foo.com'
 
-        for method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
+        for method in ('HEAD', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
             self.handler.request = MockRequest(
-                origin=origin,
                 method=method,
                 cookies=False,
-                headers=None
+                headers={
+                    'Origin': origin,
+                }
+
+            )
+            self.handler.set_default_headers()
+            assert origin not in self.handler.headers['Access-Control-Allow-Origin']
+
+    @testing.gen_test
+    def test_set_default_headers_cross_origin_has_cookie_and_auth_header(self):
+        origin = 'http://foo.com'
+
+        for method in ('HEAD', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
+            self.handler.request = MockRequest(
+                method=method,
+                cookies=True,
+                headers={
+                    'Origin': origin,
+                    'Authorization': 'asdlisdfgluiwgqruf'
+                }
             )
             self.handler.set_default_headers()
             assert origin not in self.handler.headers['Access-Control-Allow-Origin']
@@ -87,7 +143,7 @@ class TestCORsMixin(ServerTestCase):
     def test_set_default_headers_cross_origin_no_cookie_but_auth_header(self):
         origin = 'http://foo.com'
 
-        for method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
+        for method in ('HEAD', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
             self.handler.request = MockRequest(
                 method=method,
                 cookies=False,
@@ -98,3 +154,15 @@ class TestCORsMixin(ServerTestCase):
             )
             self.handler.set_default_headers()
             assert origin in self.handler.headers['Access-Control-Allow-Origin']
+
+    @testing.gen_test
+    def test_no_origin_means_no_cors(self):
+        for method in ('OPTIONS', 'HEAD' 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'):
+            self.handler.request = MockRequest(
+                method=method,
+            )
+            self.handler.set_default_headers()
+            assert 'Access-Control-Allow-Origin' not in self.handler.headers
+            assert 'Access-Control-Allow-Credentials' not in self.handler.headers
+            assert 'Access-Control-Allow-Headers' not in self.handler.headers
+            assert 'Access-Control-Expose-Headers' not in self.handler.headers


### PR DESCRIPTION
Non-browser clients may or may not set an Origin header when making a
request, but browsers always should.  Don't set ANY CORS headers if
Origin isn't set.  Non-browser clients don't pay attention to CORS, and
a browser that doesn't set Origin should reject the response.