### PR TITLE
Fix logic for handling google docs extentions

### DIFF
--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -419,6 +419,7 @@ class GoogleDriveProvider(provider.BaseProvider):
                         'mimeType': 'folder' if path.endswith('/') else '',
                     }]
                 parts.append([name, current_part[1]])
+                continue
 
             async with self.request(
                 'GET',


### PR DESCRIPTION
## Purpose:
Fix logic for handling google docs extentions.
This fixes the duplicate folder name of the parent of a google doc file when using the google docs extension in the API call.

## Changes:
Update waterbutler/providers/googledrive/provider.py add "continue" line to logic handling google doc extention.

## Side effects
None

[#OSF-6659]