### PR TITLE
Make guids  be sent in response for OSFstorage

### DIFF
--- a/waterbutler/providers/osfstorage/metadata.py
+++ b/waterbutler/providers/osfstorage/metadata.py
@@ -47,6 +47,7 @@ class OsfStorageFileMetadata(BaseOsfStorageItemMetadata, metadata.BaseFileMetada
     @property
     def extra(self):
         return {
+            'guid': self.raw.get('guid', None),
             'version': self.raw['version'],
             'downloads': self.raw['downloads'],
             'checkout': self.raw['checkout'],


### PR DESCRIPTION
# Purpose

Currently guids aren't included when files queried through WB for fangorn, the result is nice short guid links can't be generated instantly, this change (with another simple change to osf.io) will include the guid in the response, or display null if the file doesn't have a guid yet.

# Changes
 
Creates a simple property that retrieves the guid from WB call to the v1 api.

# Side Effects 

Should be noted this does nothing without a corresponding change in the v1 api of osf.io.