### PR TITLE
[OSF-6405]Registration fails if 2 files in Google Drive have the same name.

### DIFF
--- a/waterbutler/providers/googledrive/metadata.py
+++ b/waterbutler/providers/googledrive/metadata.py
@@ -13,13 +13,13 @@ class BaseGoogleDriveMetadata(metadata.BaseMetadata):
     def provider(self):
         return 'googledrive'
 
-    @property
-    def path(self):
-        return '/' + self._path.raw_path
+    # @property
+    # def path(self):
+    #     return '/' + self._path.raw_path
 
-    @property
-    def materialized_path(self):
-        return str(self._path)
+    # @property
+    # def materialized_path(self):
+    #     return str(self._path)
 
     @property
     def extra(self):
@@ -41,6 +41,14 @@ class GoogleDriveFolderMetadata(BaseGoogleDriveMetadata, metadata.BaseFolderMeta
         return self.raw['title']
 
     @property
+    def path(self):
+        return '/' + self._path.raw_path
+
+    @property
+    def materialized_path(self):
+        return str(self._path)
+
+    @property
     def export_name(self):
         return self.name
 
@@ -58,6 +66,22 @@ class GoogleDriveFileMetadata(BaseGoogleDriveMetadata, metadata.BaseFileMetadata
             ext = utils.get_extension(self.raw)
             title += ext
         return title
+
+    @property
+    def path(self):
+        path = '/' + self._path.raw_path
+        if self.is_google_doc:
+            ext = utils.get_extension(self.raw)
+            path += ext
+        return path
+
+    @property
+    def materialized_path(self):
+        materialized = str(self._path)
+        if self.is_google_doc:
+            ext = utils.get_extension(self.raw)
+            materialized += ext
+        return materialized
 
     @property
     def size(self):
@@ -109,6 +133,22 @@ class GoogleDriveFileRevisionMetadata(GoogleDriveFileMetadata):
             ext = utils.get_extension(self.raw)
             title += ext
         return title
+
+    @property
+    def path(self):
+        path = '/' + self._path.raw_path
+        if self.is_google_doc:
+            ext = utils.get_extension(self.raw)
+            path += ext
+        return path
+
+    @property
+    def materialized_path(self):
+        materialized = str(self._path)
+        if self.is_google_doc:
+            ext = utils.get_extension(self.raw)
+            materialized += ext
+        return materialized
 
     @property
     def size(self):

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -391,7 +391,7 @@ class GoogleDriveProvider(provider.BaseProvider):
             current_part = parts.pop(0)
             name, ext = os.path.splitext(current_part[0])
             if ext in ('.gdoc', '.gdraw', '.gslides', '.gsheet'):
-                gd_ext = drive_utils.get_mimeType_from_ext(ext)
+                gd_ext = drive_utils.get_mimetype_from_ext(ext)
                 query = "title = '{}' " \
                         "and trashed = false " \
                         "and mimeType = '{}'".format(clean_query(name), gd_ext)

--- a/waterbutler/providers/googledrive/utils.py
+++ b/waterbutler/providers/googledrive/utils.py
@@ -36,7 +36,7 @@ def is_docs_file(metadata):
     return metadata.get('exportLinks')
 
 
-def get_mimeType_from_ext(ext):
+def get_mimetype_from_ext(ext):
     for format in DOCS_FORMATS:
         if format['ext'] == ext:
             return format['mime_type']

--- a/waterbutler/providers/googledrive/utils.py
+++ b/waterbutler/providers/googledrive/utils.py
@@ -36,6 +36,12 @@ def is_docs_file(metadata):
     return metadata.get('exportLinks')
 
 
+def get_mimeType_from_ext(ext):
+    for format in DOCS_FORMATS:
+        if format['ext'] == ext:
+            return format['mime_type']
+
+
 def get_format(metadata):
     for format in DOCS_FORMATS:
         if format['mime_type'] == metadata['mimeType']:


### PR DESCRIPTION
## Purpose:

[OSF-6405](https://openscience.atlassian.net/browse/OSF-6405)
Enable the correct handling of google docs files of the same name but different type
## Changes:

Update  waterbutler/providers/googledrive/metadata.py add extension to path and materialized for google docs files.

Update waterbutler/providers/googledrive/provider.py to query by specific mime type for google docs files.

Update waterbutler/providers/googledrive/utils.py add "def get_mimetype_from_ext(ext)"
## Side effects:

None

[#OSF-6405]
