### PR TITLE
[WIP] Guid sent back in OSF storage response

### DIFF
--- a/waterbutler/core/metadata.py
+++ b/waterbutler/core/metadata.py
@@ -44,6 +44,7 @@ class BaseMetadata(metaclass=abc.ABCMeta):
             'path': self.path,
             'provider': self.provider,
             'materialized': self.materialized_path,
+            'guid': self.guid,
             'etag': hashlib.sha256('{}::{}'.format(self.provider, self.etag).encode('utf-8')).hexdigest(),
         }
 
@@ -126,6 +127,11 @@ class BaseMetadata(metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def kind(self):
         """ `file` or `folder` """
+        raise NotImplementedError
+
+    @abc.abstractproperty
+    def guid(self):
+        """ `not all files have them` """
         raise NotImplementedError
 
     @abc.abstractproperty

--- a/waterbutler/providers/osfstorage/metadata.py
+++ b/waterbutler/providers/osfstorage/metadata.py
@@ -45,6 +45,10 @@ class OsfStorageFileMetadata(BaseOsfStorageItemMetadata, metadata.BaseFileMetada
         return '{}::{}'.format(self.raw['version'], self.path)
 
     @property
+    def guid(self):
+        return self.raw['guid']
+
+    @property
     def extra(self):
         return {
             'version': self.raw['version'],


### PR DESCRIPTION
# Purpose

Currently guids aren't included when files queried through WB for fangorn, the result is nice short guid links can't be generated instantly, this change (with another simple change to osf.io) will include the guid in the response, or display null if the file doesn't have a guid yet.

# Changes
 
Creates a simple property that retrieves the guid from WB call to the v1 api.

# Side Effects 

Should be noted this does nothing without a corresponding change in the v1 api of osf.io.