### PR TITLE
[CR] GitLab addon

### DIFF
--- a/docs/provider.gitlab.rst
+++ b/docs/provider.gitlab.rst
@@ -1,0 +1,8 @@
+GitLab Provider
+===============
+
+.. autoclass:: waterbutler.providers.gitlab.provider.GitLabProvider
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :inherited-members:

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -11,6 +11,7 @@ Providers
    provider.figshare
    provider.filesystem
    provider.github
+   provider.gitlab
    provider.googledrive
    provider.osfstorage
    provider.owncloud

--- a/docs/waterbutler.providers.rst
+++ b/docs/waterbutler.providers.rst
@@ -12,6 +12,7 @@ Subpackages
     provider.figshare
     provider.filesystem
     provider.github
+    provider.gitlab
     provider.googledrive
     provider.osfstorage
     provider.s3

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
             'figshare = waterbutler.providers.figshare:FigshareProvider',
             'filesystem = waterbutler.providers.filesystem:FileSystemProvider',
             'github = waterbutler.providers.github:GitHubProvider',
+            'gitlab = waterbutler.providers.gitlab:GitLabProvider',
             'osfstorage = waterbutler.providers.osfstorage:OSFStorageProvider',
             'owncloud = waterbutler.providers.owncloud:OwnCloudProvider',
             's3 = waterbutler.providers.s3:S3Provider',

--- a/tests/providers/gitlab/test_provider.py
+++ b/tests/providers/gitlab/test_provider.py
@@ -1,4 +1,182 @@
 import pytest
 
-def test_first_test():
-    assert 1 == 1
+import io
+import os
+import json
+import base64
+import hashlib
+from http import client
+
+import aiohttpretty
+
+from waterbutler.core import streams
+from waterbutler.core import exceptions
+from waterbutler.core.path import WaterButlerPath
+from waterbutler.core.provider import build_url
+
+from waterbutler.providers.gitlab import GitLabProvider
+from waterbutler.providers.gitlab import settings as gitlab_settings
+from waterbutler.providers.gitlab.provider import GitLabPath
+from waterbutler.providers.gitlab.metadata import GitLabRevision
+from waterbutler.providers.gitlab.metadata import GitLabFileTreeMetadata
+from waterbutler.providers.gitlab.metadata import GitLabFolderTreeMetadata
+from waterbutler.providers.gitlab.metadata import GitLabFileContentMetadata
+from waterbutler.providers.gitlab.metadata import GitLabFolderContentMetadata
+
+@pytest.fixture
+def auth():
+    return {
+        'name': 'cat',
+        'email': 'cat@cat.com',
+    }
+
+
+@pytest.fixture
+def credentials():
+    return {'token': 'naps'}
+
+
+@pytest.fixture
+def settings():
+    return {
+        'owner': 'cat',
+        'repo': 'food',
+        'repo_id': '123',
+        'base_url': 'http://base.url',
+        'view_url': 'http://view.url',
+    }
+
+
+@pytest.fixture
+def repo_metadata():
+    return {
+        'full_name': 'octocat/Hello-World',
+        'settings': {
+            'push': False,
+            'admin': False,
+            'pull': True
+        }
+    }
+
+@pytest.fixture
+def provider(auth, credentials, settings, repo_metadata):
+    provider = GitLabProvider(auth, credentials, settings)
+    return provider
+
+class TestHelpers:
+    def test_build_repo_url(self, provider, settings):
+        expected = 'http://base.url/projects/123/contents'
+        assert provider.build_repo_url('contents') == expected
+
+class TestMetadata:
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_file_with_default_ref(self, provider):
+        path = '/folder1/folder2/file'
+
+        waterbutler_path = GitLabPath(path)
+
+        url = 'http://base.url/projects/123/repository/files?ref=master&file_path=folder1/folder2/file'
+
+        aiohttpretty.register_json_uri('GET', url, body={
+                'file_name': 'file',
+                'blob_id': 'abc123',
+                'commit_id': 'xxxyyy',
+                'file_path': '/folder1/folder2/file',
+                'size': '123'
+            }
+        )
+
+        result = await provider.metadata(waterbutler_path)
+
+        assert result.name == 'file'
+        assert result.size == '123'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_file_with_ref(self, provider):
+        path = '/folder1/folder2/file'
+
+        waterbutler_path = GitLabPath(path)
+
+        url = 'http://base.url/projects/123/repository/files?ref=my-branch&file_path=folder1/folder2/file'
+
+        aiohttpretty.register_json_uri('GET', url, body={
+                'file_name': 'file',
+                'blob_id': 'abc123',
+                'commit_id': 'xxxyyy',
+                'file_path': '/folder1/folder2/file',
+                'size': '123'
+            }
+        )
+
+        result = await provider.metadata(waterbutler_path, 'my-branch')
+
+        assert result.name == 'file'
+        assert result.size == '123'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_folder(self, provider):
+        path = '/folder1/folder2/folder3/'
+
+        waterbutler_path = GitLabPath(path)
+
+        url = 'http://base.url/projects/123/repository/tree?path=folder1/folder2/folder3/'
+
+        aiohttpretty.register_json_uri('GET', url, body=[
+            {
+                'id': '123',
+                'type': 'tree',
+                'name': 'my folder'
+            },
+            {
+                'id': '1234',
+                'type': 'file',
+                'name': 'my file'
+            }
+        ])
+
+        result = await provider.metadata(waterbutler_path)
+
+        assert isinstance(result[0], GitLabFolderContentMetadata)
+        assert result[0].name == 'my folder'
+
+        assert result[1].name == 'my file'
+        assert isinstance(result[1], GitLabFileContentMetadata)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_folder_with_sha(self, provider):
+        path = '/folder1/folder2/folder3/'
+
+        waterbutler_path = GitLabPath(path)
+
+        result = await provider.metadata(waterbutler_path, ref='4b825dc642cb6eb9a060e54bf8d69288fbee4904')
+
+        assert result == None
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_folder_recursive(self, provider):
+        path = '/folder1/folder2/folder3/'
+
+        waterbutler_path = GitLabPath(path)
+
+        result = await provider.metadata(waterbutler_path, recursive=True)
+
+        assert result == None
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_folder_with_no_dict_response(self, provider):
+        path = '/folder1/folder2/folder3/'
+
+        waterbutler_path = GitLabPath(path)
+
+        url = 'http://base.url/projects/123/repository/tree?path=folder1/folder2/folder3/'
+
+        aiohttpretty.register_json_uri('GET', url, body={})
+
+        with pytest.raises(exceptions.MetadataError) as exc:
+            await provider.metadata(waterbutler_path)

--- a/tests/providers/gitlab/test_provider.py
+++ b/tests/providers/gitlab/test_provider.py
@@ -239,7 +239,7 @@ class TestUpload:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_delete(self, provider):
+    async def test_upload(self, provider):
         path = '/folder1/file.py'
 
         waterbutler_path = WaterButlerPath(path)

--- a/tests/providers/gitlab/test_provider.py
+++ b/tests/providers/gitlab/test_provider.py
@@ -122,8 +122,7 @@ def settings():
         'owner': 'cat',
         'repo': 'food',
         'repo_id': '123',
-        'base_url': 'http://base.url',
-        'view_url': 'http://view.url',
+        'host': 'http://base.url',
     }
 
 

--- a/tests/providers/gitlab/test_provider.py
+++ b/tests/providers/gitlab/test_provider.py
@@ -19,6 +19,80 @@ def auth():
 
 
 @pytest.fixture
+def gitlab_simple_project_tree():
+    return [
+            {
+                "id": "a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba",
+                "name": "folder1",
+                "type": "tree",
+                "path": "folder1",
+                "mode": "040000"
+            },
+            {
+                "id":"a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba",
+                "name": "file1",
+                "type": "blob",
+                "path": "folder1/file1",
+                "mode": "040000"
+            }
+        ]
+
+
+@pytest.fixture
+def gitlab_example_project_tree():
+    return [
+            {
+                "id": "a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba",
+                "name": "html",
+                "type": "tree",
+                "path": "files/html",
+                "mode": "040000"
+            },
+            {
+                "id": "4535904260b1082e14f867f7a24fd8c21495bde3",
+                "name": "images",
+                "type": "tree",
+                "path": "files/images",
+                "mode": "040000"
+            },
+            {
+                "id": "31405c5ddef582c5a9b7a85230413ff90e2fe720",
+                "name": "js",
+                "type": "tree",
+                "path": "files/js",
+                "mode": "040000"
+            },
+            {
+                "id": "cc71111cfad871212dc99572599a568bfe1e7e00",
+                "name": "lfs",
+                "type": "tree",
+                "path": "files/lfs",
+                "mode": "040000"
+            },
+            {
+                "id": "fd581c619bf59cfdfa9c8282377bb09c2f897520",
+                "name": "markdown",
+                "type": "tree",
+                "path": "files/markdown",
+                "mode": "040000"
+            },
+            {
+                "id": "23ea4d11a4bdd960ee5320c5cb65b5b3fdbc60db",
+                "name": "ruby",
+                "type": "tree",
+                "path": "files/ruby",
+                "mode": "040000"
+            },
+            {
+                "id": "7d70e02340bac451f281cecf0a980907974bd8be",
+                "name": "whitespace",
+                "type": "blob",
+                "path": "files/whitespace",
+                "mode": "100644"
+            }
+        ]
+
+@pytest.fixture
 def credentials():
     return {'token': 'naps'}
 
@@ -190,6 +264,54 @@ class TestDelete:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
+    async def test_delete_folder(self, provider):
+
+        path = '/'
+
+        waterbutler_path = await provider.validate_path(path)
+
+        info_url = 'http://base.url/projects/123/repository/tree?path=/&ref_name=master'
+        sub_url = 'http://base.url/projects/123/repository/tree?path=folder1/&ref_name=master'
+
+        url = 'http://base.url/projects/123/repository/files?commit_message=Folder+/+deleted&file_path=folder1/file1&branch_name=master'
+
+        aiohttpretty.register_json_uri('GET', info_url, body=gitlab_simple_project_tree())
+        aiohttpretty.register_json_uri('GET', sub_url, body={})
+        aiohttpretty.register_json_uri('DELETE', url)
+
+        result = await provider.delete(waterbutler_path, branch='master')
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_delete_complete_folder(self, provider):
+
+        path = '/folder3/'
+
+        waterbutler_path = await provider.validate_path(path)
+
+        info_url = 'http://base.url/projects/123/repository/tree?path=folder3/&ref_name=master'
+        sub1_url = 'http://base.url/projects/123/repository/tree?path=files/html/&ref_name=master'
+        sub2_url = 'http://base.url/projects/123/repository/tree?path=files/images/&ref_name=master'
+        sub3_url = 'http://base.url/projects/123/repository/tree?path=files/js/&ref_name=master'
+        sub4_url = 'http://base.url/projects/123/repository/tree?path=files/lfs/&ref_name=master'
+        sub5_url = 'http://base.url/projects/123/repository/tree?path=files/markdown/&ref_name=master'
+        sub6_url = 'http://base.url/projects/123/repository/tree?path=files/ruby/&ref_name=master'
+
+        file1_url = 'http://base.url/projects/123/repository/files?file_path=files/whitespace&branch_name=master&commit_message=Folder+folder3/+deleted'
+
+        aiohttpretty.register_json_uri('GET', info_url, body=gitlab_example_project_tree())
+        aiohttpretty.register_json_uri('GET', sub1_url, body={})
+        aiohttpretty.register_json_uri('GET', sub2_url, body={})
+        aiohttpretty.register_json_uri('GET', sub3_url, body={})
+        aiohttpretty.register_json_uri('GET', sub4_url, body={})
+        aiohttpretty.register_json_uri('GET', sub5_url, body={})
+        aiohttpretty.register_json_uri('GET', sub6_url, body={})
+        aiohttpretty.register_json_uri('DELETE', file1_url)
+
+        result = await provider.delete(waterbutler_path, branch='master')
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
     async def test_delete_with_custom_message(self, provider):
         path = '/folder1/file.py'
 
@@ -317,49 +439,114 @@ class TestValidatePath:
     @pytest.mark.aiohttpretty
     async def test_validate_path_v1_is_file(self, provider):
         path = '/folder1/file.py'
-        url_get = 'http://base.url/projects/123'
-        aiohttpretty.register_json_uri('GET', url_get, body={'default_branch': 'master'})
+        url = 'http://base.url/projects/123/repository/tree?path=folder1/file.py'
+        aiohttpretty.register_json_uri('GET', url, body={})
 
-        validated_path = await provider.validate_v1_path(path)
+        validated = await provider.validate_v1_path(path)
 
-        assert validated_path.is_file
-        assert not validated_path.is_dir
+        assert validated.is_file
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_validate_path_v1_is_dir(self, provider):
-        path = '/folder1/folder2/'
-        url_get = 'http://base.url/projects/123'
-        aiohttpretty.register_json_uri('GET', url_get, body={'default_branch': 'master'})
+        path = '/folder1/'
+        body = gitlab_simple_project_tree()
+        url = 'http://base.url/projects/123/repository/tree?path=folder1/'
+        aiohttpretty.register_json_uri('GET', url, body=body)
 
-        validated_path = await provider.validate_v1_path(path)
+        validated = await provider.validate_v1_path(path)
 
-        assert validated_path.is_dir
-        assert not validated_path.is_file
+        assert validated.is_dir
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_validate_path_v1_with_wrong_http_response(self, provider):
-        path = '/folder1/file.py'
-        url_get = 'http://base.url/projects/123'
-        aiohttpretty.register_json_uri('GET', url_get, status=400)
+    async def test_validate_v1_root(self, provider):
+        path = '/'
+        url_get = 'http://base.url/projects/123/repository/tree?path=/'
+        body = gitlab_simple_project_tree()
+        aiohttpretty.register_json_uri('GET', url_get, body=body, status=200)
 
-        with pytest.raises(exceptions.NotFoundError) as exc:
-            validated_path = await provider.validate_v1_path(path)
+        validated = await provider.validate_v1_path(path)
+
+        assert validated.is_dir
+        assert validated.is_root
+
+    @pytest.mark.asyncio
+    async def test_validate_file_path_from_gitlab(self, provider):
+        path = 'folder1/file.py'
+
+        validated = await provider.validate_v1_path(path)
+
+        assert validated.is_file
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_validate_folder_path_from_gitlab(self, provider):
+        path = 'folder1/'
+        url_get = 'http://base.url/projects/123/repository/tree?path=folder1/'
+        body = gitlab_simple_project_tree()
+        aiohttpretty.register_json_uri('GET', url_get, body=body, status=200)
+
+        validated = await provider.validate_v1_path(path)
+
+        assert validated.is_dir
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_validate_folder_composed_path_from_gitlab(self, provider):
+        path = 'files/html/'
+        url_get = 'http://base.url/projects/123/repository/tree?path=files/html/'
+        body = gitlab_example_project_tree()
+        aiohttpretty.register_json_uri('GET', url_get, body=body, status=200)
+
+        validated = await provider.validate_v1_path(path)
+
+        assert validated.is_dir
 
     @pytest.mark.asyncio
     async def test_validate_path_is_file(self, provider):
         path = '/folder1/file.py'
 
-        validated_path = await provider.validate_path(path)
+        validated = await provider.validate_path(path)
 
-        assert validated_path.is_file
-        assert not validated_path.is_dir
+        assert validated.is_file
 
     @pytest.mark.asyncio
     async def test_validate_path_is_dir(self, provider):
         path = '/folder1/folder2/'
-        validated_path = await provider.validate_path(path)
+        validated = await provider.validate_path(path)
 
-        assert validated_path.is_dir
-        assert not validated_path.is_file
+        assert validated.is_dir
+
+    @pytest.mark.asyncio
+    async def test_validate_file_path_from_gitlab(self, provider):
+        path = 'folder1/file.py'
+
+        validated = await provider.validate_path(path)
+
+        assert validated.is_file
+
+    @pytest.mark.asyncio
+    async def test_validate_folder_path_from_gitlab(self, provider):
+        path = 'folder1/'
+
+        validated = await provider.validate_path(path)
+
+        assert validated.is_dir
+
+    @pytest.mark.asyncio
+    async def test_validate_folder_composed_path_from_gitlab(self, provider):
+        path = 'folder1/folder2/'
+
+        validated = await provider.validate_path(path)
+
+        assert validated.is_dir
+
+    @pytest.mark.asyncio
+    async def test_validate_root(self, provider):
+        path = '/'
+
+        validated = await provider.validate_path(path)
+
+        assert validated.is_dir
+        assert validated.is_root

--- a/tests/providers/gitlab/test_provider.py
+++ b/tests/providers/gitlab/test_provider.py
@@ -64,6 +64,11 @@ def provider(auth, credentials, settings, repo_metadata):
     provider = GitLabProvider(auth, credentials, settings)
     return provider
 
+@pytest.fixture
+def other(auth, credentials, settings, repo_metadata):
+    provider = GitLabProvider(auth, credentials, settings)
+    return provider
+
 class TestHelpers:
     def test_build_repo_url(self, provider, settings):
         expected = 'http://base.url/projects/123/contents'
@@ -310,3 +315,13 @@ class TestCreateFolter:
         aiohttpretty.register_json_uri('PUT', url)
 
         result = await provider.create_folder(waterbutler_path, 'master', 'commit message')
+
+class TestOperations:
+    def test_cant_duplicate_names(self, provider):
+        assert provider.can_duplicate_names() == False
+
+    def test_cant_intra_copy(self, provider, other):
+        assert provider.can_intra_copy(other) == False
+
+    def test_cant_intra_move(self, provider, other):
+        assert provider.can_intra_move(other) == False

--- a/tests/providers/gitlab/test_provider.py
+++ b/tests/providers/gitlab/test_provider.py
@@ -149,7 +149,7 @@ def other(auth, credentials, settings, repo_metadata):
 
 class TestHelpers:
     def test_build_repo_url(self, provider, settings):
-        expected = 'http://base.url/projects/123/contents'
+        expected = 'http://base.url/api/v3/projects/123/contents'
         assert provider.build_repo_url('contents') == expected
 
 class TestMetadata:
@@ -160,7 +160,7 @@ class TestMetadata:
 
         waterbutler_path = WaterButlerPath(path)
 
-        url = 'http://base.url/projects/123/repository/files?ref=master&file_path=folder1/folder2/file'
+        url = 'http://base.url/api/v3/projects/123/repository/files?ref=master&file_path=folder1/folder2/file'
 
         aiohttpretty.register_json_uri('GET', url, body={
                 'file_name': 'file',
@@ -183,7 +183,7 @@ class TestMetadata:
 
         waterbutler_path = WaterButlerPath(path)
 
-        url = 'http://base.url/projects/123/repository/files?ref=my-branch&file_path=folder1/folder2/file'
+        url = 'http://base.url/api/v3/projects/123/repository/files?ref=my-branch&file_path=folder1/folder2/file'
 
         aiohttpretty.register_json_uri('GET', url, body={
                 'file_name': 'file',
@@ -206,7 +206,7 @@ class TestMetadata:
 
         waterbutler_path = WaterButlerPath(path)
 
-        url = 'http://base.url/projects/123/repository/tree?path=folder1/folder2/folder3/'
+        url = 'http://base.url/api/v3/projects/123/repository/tree?path=folder1/folder2/folder3/'
 
         aiohttpretty.register_json_uri('GET', url, body=[
             {
@@ -258,7 +258,7 @@ class TestMetadata:
 
         waterbutler_path = WaterButlerPath(path)
 
-        url = 'http://base.url/projects/123/repository/tree?path=folder1/folder2/folder3/'
+        url = 'http://base.url/api/v3/projects/123/repository/tree?path=folder1/folder2/folder3/'
 
         aiohttpretty.register_json_uri('GET', url, body={})
 
@@ -274,7 +274,7 @@ class TestDelete:
 
         waterbutler_path = WaterButlerPath(path)
 
-        url = 'http://base.url/projects/123/repository/files?commit_message=File+folder1/file.py+deleted&branch_name=master&file_path=folder1/file.py'
+        url = 'http://base.url/api/v3/projects/123/repository/files?commit_message=File+folder1/file.py+deleted&branch_name=master&file_path=folder1/file.py'
 
         aiohttpretty.register_json_uri('DELETE', url)
 
@@ -288,10 +288,10 @@ class TestDelete:
 
         waterbutler_path = await provider.validate_path(path)
 
-        info_url = 'http://base.url/projects/123/repository/tree?path=/&ref_name=master'
-        sub_url = 'http://base.url/projects/123/repository/tree?path=folder1/&ref_name=master'
+        info_url = 'http://base.url/api/v3/projects/123/repository/tree?path=/&ref_name=master'
+        sub_url = 'http://base.url/api/v3/projects/123/repository/tree?path=folder1/&ref_name=master'
 
-        url = 'http://base.url/projects/123/repository/files?commit_message=Folder+/+deleted&file_path=folder1/file1&branch_name=master'
+        url = 'http://base.url/api/v3/projects/123/repository/files?commit_message=Folder+/+deleted&file_path=folder1/file1&branch_name=master'
 
         aiohttpretty.register_json_uri('GET', info_url, body=gitlab_simple_project_tree())
         aiohttpretty.register_json_uri('GET', sub_url, body={})
@@ -307,17 +307,17 @@ class TestDelete:
 
         waterbutler_path = await provider.validate_path(path)
 
-        info_url = 'http://base.url/projects/123/repository/tree?path=folder3/&ref_name=master'
-        sub1_url = 'http://base.url/projects/123/repository/tree?path=files/html/&ref_name=master'
-        sub2_url = 'http://base.url/projects/123/repository/tree?path=files/images/&ref_name=master'
-        sub3_url = 'http://base.url/projects/123/repository/tree?path=files/js/&ref_name=master'
-        sub4_url = 'http://base.url/projects/123/repository/tree?path=files/lfs/&ref_name=master'
-        sub5_url = 'http://base.url/projects/123/repository/tree?path=files/markdown/&ref_name=master'
-        sub6_url = 'http://base.url/projects/123/repository/tree?path=files/ruby/&ref_name=master'
-        sub7_url = 'http://base.url/projects/123/repository/tree?path=files/html/static/&ref_name=master'
+        info_url = 'http://base.url/api/v3/projects/123/repository/tree?path=folder3/&ref_name=master'
+        sub1_url = 'http://base.url/api/v3/projects/123/repository/tree?path=files/html/&ref_name=master'
+        sub2_url = 'http://base.url/api/v3/projects/123/repository/tree?path=files/images/&ref_name=master'
+        sub3_url = 'http://base.url/api/v3/projects/123/repository/tree?path=files/js/&ref_name=master'
+        sub4_url = 'http://base.url/api/v3/projects/123/repository/tree?path=files/lfs/&ref_name=master'
+        sub5_url = 'http://base.url/api/v3/projects/123/repository/tree?path=files/markdown/&ref_name=master'
+        sub6_url = 'http://base.url/api/v3/projects/123/repository/tree?path=files/ruby/&ref_name=master'
+        sub7_url = 'http://base.url/api/v3/projects/123/repository/tree?path=files/html/static/&ref_name=master'
 
-        file1_url = 'http://base.url/projects/123/repository/files?file_path=files/whitespace&branch_name=master&commit_message=Folder+folder3/+deleted'
-        file2_url = 'http://base.url/projects/123/repository/files?file_path=files/html/.gitkeep&branch_name=master&commit_message=Folder+folder3/+deleted'
+        file1_url = 'http://base.url/api/v3/projects/123/repository/files?file_path=files/whitespace&branch_name=master&commit_message=Folder+folder3/+deleted'
+        file2_url = 'http://base.url/api/v3/projects/123/repository/files?file_path=files/html/.gitkeep&branch_name=master&commit_message=Folder+folder3/+deleted'
 
         aiohttpretty.register_json_uri('GET', info_url, body=gitlab_example_project_tree())
         aiohttpretty.register_json_uri('GET', sub1_url, body=gitlab_example_sub_project_tree())
@@ -339,7 +339,7 @@ class TestDelete:
 
         waterbutler_path = WaterButlerPath(path)
 
-        url = 'http://base.url/projects/123/repository/files?commit_message=custom&branch_name=master&file_path=folder1/file.py'
+        url = 'http://base.url/api/v3/projects/123/repository/files?commit_message=custom&branch_name=master&file_path=folder1/file.py'
 
         aiohttpretty.register_json_uri('DELETE', url)
 
@@ -355,7 +355,7 @@ class TestDownload:
 
         waterbutler_path = WaterButlerPath(path)
 
-        url = 'http://base.url/projects/2123/repository/files?commit_message=File+folder1/file.py+deleted&branch_name=master&file_path=folder1/file.py'
+        url = 'http://base.url/api/v3/projects/2123/repository/files?commit_message=File+folder1/file.py+deleted&branch_name=master&file_path=folder1/file.py'
 
         aiohttpretty.register_json_uri('GET', url)
 
@@ -369,7 +369,7 @@ class TestDownload:
 
         waterbutler_path = WaterButlerPath(path)
 
-        url = 'http://base.url/projects/123/repository/files?ref=master&file_path=folder1/file.py'
+        url = 'http://base.url/api/v3/projects/123/repository/files?ref=master&file_path=folder1/file.py'
 
         aiohttpretty.register_json_uri('GET', url, body={
             'content': 'aGVsbG8='
@@ -388,13 +388,13 @@ class TestUpload:
 
         waterbutler_path = WaterButlerPath(path)
 
-        url = 'http://base.url/projects/123/repository/files'
+        url = 'http://base.url/api/v3/projects/123/repository/files'
         aiohttpretty.register_json_uri('POST', url)
 
-        url_put = 'http://base.url/projects/123/repository/files'
+        url_put = 'http://base.url/api/v3/projects/123/repository/files'
         aiohttpretty.register_json_uri('PUT', url)
 
-        url_metadata = 'http://base.url/projects/123/repository/files?file_path=folder1/file.py&ref=master'
+        url_metadata = 'http://base.url/api/v3/projects/123/repository/files?file_path=folder1/file.py&ref=master'
         aiohttpretty.register_json_uri('GET', url_metadata, body={
             'file_name': 'file.py',
             'file_path': path,
@@ -429,10 +429,10 @@ class TestCreateFolter:
 
         waterbutler_path = WaterButlerPath(path)
 
-        url = 'http://base.url/projects/123/repository/files'
+        url = 'http://base.url/api/v3/projects/123/repository/files'
         aiohttpretty.register_json_uri('POST', url)
 
-        url_get_metadata = 'http://base.url/projects/123/repository/files?file_path=folder1/.gitkeep&ref=master'
+        url_get_metadata = 'http://base.url/api/v3/projects/123/repository/files?file_path=folder1/.gitkeep&ref=master'
         aiohttpretty.register_json_uri('GET', url_get_metadata, body={
             'file_name': '.gitkeep',
             'file_path': '/folder1/.gitkeep',
@@ -441,7 +441,7 @@ class TestCreateFolter:
             'commit_id': '1442422sss',
         })
 
-        url_put = 'http://base.url/projects/123/repository/files'
+        url_put = 'http://base.url/api/v3/projects/123/repository/files'
         aiohttpretty.register_json_uri('PUT', url)
 
         result = await provider.create_folder(waterbutler_path, 'master', 'commit message')
@@ -461,7 +461,7 @@ class TestValidatePath:
     @pytest.mark.aiohttpretty
     async def test_validate_path_v1_is_file(self, provider):
         path = '/folder1/file.py'
-        url = 'http://base.url/projects/123/repository/tree?path=folder1/file.py'
+        url = 'http://base.url/api/v3/projects/123/repository/tree?path=folder1/file.py'
         aiohttpretty.register_json_uri('GET', url, body={})
 
         validated = await provider.validate_v1_path(path)
@@ -473,7 +473,7 @@ class TestValidatePath:
     async def test_validate_path_v1_is_dir(self, provider):
         path = '/folder1/'
         body = gitlab_simple_project_tree()
-        url = 'http://base.url/projects/123/repository/tree?path=folder1/'
+        url = 'http://base.url/api/v3/projects/123/repository/tree?path=folder1/'
         aiohttpretty.register_json_uri('GET', url, body=body)
 
         validated = await provider.validate_v1_path(path)
@@ -484,7 +484,7 @@ class TestValidatePath:
     @pytest.mark.aiohttpretty
     async def test_validate_v1_root(self, provider):
         path = '/'
-        url_get = 'http://base.url/projects/123/repository/tree?path=/'
+        url_get = 'http://base.url/api/v3/projects/123/repository/tree?path=/'
         body = gitlab_simple_project_tree()
         aiohttpretty.register_json_uri('GET', url_get, body=body, status=200)
 
@@ -505,7 +505,7 @@ class TestValidatePath:
     @pytest.mark.aiohttpretty
     async def test_validate_folder_path_from_gitlab(self, provider):
         path = 'folder1/'
-        url_get = 'http://base.url/projects/123/repository/tree?path=folder1/'
+        url_get = 'http://base.url/api/v3/projects/123/repository/tree?path=folder1/'
         body = gitlab_simple_project_tree()
         aiohttpretty.register_json_uri('GET', url_get, body=body, status=200)
 
@@ -517,7 +517,7 @@ class TestValidatePath:
     @pytest.mark.aiohttpretty
     async def test_validate_folder_composed_path_from_gitlab(self, provider):
         path = 'files/html/'
-        url_get = 'http://base.url/projects/123/repository/tree?path=files/html/'
+        url_get = 'http://base.url/api/v3/projects/123/repository/tree?path=files/html/'
         body = gitlab_example_project_tree()
         aiohttpretty.register_json_uri('GET', url_get, body=body, status=200)
 

--- a/tests/providers/gitlab/test_provider.py
+++ b/tests/providers/gitlab/test_provider.py
@@ -1,0 +1,4 @@
+import pytest
+
+def test_first_test():
+    assert 1 == 1

--- a/tests/providers/gitlab/test_provider.py
+++ b/tests/providers/gitlab/test_provider.py
@@ -10,6 +10,7 @@ from waterbutler.providers.gitlab import settings as gitlab_settings
 from waterbutler.providers.gitlab.metadata import GitLabFileContentMetadata
 from waterbutler.providers.gitlab.metadata import GitLabFolderContentMetadata
 
+
 @pytest.fixture
 def auth():
     return {
@@ -37,6 +38,24 @@ def gitlab_simple_project_tree():
             }
         ]
 
+@pytest.fixture
+def gitlab_example_sub_project_tree():
+    return [
+            {
+                "id": "a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba",
+                "name": ".gitkeep",
+                "type": "blob",
+                "path": "files/html/.gitkeep",
+                "mode": "040000"
+            },
+            {
+                "id": "a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba",
+                "name": ".gitkeep",
+                "type": "tree",
+                "path": "files/html/static",
+                "mode": "040000"
+            }
+        ]
 
 @pytest.fixture
 def gitlab_example_project_tree():
@@ -296,17 +315,21 @@ class TestDelete:
         sub4_url = 'http://base.url/projects/123/repository/tree?path=files/lfs/&ref_name=master'
         sub5_url = 'http://base.url/projects/123/repository/tree?path=files/markdown/&ref_name=master'
         sub6_url = 'http://base.url/projects/123/repository/tree?path=files/ruby/&ref_name=master'
+        sub7_url = 'http://base.url/projects/123/repository/tree?path=files/html/static/&ref_name=master'
 
         file1_url = 'http://base.url/projects/123/repository/files?file_path=files/whitespace&branch_name=master&commit_message=Folder+folder3/+deleted'
+        file2_url = 'http://base.url/projects/123/repository/files?file_path=files/html/.gitkeep&branch_name=master&commit_message=Folder+folder3/+deleted'
 
         aiohttpretty.register_json_uri('GET', info_url, body=gitlab_example_project_tree())
-        aiohttpretty.register_json_uri('GET', sub1_url, body={})
+        aiohttpretty.register_json_uri('GET', sub1_url, body=gitlab_example_sub_project_tree())
         aiohttpretty.register_json_uri('GET', sub2_url, body={})
         aiohttpretty.register_json_uri('GET', sub3_url, body={})
         aiohttpretty.register_json_uri('GET', sub4_url, body={})
         aiohttpretty.register_json_uri('GET', sub5_url, body={})
         aiohttpretty.register_json_uri('GET', sub6_url, body={})
+        aiohttpretty.register_json_uri('GET', sub7_url, body={})
         aiohttpretty.register_json_uri('DELETE', file1_url)
+        aiohttpretty.register_json_uri('DELETE', file2_url)
 
         result = await provider.delete(waterbutler_path, branch='master')
 

--- a/tests/providers/gitlab/test_provider.py
+++ b/tests/providers/gitlab/test_provider.py
@@ -1,26 +1,12 @@
 import pytest
-
-import io
-import os
-import json
-import base64
-import hashlib
-
-from http import client
-
 import aiohttpretty
 
 from waterbutler.core import streams
 from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
-from waterbutler.core.provider import build_url
-from waterbutler.core.path import WaterButlerPath
 
 from waterbutler.providers.gitlab import GitLabProvider
 from waterbutler.providers.gitlab import settings as gitlab_settings
-from waterbutler.providers.gitlab.metadata import GitLabRevision
-from waterbutler.providers.gitlab.metadata import GitLabFileTreeMetadata
-from waterbutler.providers.gitlab.metadata import GitLabFolderTreeMetadata
 from waterbutler.providers.gitlab.metadata import GitLabFileContentMetadata
 from waterbutler.providers.gitlab.metadata import GitLabFolderContentMetadata
 

--- a/waterbutler/providers/gitlab/__init__.py
+++ b/waterbutler/providers/gitlab/__init__.py
@@ -1,0 +1,1 @@
+from .provider import GitLabProvider  # noqa

--- a/waterbutler/providers/gitlab/exceptions.py
+++ b/waterbutler/providers/gitlab/exceptions.py
@@ -1,9 +1,0 @@
-from waterbutler.core.exceptions import ProviderError
-
-
-class GitLabUnsupportedRepoError(ProviderError):
-    def __init__(self):
-        message = ('Some folder operations on large GitLab repositories cannot be supported without'
-                   ' data loss.  To carry out this operation, please perform it in a local git'
-                   ' repository, then push to the target repository on GitLab.')
-        super().__init__(message, code=501)

--- a/waterbutler/providers/gitlab/exceptions.py
+++ b/waterbutler/providers/gitlab/exceptions.py
@@ -1,0 +1,9 @@
+from waterbutler.core.exceptions import ProviderError
+
+
+class GitLabUnsupportedRepoError(ProviderError):
+    def __init__(self):
+        message = ('Some folder operations on large GitLab repositories cannot be supported without'
+                   ' data loss.  To carry out this operation, please perform it in a local git'
+                   ' repository, then push to the target repository on GitLab.')
+        super().__init__(message, code=501)

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -83,7 +83,6 @@ class GitLabFileContentMetadata(BaseGitLabFileMetadata):
     def size(self):
         return None
 
-
 class GitLabFolderContentMetadata(BaseGitLabFolderMetadata):
 
     @property

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -99,7 +99,7 @@ class GitLabFileMetadata(BaseGitLabMetadata, metadata.BaseFileMetadata):
 
     @property
     def web_view(self):
-        return 'https://{}/{}/{}/blob/{}/{}'.format(self.host, self.owner, self.repo, self.branch_name, self.path)
+        return '{}/{}/{}/blob/{}{}'.format(self.host, self.owner, self.repo, self.branch_name, self.path)
 
 
 

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -27,9 +27,14 @@ class BaseGitLabMetadata(metadata.BaseMetadata):
         return self._path_obj.branch_name
 
     @property
+    def commit_sha(self):
+        return self._path_obj.commit_sha
+
+    @property
     def extra(self):
         return {
-                'ref': self.branch_name
+                'ref': self.branch_name,
+                'commitSha': self.commit_sha,
                 }
 
     def build_path(self):
@@ -39,9 +44,11 @@ class BaseGitLabMetadata(metadata.BaseMetadata):
         """Update JSON-API links to add branch, if available"""
         links = super()._json_api_links(resource)
 
-        ref = None
+        ref = {}
         if self.branch_name is not None:
-            ref = {'branch': self.branch_name}
+            ref['branch'] = self.branch_name
+        if self.commit_sha is not None:
+            ref['commitSha'] = self.commit_sha
 
         if ref is not None:
             for action, link in links.items():

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -33,10 +33,11 @@ class BaseGitLabFileMetadata(BaseGitLabMetadata, metadata.BaseFileMetadata):
         super().__init__(raw, folder, commit)
         self.web_view = web_view
         self.givenpath = thepath
+        self.file_name = raw['name']
 
     @property
     def path(self):
-        return self.build_path(self.givenpath.path)
+        return '/' + self.givenpath.path + self.file_name
 
     @property
     def modified(self):
@@ -73,10 +74,6 @@ class BaseGitLabFolderMetadata(BaseGitLabMetadata, metadata.BaseFolderMetadata):
 
 
 class GitLabFileContentMetadata(BaseGitLabFileMetadata):
-
-    def __init__(self, raw, folder=None, commit=None, web_view=None, thepath=None):
-        super().__init__(raw, folder, commit, web_view)
-        self.givenpath = thepath
 
     @property
     def name(self):

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -114,20 +114,20 @@ class GitLabRevision(metadata.BaseFileRevisionMetadata):
 
     @property
     def version_identifier(self):
-        return 'ref'
+        return 'commitSha'
 
     @property
     def modified(self):
-        return self.raw['commit']['author']['date']
+        return self.raw['committed_date']
 
     @property
     def version(self):
-        return self.file_sha
+        return self.raw['id']
 
     @property
     def extra(self):
         return {
                 'user': {
-                    'name': self.raw['commit']['committer']['name']
+                    'name': self.raw['author_name'],
                     },
                 }

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -99,7 +99,7 @@ class GitLabFileMetadata(BaseGitLabMetadata, metadata.BaseFileMetadata):
 
     @property
     def web_view(self):
-        return 'https://{}/{}/{}/blob/{}/{}'.format(self.host, self.owner, self.repo, self.branch_name, self.name)
+        return 'https://{}/{}/{}/blob/{}/{}'.format(self.host, self.owner, self.repo, self.branch_name, self.path)
 
 
 

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -65,10 +65,11 @@ class BaseGitLabFolderMetadata(BaseGitLabMetadata, metadata.BaseFolderMetadata):
     def __init__(self, raw, folder=None, commit=None, thepath=None):
         super().__init__(raw, folder, commit)
         self.givenpath = thepath
+        self.current_path = raw['name']
 
     @property
     def path(self):
-        return self.build_path(self.givenpath.path)
+        return '/' + self.givenpath.path + self.current_path + '/'
 
 
 class GitLabFileContentMetadata(BaseGitLabFileMetadata):

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -29,13 +29,14 @@ class BaseGitLabMetadata(metadata.BaseMetadata):
 
 class BaseGitLabFileMetadata(BaseGitLabMetadata, metadata.BaseFileMetadata):
 
-    def __init__(self, raw, folder=None, commit=None, web_view=None):
+    def __init__(self, raw, folder=None, commit=None, web_view=None, thepath=None):
         super().__init__(raw, folder, commit)
         self.web_view = web_view
+        self.givenpath = thepath
 
     @property
     def path(self):
-        return self.build_path(self.raw['path'])
+        return self.build_path(self.givenpath.path)
 
     @property
     def modified(self):
@@ -49,24 +50,32 @@ class BaseGitLabFileMetadata(BaseGitLabMetadata, metadata.BaseFileMetadata):
 
     @property
     def etag(self):
-        return '{}::{}'.format(self.path, self.raw['sha'])
+        return '{}::{}'.format(self.path, self.raw['id'])
 
     @property
     def extra(self):
         return dict(super().extra, **{
-            'fileSha': self.raw['sha'],
+            'fileSha': self.raw['id'],
             'webView': self.web_view
         })
 
 
 class BaseGitLabFolderMetadata(BaseGitLabMetadata, metadata.BaseFolderMetadata):
 
+    def __init__(self, raw, folder=None, commit=None, thepath=None):
+        super().__init__(raw, folder, commit)
+        self.givenpath = thepath
+
     @property
     def path(self):
-        return self.build_path(self.raw['path'])
+        return self.build_path(self.givenpath.path)
 
 
 class GitLabFileContentMetadata(BaseGitLabFileMetadata):
+
+    def __init__(self, raw, folder=None, commit=None, web_view=None, thepath=None):
+        super().__init__(raw, folder, commit, web_view)
+        self.givenpath = thepath
 
     @property
     def name(self):
@@ -74,7 +83,7 @@ class GitLabFileContentMetadata(BaseGitLabFileMetadata):
 
     @property
     def size(self):
-        return self.raw['size']
+        return None
 
 
 class GitLabFolderContentMetadata(BaseGitLabFolderMetadata):
@@ -115,7 +124,7 @@ class GitLabRevision(metadata.BaseFileRevisionMetadata):
 
     @property
     def version(self):
-        return self.raw['sha']
+        return self.raw['id']
 
     @property
     def extra(self):

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -73,6 +73,7 @@ class BaseGitLabFolderMetadata(BaseGitLabMetadata, metadata.BaseFolderMetadata):
     def path(self):
         return '/' + self.givenpath.path + self.current_path + '/'
 
+
 class GitLabFileContentMetadata(BaseGitLabFileMetadata):
 
     @property
@@ -82,6 +83,7 @@ class GitLabFileContentMetadata(BaseGitLabFileMetadata):
     @property
     def size(self):
         return None
+
 
 class GitLabFolderContentMetadata(BaseGitLabFolderMetadata):
 

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -56,9 +56,12 @@ class BaseGitLabMetadata(metadata.BaseMetadata):
 
 class GitLabFileMetadata(BaseGitLabMetadata, metadata.BaseFileMetadata):
 
-    def __init__(self, raw, path, web_view=None):
+    def __init__(self, raw, path, host=None, owner=None, repo=None):
         super().__init__(raw, path)
         self._path_obj = path
+        self.host = host
+        self.owner = owner
+        self.repo = repo
         self.file_size = 0
         if 'size' in raw:
             self.file_size = raw['size']
@@ -96,7 +99,8 @@ class GitLabFileMetadata(BaseGitLabMetadata, metadata.BaseFileMetadata):
 
     @property
     def web_view(self):
-        return None
+        return 'https://{}/{}/{}/blob/{}/{}'.format(self.host, self.owner, self.repo, self.branch_name, self.name)
+
 
 
 class GitLabFolderMetadata(BaseGitLabMetadata, metadata.BaseFolderMetadata):

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -1,0 +1,126 @@
+import os
+
+from waterbutler.core import metadata
+
+
+class BaseGitLabMetadata(metadata.BaseMetadata):
+
+    def __init__(self, raw, folder=None, commit=None):
+        super().__init__(raw)
+        self.folder = folder
+        self.commit = commit
+
+    @property
+    def provider(self):
+        return 'gitlab'
+
+    @property
+    def extra(self):
+        ret = {}
+        if self.commit is not None:
+            ret['commit'] = self.commit
+        return ret
+
+    def build_path(self, path):
+        if self.folder:
+            path = os.path.join(self.folder, path.lstrip('/'))
+        return super().build_path(path)
+
+
+class BaseGitLabFileMetadata(BaseGitLabMetadata, metadata.BaseFileMetadata):
+
+    def __init__(self, raw, folder=None, commit=None, web_view=None):
+        super().__init__(raw, folder, commit)
+        self.web_view = web_view
+
+    @property
+    def path(self):
+        return self.build_path(self.raw['path'])
+
+    @property
+    def modified(self):
+        if not self.commit:
+            return None
+        return self.commit['author']['date']
+
+    @property
+    def content_type(self):
+        return None
+
+    @property
+    def etag(self):
+        return '{}::{}'.format(self.path, self.raw['sha'])
+
+    @property
+    def extra(self):
+        return dict(super().extra, **{
+            'fileSha': self.raw['sha'],
+            'webView': self.web_view
+        })
+
+
+class BaseGitLabFolderMetadata(BaseGitLabMetadata, metadata.BaseFolderMetadata):
+
+    @property
+    def path(self):
+        return self.build_path(self.raw['path'])
+
+
+class GitLabFileContentMetadata(BaseGitLabFileMetadata):
+
+    @property
+    def name(self):
+        return self.raw['name']
+
+    @property
+    def size(self):
+        return self.raw['size']
+
+
+class GitLabFolderContentMetadata(BaseGitLabFolderMetadata):
+
+    @property
+    def name(self):
+        return self.raw['name']
+
+
+class GitLabFileTreeMetadata(BaseGitLabFileMetadata):
+
+    @property
+    def name(self):
+        return os.path.basename(self.raw['path'])
+
+    @property
+    def size(self):
+        return self.raw['size']
+
+
+class GitLabFolderTreeMetadata(BaseGitLabFolderMetadata):
+
+    @property
+    def name(self):
+        return os.path.basename(self.raw['path'])
+
+
+# TODO dates!
+class GitLabRevision(metadata.BaseFileRevisionMetadata):
+
+    @property
+    def version_identifier(self):
+        return 'ref'
+
+    @property
+    def modified(self):
+        return self.raw['commit']['author']['date']
+
+    @property
+    def version(self):
+        return self.raw['sha']
+
+    @property
+    def extra(self):
+        return {
+            'user': {
+                'name': self.raw['commit']['committer']['name']
+            }
+        }

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -74,10 +74,6 @@ class BaseGitLabFolderMetadata(BaseGitLabMetadata, metadata.BaseFolderMetadata):
 
 class GitLabFileContentMetadata(BaseGitLabFileMetadata):
 
-    def __init__(self, raw, folder=None, commit=None, web_view=None, thepath=None):
-        super().__init__(raw, folder, commit, web_view)
-        self.givenpath = thepath
-
     @property
     def name(self):
         return self.raw['name']

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -62,9 +62,8 @@ class GitLabFileMetadata(BaseGitLabMetadata, metadata.BaseFileMetadata):
         self.host = host
         self.owner = owner
         self.repo = repo
-        self.file_size = 0
-        if 'size' in raw:
-            self.file_size = raw['size']
+        self.file_size = raw.get('size', 0)
+        self.mimetype = raw.get('mimetype', 'text/plain')
 
     @property
     def modified(self):
@@ -76,7 +75,7 @@ class GitLabFileMetadata(BaseGitLabMetadata, metadata.BaseFileMetadata):
 
     @property
     def content_type(self):
-        return None
+        return self.mimetype
 
     @property
     def size(self):

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -29,21 +29,22 @@ class BaseGitLabMetadata(metadata.BaseMetadata):
 
 class BaseGitLabFileMetadata(BaseGitLabMetadata, metadata.BaseFileMetadata):
 
-    def __init__(self, raw, folder=None, commit=None, web_view=None, thepath=None):
-        super().__init__(raw, folder, commit)
+    def __init__(self, raw, commit=None, web_view=None, thepath=None):
+        super().__init__(raw, commit=commit)
         self.web_view = web_view
         self.givenpath = thepath
         self.file_name = raw['name']
 
     @property
     def path(self):
-        return '/' + self.givenpath.path + self.file_name
+        if (isinstance(self.givenpath, str)):
+            return '/' + self.givenpath + self.file_name
+        else:
+            return '/' + self.givenpath.path + self.file_name
 
     @property
     def modified(self):
-        if not self.commit:
-            return None
-        return self.commit['author']['date']
+        return None
 
     @property
     def content_type(self):

--- a/waterbutler/providers/gitlab/metadata.py
+++ b/waterbutler/providers/gitlab/metadata.py
@@ -72,8 +72,11 @@ class BaseGitLabFolderMetadata(BaseGitLabMetadata, metadata.BaseFolderMetadata):
     def path(self):
         return '/' + self.givenpath.path + self.current_path + '/'
 
-
 class GitLabFileContentMetadata(BaseGitLabFileMetadata):
+
+    def __init__(self, raw, folder=None, commit=None, web_view=None, thepath=None):
+        super().__init__(raw, folder, commit, web_view)
+        self.givenpath = thepath
 
     @property
     def name(self):

--- a/waterbutler/providers/gitlab/path.py
+++ b/waterbutler/providers/gitlab/path.py
@@ -5,7 +5,7 @@ from waterbutler.core.path import WaterButlerPathPart
 class GitLabPathPart(WaterButlerPathPart):
     def increment_name(self, _id=None):
         """Overridden to preserve branch from _id upon incrementing"""
-        self._id = _id or (self._id[0], None)
+        self._id = _id or (self._id[0], self._id[1], self._id[2])
         self._count += 1
         return self
 
@@ -32,9 +32,15 @@ class GitLabPath(WaterButlerPath):
         return self.identifier[1]
 
     @property
+    def commit_sha(self):
+        """Commit SHA-1"""
+        return self.identifier[2]
+
+    @property
     def extra(self):
         return dict(super().extra, **{
             'fileSha': self.file_sha,
+            'commitSha': self.commit_sha,
             'ref': self.branch_name
         })
 
@@ -48,11 +54,11 @@ class GitLabPath(WaterButlerPath):
         super().__init__(wb_path, _ids=_ids, prepend=prepend, folder=folder)
 
     def child(self, name, _id=None, folder=False):
-        """Pass current branch down to children"""
+        """Pass current branch and commit down to children"""
         if _id is None:
-            _id = (self.branch_name, None)
+            _id = (self.branch_name, None, self.commit_sha)
         return super().child(name, _id=_id, folder=folder)
 
     def set_file_sha(self, file_sha):
         for part in self.parts:
-            part._id = (part._id[0], file_sha)
+            part._id = (part._id[0], file_sha, part._id[2])

--- a/waterbutler/providers/gitlab/path.py
+++ b/waterbutler/providers/gitlab/path.py
@@ -1,0 +1,54 @@
+from waterbutler.core.path import WaterButlerPath
+from waterbutler.core.path import WaterButlerPathPart
+
+
+class GitLabPathPart(WaterButlerPathPart):
+    def increment_name(self, _id=None):
+        """Overridden to preserve branch from _id upon incrementing"""
+        self._id = _id or (self._id[0], None)
+        self._count += 1
+        return self
+
+
+class GitLabPath(WaterButlerPath):
+    """WB and GL use slightly different default conventions for their paths, so we
+    often have to munge our WB paths before comparison. Here is a quick overview::
+
+        WB (dirs):  wb_dir.path == 'foo/bar/'     str(wb_dir) == '/foo/bar/'
+        WB (file):  wb_file.path = 'foo/bar.txt'  str(wb_file) == '/foo/bar.txt'
+        GL (dir):   'foo/bar'
+        GL (file):  'foo/bar.txt'
+    """
+    PART_CLASS = GitLabPathPart
+
+    @property
+    def branch_ref(self):
+        """Branch name or commit sha in which this file exists"""
+        return self.identifier[0]
+
+    @property
+    def file_sha(self):
+        """SHA-1 of this file"""
+        return self.identifier[1]
+
+    @property
+    def extra(self):
+        return dict(super().extra, **{
+            'ref': self.branch_ref,
+            'fileSha': self.file_sha,
+        })
+
+    def __init__(self, path, _ids=(), prepend=None, folder=False):
+        wb_path = path
+        if path is not '/':
+            if not path.startswith('/'):
+                wb_path = "/{}".format(path)
+        if path.endswith('/'):
+            folder = True
+        super().__init__(wb_path, _ids=_ids, prepend=prepend, folder=folder)
+
+    def child(self, name, _id=None, folder=False):
+        """Pass current branch down to children"""
+        if _id is None:
+            _id = (self.branch_ref, None)
+        return super().child(name, _id=_id, folder=folder)

--- a/waterbutler/providers/gitlab/path.py
+++ b/waterbutler/providers/gitlab/path.py
@@ -22,8 +22,8 @@ class GitLabPath(WaterButlerPath):
     PART_CLASS = GitLabPathPart
 
     @property
-    def branch_ref(self):
-        """Branch name or commit sha in which this file exists"""
+    def branch_name(self):
+        """Branch name in which this file exists"""
         return self.identifier[0]
 
     @property
@@ -34,8 +34,8 @@ class GitLabPath(WaterButlerPath):
     @property
     def extra(self):
         return dict(super().extra, **{
-            'ref': self.branch_ref,
             'fileSha': self.file_sha,
+            'ref': self.branch_name
         })
 
     def __init__(self, path, _ids=(), prepend=None, folder=False):
@@ -50,5 +50,9 @@ class GitLabPath(WaterButlerPath):
     def child(self, name, _id=None, folder=False):
         """Pass current branch down to children"""
         if _id is None:
-            _id = (self.branch_ref, None)
+            _id = (self.branch_name, None)
         return super().child(name, _id=_id, folder=folder)
+
+    def set_file_sha(self, file_sha):
+        for part in self.parts:
+            part._id = (part._id[0], file_sha)

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -285,12 +285,8 @@ class GitLabProvider(provider.BaseProvider):
 
         resp, insert = await self.upload(stream, keep_path, message, branch, **kwargs)
 
-        metadata = await self.metadata(path, ref=branch, **kwargs)
-
-        if not metadata:
-            raise exceptions.NotFoundError(path.full_path)
-
-        return metadata[0]
+        raw = {'name': path.path.strip('/').split('/')[-1]}
+        return GitLabFolderContentMetadata(raw, thepath=path.parent)
 
     async def _delete_file(self, path, message=None, branch=None, **kwargs):
 
@@ -448,7 +444,7 @@ class GitLabProvider(provider.BaseProvider):
         raise exceptions.NotFoundError(str(path))
 
     async def _upsert_blob(self, stream, filepath, branchname, insert=True):
-        if type(stream) is not Base64EncodeStream:
+        if type(stream) is not streams.Base64EncodeStream:
             stream = streams.Base64EncodeStream(stream)
 
         if insert:

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -136,7 +136,7 @@ class GitLabProvider(provider.BaseProvider):
         :raises: :class:`waterbutler.core.exceptions.NotFoundError`
         """
 
-        branch_name = kwargs.get('ref') or kwargs.get('branch')
+        branch_name = kwargs.get('ref') or kwargs.get('branch') or kwargs.get('revision')
         file_sha = kwargs.get('fileSha')
         commit_sha = kwargs.get('commitSha')
 
@@ -265,7 +265,7 @@ class GitLabProvider(provider.BaseProvider):
         :rtype: :class:`list` of :class:`GitLabRevision`
         :raises: :class:`waterbutler.core.exceptions.RevisionsError`
         """
-        url = self.build_repo_url('repository', 'commits', path=path.path)
+        url = self.build_repo_url('repository', 'commits', path=path.path, ref_name=path.branch_name)
         resp = await self.make_request(
                 'GET',
                 url,

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -54,9 +54,9 @@ class GitLabProvider(provider.BaseProvider):
     def default_headers(self):
         """ Headers to be included with every request.
 
-        :rtype: :class:`dict` with `Authorization` token
+        :rtype: :class:`dict` with `PRIVATE-TOKEN` token
         """
-        return {'Authorization': 'Bearer {}'.format(self.token), 'Accept': 'text/json'}
+        return {'PRIVATE-TOKEN': str(self.token), 'Accept': 'text/json'}
 
     @property
     def committer(self):

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -501,9 +501,13 @@ class GitLabProvider(provider.BaseProvider):
         return (await resp.json())
 
     async def _fetch_contents(self, path, ref=None):
-        url = furl.furl(self.build_repo_url('repository', 'tree', path.path))
+        url = furl.furl(self.build_repo_url('repository', 'tree'))
+
+        if path.full_path:
+            url.add({'path': path.full_path})
+
         if ref:
-            url.args.update({'ref': ref})
+            url.args.update({'ref_name': ref})
 
         resp = await self.make_request(
             'GET',

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -1,4 +1,3 @@
-import json
 import base64
 import aiohttp
 import mimetypes
@@ -16,7 +15,6 @@ from waterbutler.providers.gitlab.metadata import GitLabRevision
 from waterbutler.providers.gitlab.metadata import GitLabFileContentMetadata
 from waterbutler.providers.gitlab.metadata import GitLabFolderContentMetadata
 from waterbutler.providers.gitlab.metadata import GitLabFileTreeMetadata
-from waterbutler.providers.gitlab.exceptions import GitLabUnsupportedRepoError
 
 
 GIT_EMPTY_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
@@ -130,8 +128,8 @@ class GitLabProvider(provider.BaseProvider):
         :param str path: The path to a file
         :rtype: WaterButlerPath
         """
-        return WaterButlerPath(path)
 
+        return WaterButlerPath(path)
 
     async def revalidate_path(self, base, path, folder=False):
         return base.child(path, _id=((base.identifier[0], None)), folder=folder)
@@ -461,10 +459,8 @@ class GitLabProvider(provider.BaseProvider):
         if not commits:
             raise exceptions.NotFoundError(str(path))
 
-        data = {
-                'name': commits['file_name'], 'id': commits['blob_id'],
-                'path': commits['file_path'], 'size': commits['size']
-        }
+        data = {'name': commits['file_name'], 'id': commits['blob_id'],
+                'path': commits['file_path'], 'size': commits['size']}
 
         return GitLabFileTreeMetadata(data, commit=commits['commit_id'],
                                       thepath=commits['file_path'])

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -47,7 +47,7 @@ class GitLabProvider(provider.BaseProvider):
         self.owner = self.settings['owner']
         self.repo = self.settings['repo']
         self.repo_id = self.settings['repo_id']
-        self.BASE_URL = self.settings['host'] + '/api/v3'
+        self.BASE_URL = self.settings['host'] + '/api/v4'
         self.VIEW_URL = self.settings['host']
 
     @property

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -365,8 +365,6 @@ class GitLabProvider(provider.BaseProvider):
 
         headers = {"Authorization": 'Bearer {}'.format(self.token)}
 
-        pdb.set_trace()
-
         resp = await self.make_request(
             'DELETE',
             url,

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -222,6 +222,8 @@ class GitLabProvider(provider.BaseProvider):
         except:
             insert = True
 
+        await self._upsert_blob(stream, path.path, branch, insert)
+
         metadata = await self.metadata(path, ref=branch)
 
         return metadata, insert

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import pdb
 import base64
 import aiohttp
 import mimetypes
@@ -176,7 +175,7 @@ class GitLabProvider(provider.BaseProvider):
         :param dict kwargs: Ignored
         '''
 
-        if not 'branch' in kwargs:
+        if 'branch' not in kwargs:
             raise exceptions.DownloadError(
                 'you must specify the branch to download the file',
                 code=400,
@@ -203,11 +202,10 @@ class GitLabProvider(provider.BaseProvider):
 
         mdict_options = {}
 
-        if mimetype != None:
+        if mimetype is not None:
             mdict_options['CONTENT-TYPE'] = mimetype
 
         mdict.update(mdict_options)
-
 
         resp.headers = mdict
         resp.content = streams.StringStream(raw)
@@ -223,8 +221,6 @@ class GitLabProvider(provider.BaseProvider):
             metadata = await self.metadata(path, ref=branch)
         except:
             insert = True
-
-        blob = await self._upsert_blob(stream, path.path, branch, insert)
 
         metadata = await self.metadata(path, ref=branch)
 
@@ -281,7 +277,6 @@ class GitLabProvider(provider.BaseProvider):
 
         content = '\n'
         stream = streams.StringStream(content)
-        commit_msg = message or settings.UPLOAD_FILE_MESSAGE
 
         resp, insert = await self.upload(stream, keep_path, message, branch, **kwargs)
 
@@ -290,14 +285,13 @@ class GitLabProvider(provider.BaseProvider):
 
     async def _delete_file(self, path, message=None, branch=None, **kwargs):
 
-        if branch == None:
+        if branch is None:
             raise exceptions.DeleteError(
                 'you must specify the branch to delete the file',
                 code=400,
             )
 
-
-        if message == None:
+        if message is None:
             message = 'File {} deleted'.format(path.full_path)
 
         url = self.build_repo_url('repository', 'files', file_path=path.full_path, branch_name=branch, commit_message=message)
@@ -315,14 +309,13 @@ class GitLabProvider(provider.BaseProvider):
 
     async def _delete_folder(self, path, message=None, branch=None, **kwargs):
 
-        if branch == None:
+        if branch is None:
             raise exceptions.DeleteError(
                 'you must specify the branch to delete the file',
                 code=400,
             )
 
-
-        if message == None:
+        if message is None:
             message = 'Folder {} deleted'.format(path.full_path)
 
         url = self.build_repo_url('repository', 'files', file_path=path.full_path, branch_name=branch, commit_message=message)
@@ -519,7 +512,7 @@ class GitLabProvider(provider.BaseProvider):
 
     async def _metadata_file(self, path, revision=None, ref=None, **kwargs):
 
-        if ref == None:
+        if ref is None:
             ref = 'master'
 
         resp = await self.make_request(

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -188,7 +188,6 @@ class GitLabProvider(provider.BaseProvider):
 
         mdict.update(mdict_options)
 
-
         resp.headers = mdict
         resp.content = streams.StringStream(raw)
 

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -198,8 +198,7 @@ class GitLabProvider(provider.BaseProvider):
         :raises: :class:`waterbutler.core.exceptions.DownloadError`
         """
 
-        url = self.build_repo_url('repository', 'files', file_path=path.full_path,
-                ref=path.branch_name)
+        url = self.build_repo_url('repository', 'files', path.full_path, ref=path.branch_name)
 
         resp = await self.make_request(
                 'GET',

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -547,16 +547,10 @@ class GitLabProvider(provider.BaseProvider):
         if not commits:
             raise exceptions.NotFoundError(str(path))
 
-        data = {'name': commits['file_name'], 'id': commits['blob_id'], 'path': commits['file_path'], 'size': commits['size']}
+        data = {
+                'name': commits['file_name'], 'id': commits['blob_id'],
+                'path': commits['file_path'], 'size': commits['size']
+        }
 
-        return GitLabFileTreeMetadata(data, commit=commits['commit_id'], thepath=commits['file_path'])
-
-    async def _get_latest_sha(self, ref='master'):
-        resp = await self.make_request(
-            'GET',
-            self.build_repo_url('git', 'refs', 'heads', ref),
-            expects=(200, ),
-            throws=exceptions.ProviderError
-        )
-        data = await resp.json()
-        return data['object']['sha']
+        return GitLabFileTreeMetadata(data, commit=commits['commit_id'],
+                                      thepath=commits['file_path'])

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -175,6 +175,7 @@ class GitLabProvider(provider.BaseProvider):
         :param dict kwargs: Ignored
         '''
 
+        #TODO: make ref dynamic
         url = self.build_repo_url('repository', 'files', file_path=path.full_path, ref='master')
         
         headers = {"Authorization": 'Bearer {}'.format(self.token)}
@@ -189,7 +190,6 @@ class GitLabProvider(provider.BaseProvider):
 
         data = await resp.json()
         raw = base64.b64decode(data['content'])
-        ss = streams.StringStream(raw)
 
         mdict = aiohttp.multidict.MultiDict(resp.headers)
         mdict_options = {'Content-Length': len(raw)}
@@ -198,7 +198,6 @@ class GitLabProvider(provider.BaseProvider):
         resp.headers = mdict
         resp.content = streams.StringStream(raw)
 
-        pdb.set_trace()
         return streams.ResponseStreamReader(resp)
 
     async def upload(self, stream, path, message=None, branch=None, **kwargs):

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -3,6 +3,7 @@ import json
 import pdb
 import base64
 import aiohttp
+import mimetypes
 
 import furl
 
@@ -198,13 +199,21 @@ class GitLabProvider(provider.BaseProvider):
         raw = base64.b64decode(data['content'])
 
         mdict = aiohttp.multidict.MultiDict(resp.headers)
-        mdict_options = {'Content-Length': len(raw)}
+
+        mimetype = mimetypes.guess_type(path.full_path)[0]
+
+        mdict_options = {}
+
+        if mimetype != None:
+            mdict_options['CONTENT-TYPE'] = mimetype
+
         mdict.update(mdict_options)
+
 
         resp.headers = mdict
         resp.content = streams.StringStream(raw)
 
-        return streams.ResponseStreamReader(resp)
+        return streams.ResponseStreamReader(resp, len(raw))
 
     async def upload(self, stream, path, message=None, branch=None, **kwargs):
         assert self.name is not None

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -10,6 +10,7 @@ from waterbutler.core import path
 from waterbutler.core import streams
 from waterbutler.core import provider
 from waterbutler.core import exceptions
+from waterbutler.core.path import WaterButlerPath
 
 from waterbutler.providers.gitlab import settings
 from waterbutler.providers.gitlab.metadata import GitLabRevision
@@ -29,15 +30,6 @@ class GitLabPathPart(path.WaterButlerPathPart):
         self._id = _id or (self._id[0], None)
         self._count += 1
         return self
-
-
-class GitLabPath(path.WaterButlerPath):
-    PART_CLASS = GitLabPathPart
-
-    def child(self, name, _id=None, folder=False):
-        if _id is None:
-            _id = (self.identifier[0], None)
-        return super().child(name, _id=_id, folder=folder)
 
 
 class GitLabProvider(provider.BaseProvider):
@@ -100,12 +92,12 @@ class GitLabProvider(provider.BaseProvider):
         branch_ref = kwargs.get('ref') or kwargs.get('branch') or self.default_branch
 
         if path == '/':
-            return GitLabPath(path, _ids=[(branch_ref, '')])
+            return WaterButlerPath(path, _ids=[(branch_ref, '')])
 
         branch_data = await self._fetch_branch(branch_ref)
         await self._search_tree_for_path(path, branch_data['commit']['commit']['tree']['sha'])
 
-        path = GitLabPath(path)
+        path = WaterButlerPath(path)
         for part in path.parts:
             part._id = (branch_ref, None)
 
@@ -119,7 +111,7 @@ class GitLabProvider(provider.BaseProvider):
             self._repo = await self._fetch_repo()
             self.default_branch = self._repo['default_branch']
 
-        path = GitLabPath(path)
+        path = WaterButlerPath(path)
         branch_ref = kwargs.get('ref') or kwargs.get('branch') or self.default_branch
 
         for part in path.parts:
@@ -232,7 +224,7 @@ class GitLabProvider(provider.BaseProvider):
                confirm_delete=0, **kwargs):
         """Delete file, folder, or provider root contents
 
-        :param GitLabPath path: GitLabPath path object for file, folder, or root
+        :param WaterButlerPath path: WaterButlerPath path object for file, folder, or root
         :param str sha: SHA-1 checksum of file/folder object
         :param str message: Commit message
         :param str branch: Repository branch
@@ -270,7 +262,7 @@ class GitLabProvider(provider.BaseProvider):
         ]
 
     async def create_folder(self, path, branch=None, message=None, **kwargs):
-        GitLabPath.validate_folder(path)
+        WaterButlerPath.validate_folder(path)
 
         message = message or settings.UPLOAD_FILE_MESSAGE
         branch = branch or path.identifier[0]
@@ -336,7 +328,7 @@ class GitLabProvider(provider.BaseProvider):
     async def _delete_root_folder_contents(self, path, message=None, **kwargs):
         """Delete the contents of the root folder.
 
-        :param GitLabPath path: GitLabPath path object for folder
+        :param WaterButlerPath path: WaterButlerPath path object for folder
         :param str message: Commit message
         """
         branch_data = await self._fetch_branch(path.identifier[0])

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -285,7 +285,7 @@ class GitLabProvider(provider.BaseProvider):
                 ret.append(GitLabFolderMetadata(item, folder_path))
             else:
                 file_path = path.child(name, folder=False)
-                ret.append(GitLabFileMetadata(item, file_path, web_view=item['name']))
+                ret.append(GitLabFileMetadata(item, file_path, host=self.VIEW_URL, owner=self.owner, repo=self.repo))
 
         return ret
 
@@ -301,4 +301,4 @@ class GitLabProvider(provider.BaseProvider):
         data = {'name': data['file_name'], 'id': data['blob_id'],
                 'path': data['file_path'], 'size': data['size']}
 
-        return GitLabFileMetadata(data, path)
+        return GitLabFileMetadata(data, path, host=self.VIEW_URL, owner=self.owner, repo=self.repo)

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -132,7 +132,7 @@ class GitLabProvider(provider.BaseProvider):
         :rtype: GitLabPath
         :raises: :class:`waterbutler.core.exceptions.NotFoundError`
         """
-        branch_name = kwargs.get('ref')
+        branch_name = kwargs.get('ref') or kwargs.get('branch')
         file_sha = kwargs.get('fileSha')
 
         if not branch_name and not file_sha:
@@ -198,23 +198,17 @@ class GitLabProvider(provider.BaseProvider):
         :raises: :class:`waterbutler.core.exceptions.DownloadError`
         """
 
-        if 'branch' not in kwargs:
-            raise exceptions.DownloadError(
-                    'you must specify the branch to download the file',
-                    code=400,
-                    )
+        url = self.build_repo_url('repository', 'files', file_path=path.full_path,
+                ref=path.branch_name)
 
-            url = self.build_repo_url('repository', 'files', file_path=path.full_path,
-                    ref=kwargs['branch'])
+        resp = await self.make_request(
+                'GET',
+                url,
+                expects=(200,),
+                throws=exceptions.DownloadError,
+                )
 
-            resp = await self.make_request(
-                    'GET',
-                    url,
-                    expects=(200,),
-                    throws=exceptions.DownloadError,
-                    )
-
-            data = await resp.json()
+        data = await resp.json()
         raw = base64.b64decode(data['content'])
 
         mdict = aiohttp.multidict.MultiDict(resp.headers)

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -175,10 +175,10 @@ class GitLabProvider(provider.BaseProvider):
         :param dict kwargs: Ignored
         '''
 
-        #TODO: make ref dynamic
-        url = self.build_repo_url('repository', 'files', file_path=path.full_path, ref='master')
+        url = self.build_repo_url('repository', 'files', file_path=path.full_path, ref=kwargs['ref'])
         
         headers = {"Authorization": 'Bearer {}'.format(self.token)}
+        pdb.set_trace()
 
         resp = await self.make_request(
             'GET',

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -250,8 +250,8 @@ class GitLabProvider(provider.BaseProvider):
             raise exceptions.MetadataError('error on fetch metadata from path {0}'
                     .format(path.full_path))
 
-        async def revisions(self, path, sha=None, **kwargs):
-            """Get past versions of the request file.
+    async def revisions(self, path, sha=None, **kwargs):
+        """Get past versions of the request file.
 
         :param str path: The user specified path
         :param str sha: The sha of the revision

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -2,8 +2,6 @@ import base64
 import aiohttp
 import mimetypes
 
-import furl
-
 from waterbutler.core import streams
 from waterbutler.core import provider
 from waterbutler.core import exceptions
@@ -67,39 +65,36 @@ class GitLabProvider(provider.BaseProvider):
         :rtype: :class:`dict` with `name` and `email` of the author
         """
         return {
-            'name': self.name,
-            'email': self.email,
-        }
+                'name': self.name,
+                'email': self.email,
+                }
 
     async def revalidate_path(self, base, path, folder=False):
-        return base.child(path, _id=((base.branch_ref, None)), folder=folder)
+        return base.child(path, _id=((base.branch_name, None)), folder=folder)
 
-    async def _fetch_file_contents(self, path, ref):
+    async def _fetch_file_contents(self, path):
 
-        url = self.build_repo_url('repository', 'files',
-                                  file_path=path,
-                                  ref=ref)
+        url = self.build_repo_url('repository', 'files', file_path=path.raw_path, ref=path.branch_name)
 
         resp = await self.make_request(
-            'GET',
-            url,
-            expects=(200,),
-            throws=exceptions.NotFoundError(path.full_path)
-        )
+                'GET',
+                url,
+                expects=(200,),
+                throws=exceptions.NotFoundError(path.full_path)
+                )
 
         return await resp.json()
 
+    async def _fetch_tree_contents(self, path):
 
-    async def _fetch_tree_contents(self, path, ref):
-
-        url = self.build_repo_url('repository', 'tree', path=path, ref=ref)
+        url = self.build_repo_url('repository', 'tree', path=path.raw_path, ref=path.branch_name)
 
         resp = await self.make_request(
-            'GET',
-            url,
-            expects=(200, 404),
-            throws=exceptions.NotFoundError(path.full_path)
-        )
+                'GET',
+                url,
+                expects=(200, 404),
+                throws=exceptions.NotFoundError(path.full_path)
+                )
 
         data = await resp.json()
 
@@ -108,32 +103,70 @@ class GitLabProvider(provider.BaseProvider):
             if data['message'] == '404 Tree Not Found':
                 return []
             # True Not Found
-            elif resp.status == 404:
-                raise exceptions.NotFoundError(path.full_path)
+        elif resp.status == 404:
+            raise exceptions.NotFoundError(path.full_path)
 
         return data
 
-    async def validate_v1_path(self, path, **kwargs):
+    async def _fetch_default_branch(self):
+        url = self.build_repo_url()
+
+        resp = await self.make_request(
+                'GET',
+                url,
+                expects=(200,),
+                throws=exceptions.NotFoundError,
+                )
+
+        data = await resp.json()
+
+        if 'default_branch' not in data:
+            raise exceptions.NotFoundError
+
+        return data['default_branch']
+
+    async def validate_v1_path(self, str_path, **kwargs):
         """Ensure path is in Waterbutler v1 format.
 
-        :param str path: The path to a file/folder
+        :param str str_path: The path to a file/folder
         :rtype: GitLabPath
         :raises: :class:`waterbutler.core.exceptions.NotFoundError`
         """
+        branch_name = kwargs.get('ref')
+        file_sha = kwargs.get('fileSha')
 
-        if 'ref' not in kwargs:
-            raise exceptions.InvalidPathError('you must specify the ref branch')
+        if not branch_name and not file_sha:
+            if 'revisions' in kwargs:
+                branch_name = kwargs['revisions']
+            else:
+                branch_name = await self._fetch_default_branch()
 
-        ref = kwargs['ref']
+        if str_path == '/':
+            return GitLabPath(str_path, _ids=[(branch_name, file_sha)])
 
-        g_path = GitLabPath(path)
+        path = GitLabPath(str_path, _ids=[(branch_name, file_sha)])
+        for part in path.parts:
+            part._id = (branch_name, file_sha)
 
-        if g_path.is_dir:
-            data = await self._fetch_tree_contents(g_path, ref)
+        data = await self._fetch_tree_contents(path.parent)
+
+        data_list = []
+
+        if path.is_dir:
+            data_list = list(filter(lambda x: x['type'] == 'tree', data))
         else:
-            data = await self._fetch_file_contents(g_path, ref)
+            data_list = list(filter(lambda x: x['type'] == 'blob', data))
 
-        return g_path
+        data_found = list(filter(lambda x: x['name'] == path.name, data_list))
+
+        if not data_found:
+            raise exceptions.NotFoundError(path.full_path)
+
+        file_sha = data_found[0]['id']
+
+        path.set_file_sha(file_sha)
+
+        return path
 
     async def validate_path(self, path, **kwargs):
         """Ensure path is in Waterbutler format.
@@ -167,21 +200,21 @@ class GitLabProvider(provider.BaseProvider):
 
         if 'branch' not in kwargs:
             raise exceptions.DownloadError(
-                'you must specify the branch to download the file',
-                code=400,
-            )
+                    'you must specify the branch to download the file',
+                    code=400,
+                    )
 
-        url = self.build_repo_url('repository', 'files', file_path=path.full_path,
-                                  ref=kwargs['branch'])
+            url = self.build_repo_url('repository', 'files', file_path=path.full_path,
+                    ref=kwargs['branch'])
 
-        resp = await self.make_request(
-            'GET',
-            url,
-            expects=(200, ),
-            throws=exceptions.DownloadError,
-        )
+            resp = await self.make_request(
+                    'GET',
+                    url,
+                    expects=(200,),
+                    throws=exceptions.DownloadError,
+                    )
 
-        data = await resp.json()
+            data = await resp.json()
         raw = base64.b64decode(data['content'])
 
         mdict = aiohttp.multidict.MultiDict(resp.headers)
@@ -204,32 +237,28 @@ class GitLabProvider(provider.BaseProvider):
         raise NotImplementedError
 
     async def delete(self, path, sha=None, message=None, branch=None,
-               confirm_delete=0, **kwargs):
+            confirm_delete=0, **kwargs):
         raise NotImplementedError
 
-    async def metadata(self, path, ref=None, recursive=False, **kwargs):
+    async def metadata(self, path, **kwargs):
         """Get Metadata about the requested file or folder.
 
         :param GitLabPath path: The path to a file or folder
-        :param str ref: A branch or a commit SHA
         :rtype: :class:`GitLabFileMetadata`
         :rtype: :class:`list` of :class:`GitLabFileMetadata` or :class:`GitLabFolderMetadata`
         :raises: :class:`waterbutler.core.exceptions.MetadataError`
         """
         try:
             if path.is_dir:
-                return (await self._metadata_folder(path, ref=ref, recursive=recursive, **kwargs))
+                return (await self._metadata_folder(path, **kwargs))
             else:
-                if ref is not None:
-                    return (await self._metadata_file(path, ref=ref, **kwargs))
-                else:
-                    return (await self._metadata_file(path, **kwargs))
+                return (await self._metadata_file(path, **kwargs))
         except:
             raise exceptions.MetadataError('error on fetch metadata from path {0}'
-                                           .format(path.full_path))
+                    .format(path.full_path))
 
-    async def revisions(self, path, sha=None, **kwargs):
-        """Get past versions of the request file.
+        async def revisions(self, path, sha=None, **kwargs):
+            """Get past versions of the request file.
 
         :param str path: The user specified path
         :param str sha: The sha of the revision
@@ -239,49 +268,36 @@ class GitLabProvider(provider.BaseProvider):
         """
         #TODO:
         resp = await self.make_request(
-            'GET',
-            self.build_repo_url('commits', path=path.path, sha=sha or path.identifier),
-            expects=(200, ),
-            throws=exceptions.RevisionsError
-        )
+                'GET',
+                self.build_repo_url('commits', path=path.path, sha=sha or path.identifier),
+                expects=(200,),
+                throws=exceptions.RevisionsError
+                )
 
         return [GitLabRevision(item) for item in (await resp.json())]
 
     async def create_folder(self, path, branch=None, message=None, **kwargs):
         raise NotImplementedError
 
-    def _is_sha(self, ref):
-        # sha1 is always 40 characters in length
-        try:
-            if len(ref) != 40:
-                return False
-            # sha1 is always base 16 (hex)
-            int(ref, 16)
-        except (TypeError, ValueError, ):
-            return False
-        return True
+    async def _metadata_folder(self, path, **kwargs):
 
-    async def _metadata_folder(self, path, recursive=False, ref=None, **kwargs):
-        # if we have a sha or recursive lookup specified we'll need to perform
-        # the operation using the git/trees api which requires a sha.
+        data = await self._fetch_tree_contents(path)
 
-        if not (self._is_sha(ref) or recursive):
+        ret = []
+        for item in data:
+            name = item['name']
+            if item['type'] == 'tree':
+                folder_path = path.child(name, folder=True)
+                ret.append(GitLabFolderMetadata(item, folder_path))
+            else:
+                file_path = path.child(name, folder=False)
+                ret.append(GitLabFileMetadata(item, file_path, web_view=item['name']))
 
-            data = await self._fetch_tree_contents(path, ref=ref)
+        return ret
 
-            ret = []
-            for item in data:
-                commit = ref or item['id']
-                if item['type'] == 'tree':
-                    ret.append(GitLabFolderMetadata(item, thepath=path, commit=commit))
-                else:
-                    ret.append(GitLabFileMetadata(item, web_view=item['name'],
-                                                         thepath=path, commit=commit))
-            return ret
+    async def _metadata_file(self, path, **kwargs):
 
-    async def _metadata_file(self, path, revision=None, ref='master', **kwargs):
-
-        resp = await self._fetch_file_contents(path, ref)
+        resp = await self._fetch_file_contents(path)
 
         data = await resp.json()
 
@@ -291,5 +307,4 @@ class GitLabProvider(provider.BaseProvider):
         data = {'name': data['file_name'], 'id': data['blob_id'],
                 'path': data['file_path'], 'size': data['size']}
 
-        return GitLabFileMetadata(data, commit=data['commit_id'],
-                                      thepath=data['file_path'])
+        return GitLabFileMetadata(data, path)

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import base64
 import aiohttp
@@ -17,7 +16,6 @@ from waterbutler.providers.gitlab.metadata import GitLabRevision
 from waterbutler.providers.gitlab.metadata import GitLabFileContentMetadata
 from waterbutler.providers.gitlab.metadata import GitLabFolderContentMetadata
 from waterbutler.providers.gitlab.metadata import GitLabFileTreeMetadata
-from waterbutler.providers.gitlab.metadata import GitLabFolderTreeMetadata
 from waterbutler.providers.gitlab.exceptions import GitLabUnsupportedRepoError
 
 

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -266,6 +266,14 @@ class GitLabProvider(provider.BaseProvider):
         ]
 
     async def create_folder(self, path, branch=None, message=None, **kwargs):
+        """Create a folder at `path`. Returns a `GitLabFolderContentMetadata` object
+        if successful.
+
+        :param str path: user-supplied path to create. must be a directory.
+        :param str branch: user-supplied repository branch to create folder.
+        :param str message: user-supplied message used as commit message.
+        :rtype: :class:`waterbutler.providers.gitlab.metadata.GitLabFileContentMetadata`.
+        """
         WaterButlerPath.validate_folder(path)
 
         message = message or settings.UPLOAD_FILE_MESSAGE

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -176,9 +176,8 @@ class GitLabProvider(provider.BaseProvider):
         '''
 
         url = self.build_repo_url('repository', 'files', file_path=path.full_path, ref=kwargs['ref'])
-        
+
         headers = {"Authorization": 'Bearer {}'.format(self.token)}
-        pdb.set_trace()
 
         resp = await self.make_request(
             'GET',

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -259,9 +259,10 @@ class GitLabProvider(provider.BaseProvider):
         :rtype: :class:`list` of :class:`GitLabRevision`
         :raises: :class:`waterbutler.core.exceptions.RevisionsError`
         """
+        url = self.build_repo_url('repository', 'commits', path=path.path)
         resp = await self.make_request(
                 'GET',
-                self.build_repo_url('commits', path=path.path),
+                url,
                 expects=(200,),
                 throws=exceptions.RevisionsError
                 )
@@ -294,7 +295,14 @@ class GitLabProvider(provider.BaseProvider):
         if not data:
             raise exceptions.NotFoundError(str(path))
 
-        data = {'name': data['file_name'], 'id': data['blob_id'],
+        file_name = data['file_name']
+
+        data = {'name': file_name, 'id': data['blob_id'],
                 'path': data['file_path'], 'size': data['size']}
+
+        mimetype = mimetypes.guess_type(file_name)[0]
+
+        if mimetype:
+            data['mimetype'] = mimetype
 
         return GitLabFileMetadata(data, path, host=self.VIEW_URL, owner=self.owner, repo=self.repo)

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -74,7 +74,7 @@ class GitLabProvider(provider.BaseProvider):
 
     async def _fetch_file_contents(self, path):
 
-        url = self.build_repo_url('repository', 'files', file_path=path.raw_path, ref=path.branch_name)
+        url = self.build_repo_url('repository', 'files', path.full_path, ref=path.branch_name)
 
         resp = await self.make_request(
                 'GET',

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -188,6 +188,7 @@ class GitLabProvider(provider.BaseProvider):
 
         mdict.update(mdict_options)
 
+
         resp.headers = mdict
         resp.content = streams.StringStream(raw)
 

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -1,0 +1,797 @@
+import copy
+import json
+import pdb
+
+import furl
+
+from waterbutler.core import path
+from waterbutler.core import streams
+from waterbutler.core import provider
+from waterbutler.core import exceptions
+
+from waterbutler.providers.gitlab import settings
+from waterbutler.providers.gitlab.metadata import GitLabRevision
+from waterbutler.providers.gitlab.metadata import GitLabFileContentMetadata
+from waterbutler.providers.gitlab.metadata import GitLabFolderContentMetadata
+from waterbutler.providers.gitlab.metadata import GitLabFileTreeMetadata
+from waterbutler.providers.gitlab.metadata import GitLabFolderTreeMetadata
+from waterbutler.providers.gitlab.exceptions import GitLabUnsupportedRepoError
+
+
+GIT_EMPTY_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+
+
+class GitLabPathPart(path.WaterButlerPathPart):
+    def increment_name(self, _id=None):
+        """Overridden to preserve branch from _id upon incrementing"""
+        self._id = _id or (self._id[0], None)
+        self._count += 1
+        return self
+
+
+class GitLabPath(path.WaterButlerPath):
+    PART_CLASS = GitLabPathPart
+
+    def child(self, name, _id=None, folder=False):
+        if _id is None:
+            _id = (self.identifier[0], None)
+        return super().child(name, _id=_id, folder=folder)
+
+
+class GitLabProvider(provider.BaseProvider):
+    """Provider for GitLab repositories.
+
+    **On paths:**  WB and GH use slightly different default conventions for their paths, so we
+    often have to munge our WB paths before comparison. Here is a quick overview::
+
+        WB (dirs):  wb_dir.path == 'foo/bar/'     str(wb_dir) == '/foo/bar/'
+        WB (file):  wb_file.path = 'foo/bar.txt'  str(wb_file) == '/foo/bar.txt'
+        GH (dir):   'foo/bar'
+        GH (file):  'foo/bar.txt'
+
+    API docs: https://developer.github.com/v3/
+
+    Quirks:
+
+    * git doesn't have a concept of empty folders, so this provider creates 0-byte ``.gitkeep``
+      files in the requested folder.
+
+    * The ``contents`` endpoint cannot be used to fetch metadata reliably for all files. Requesting
+      a file that is larger than 1Mb will result in a error response directing you to the ``blob``
+      endpoint.  A recursive tree fetch may be used instead.
+
+    * The tree endpoint truncates results after a large number of files.  It does not provide a way
+      to page through the tree.  Since move, copy, and folder delete operations rely on whole-tree
+      replacement, they cannot be reliably supported for large repos.  Attempting to use them will
+      throw a 501 Not Implemented error.
+    """
+    NAME = 'gitlab'
+    BASE_URL = settings.BASE_URL
+    VIEW_URL = settings.VIEW_URL
+
+    @staticmethod
+    def is_sha(ref):
+        # sha1 is always 40 characters in length
+        try:
+            if len(ref) != 40:
+                return False
+            # sha1 is always base 16 (hex)
+            int(ref, 16)
+        except (TypeError, ValueError, ):
+            return False
+        return True
+
+    def __init__(self, auth, credentials, settings):
+        super().__init__(auth, credentials, settings)
+        self.name = self.auth.get('name', None)
+        self.email = self.auth.get('email', None)
+        self.token = self.credentials['token']
+        self.owner = self.settings['owner']
+        self.repo = self.settings['repo']
+
+    async def validate_v1_path(self, path, **kwargs):
+        if not getattr(self, '_repo', None):
+            self._repo = await self._fetch_repo()
+            self.default_branch = self._repo['default_branch']
+
+        branch_ref = kwargs.get('ref') or kwargs.get('branch') or self.default_branch
+
+        if path == '/':
+            return GitLabPath(path, _ids=[(branch_ref, '')])
+
+        branch_data = await self._fetch_branch(branch_ref)
+        await self._search_tree_for_path(path, branch_data['commit']['commit']['tree']['sha'])
+
+        path = GitLabPath(path)
+        for part in path.parts:
+            part._id = (branch_ref, None)
+
+        # TODO Validate that filesha is a valid sha
+        path.parts[-1]._id = (branch_ref, kwargs.get('fileSha'))
+
+        return path
+
+    async def validate_path(self, path, **kwargs):
+        if not getattr(self, '_repo', None):
+            self._repo = await self._fetch_repo()
+            self.default_branch = self._repo['default_branch']
+
+        path = GitLabPath(path)
+        branch_ref = kwargs.get('ref') or kwargs.get('branch') or self.default_branch
+
+        for part in path.parts:
+            part._id = (branch_ref, None)
+
+        # TODO Validate that filesha is a valid sha
+        path.parts[-1]._id = (branch_ref, kwargs.get('fileSha'))
+
+        return path
+
+    async def revalidate_path(self, base, path, folder=False):
+        return base.child(path, _id=((base.identifier[0], None)), folder=folder)
+
+    def can_duplicate_names(self):
+        return False
+
+    @property
+    def default_headers(self):
+        return {'Authorization': 'Bearer {}'.format(self.token)}
+
+    @property
+    def committer(self):
+        return {
+            'name': self.name,
+            'email': self.email,
+        }
+
+    def build_repo_url(self, *segments, **query):
+        segments = ('projects', '1316205') + segments
+
+        return self.build_url(*segments, **query)
+
+    def can_intra_move(self, other, path=None):
+        return self.can_intra_copy(other, path=path)
+
+    def can_intra_copy(self, other, path=None):
+        return (
+            type(self) == type(other) and
+            self.repo == other.repo and
+            self.owner == other.owner
+        )
+
+    # do these need async?
+    async def intra_copy(self, dest_provider, src_path, dest_path):
+        return (await self._do_intra_move_or_copy(src_path, dest_path, True))
+
+    async def intra_move(self, dest_provider, src_path, dest_path):
+        return (await self._do_intra_move_or_copy(src_path, dest_path, False))
+
+    async def download(self, path, revision=None, **kwargs):
+        '''Get the stream to the specified file on github
+        :param str path: The path to the file on github
+        :param str ref: The git 'ref' a branch or commit sha at which to get the file from
+        :param str fileSha: The sha of file to be downloaded if specifed path will be ignored
+        :param dict kwargs: Ignored
+        '''
+        data = await self.metadata(path, revision=revision)
+        file_sha = path.identifier[1] or data.extra['fileSha']
+
+        resp = await self.make_request(
+            'GET',
+            self.build_repo_url('git', 'blobs', file_sha),
+            headers={'Accept': 'application/vnd.github.v3.raw'}, #TODO
+            expects=(200, ),
+            throws=exceptions.DownloadError,
+        )
+
+        return streams.ResponseStreamReader(resp, size=data.size)
+
+    async def upload(self, stream, path, message=None, branch=None, **kwargs):
+        assert self.name is not None
+        assert self.email is not None
+
+        try:
+            exists = await self.exists(path)
+        except exceptions.ProviderError as e:
+            if e.data.get('message') == 'Git Repository is empty.':
+                exists = False
+                resp = await self.make_request(
+                    'PUT',
+                    self.build_repo_url('contents', '.gitkeep'),
+                    data=json.dumps({
+                        'content': '',
+                        'path': '.gitkeep',
+                        'committer': self.committer,
+                        'branch': path.identifier[0],
+                        'message': 'Initial commit'
+                    }),
+                    expects=(201,),
+                    throws=exceptions.CreateFolderError
+                )
+                data = await resp.json()
+                latest_sha = data['commit']['sha']
+        else:
+            latest_sha = await self._get_latest_sha(ref=path.identifier[0])
+
+        blob = await self._create_blob(stream)
+        tree = await self._create_tree({
+            'base_tree': latest_sha,
+            'tree': [{
+                'path': path.path,
+                'mode': '100644',
+                'type': 'blob',
+                'sha': blob['sha']
+            }]
+        })
+
+        commit = await self._create_commit({
+            'tree': tree['sha'],
+            'parents': [latest_sha],
+            'committer': self.committer,
+            'message': message or (settings.UPDATE_FILE_MESSAGE if exists else settings.UPLOAD_FILE_MESSAGE),
+        })
+
+        # Doesn't return anything useful
+        await self._update_ref(commit['sha'], ref=path.identifier[0])
+
+        # You're hacky
+        return GitLabFileTreeMetadata({
+            'path': path.path,
+            'sha': blob['sha'],
+            'size': stream.size,
+        }, commit=commit), not exists
+
+    async def delete(self, path, sha=None, message=None, branch=None,
+               confirm_delete=0, **kwargs):
+        """Delete file, folder, or provider root contents
+
+        :param GitHubPath path: GitHubPath path object for file, folder, or root
+        :param str sha: SHA-1 checksum of file/folder object
+        :param str message: Commit message
+        :param str branch: Repository branch
+        :param int confirm_delete: Must be 1 to confirm root folder delete
+        """
+        assert self.name is not None
+        assert self.email is not None
+
+        if path.is_root:
+            if confirm_delete == 1:
+                await self._delete_root_folder_contents(path)
+            else:
+                raise exceptions.DeleteError(
+                    'confirm_delete=1 is required for deleting root provider folder',
+                    code=400,
+                )
+        elif path.is_dir:
+            await self._delete_folder(path, message, **kwargs)
+        else:
+            await self._delete_file(path, message, **kwargs)
+
+    async def metadata(self, path, ref=None, recursive=False, **kwargs):
+        """Get Metadata about the requested file or folder
+        :param str path: The path to a file or folder
+        :param str ref: A branch or a commit SHA
+        :rtype dict:
+        :rtype list:
+        """
+        if path.is_dir:
+            return (await self._metadata_folder(path, ref=ref, recursive=recursive, **kwargs))
+        else:
+            return (await self._metadata_file(path, ref=ref, **kwargs))
+
+    async def revisions(self, path, sha=None, **kwargs):
+        resp = await self.make_request(
+            'GET',
+            self.build_repo_url('commits', path=path.path, sha=sha or path.identifier),
+            expects=(200, ),
+            throws=exceptions.RevisionsError
+        )
+
+        return [
+            GitLabRevision(item)
+            for item in (await resp.json())
+        ]
+
+    async def create_folder(self, path, branch=None, message=None, **kwargs):
+        GitLabPath.validate_folder(path)
+
+        assert self.name is not None
+        assert self.email is not None
+        message = message or settings.UPLOAD_FILE_MESSAGE
+
+        keep_path = path.child('.gitkeep')
+
+        data = {
+            'content': '',
+            'path': keep_path.path,
+            'committer': self.committer,
+            'branch': path.identifier[0],
+            'message': message or settings.UPLOAD_FILE_MESSAGE
+        }
+
+        resp = await self.make_request(
+            'PUT',
+            self.build_repo_url('contents', keep_path.path),
+            data=json.dumps(data),
+            expects=(201, 422, 409),
+            throws=exceptions.CreateFolderError
+        )
+
+        data = await resp.json()
+
+        if resp.status in (422, 409):
+            if resp.status == 409 or data.get('message') == 'Invalid request.\n\n"sha" wasn\'t supplied.':
+                raise exceptions.FolderNamingConflict(str(path))
+            raise exceptions.CreateFolderError(data, code=resp.status)
+
+        data['content']['name'] = path.name
+        data['content']['path'] = data['content']['path'].replace('.gitkeep', '')
+
+        return GitLabFolderContentMetadata(data['content'], commit=data['commit'])
+
+    async def _delete_file(self, path, message=None, **kwargs):
+        if path.identifier[1]:
+            sha = path.identifier
+        else:
+            sha = (await self.metadata(path)).extra['fileSha']
+
+        if not sha:
+            raise exceptions.MetadataError('A sha is required for deleting')
+
+        data = {
+            'sha': sha,
+            'branch': path.identifier[0],
+            'committer': self.committer,
+            'message': message or settings.DELETE_FILE_MESSAGE,
+        }
+
+        resp = await self.make_request(
+            'DELETE',
+            self.build_repo_url('contents', path.path),
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps(data),
+            expects=(200, ),
+            throws=exceptions.DeleteError,
+        )
+        await resp.release()
+
+    async def _delete_folder(self, path, message=None, **kwargs):
+        branch_data = await self._fetch_branch(path.identifier[0])
+
+        old_commit_sha = branch_data['commit']['sha']
+        old_commit_tree_sha = branch_data['commit']['commit']['tree']['sha']
+
+        # e.g. 'level1', 'level2', or ''
+        tree_paths = path.parts[1:]
+        trees = [{
+            'target': tree_paths[0].value,
+            'tree': [
+                {
+                    'path': item['path'],
+                    'mode': item['mode'],
+                    'type': item['type'],
+                    'sha': item['sha'],
+                }
+                for item in (await self._fetch_tree(old_commit_tree_sha))['tree']
+            ]
+        }]
+
+        for idx, tree_path in enumerate(tree_paths[:-1]):
+            try:
+                tree_sha = next(x for x in trees[-1]['tree'] if x['path'] == tree_path.value)['sha']
+            except StopIteration:
+                raise exceptions.MetadataError(
+                    'Could not delete folder \'{0}\''.format(path),
+                    code=404,
+                )
+            trees.append({
+                'target': tree_paths[idx + 1].value,
+                'tree': [
+                    {
+                        'path': item['path'],
+                        'mode': item['mode'],
+                        'type': item['type'],
+                        'sha': item['sha'],
+                    }
+                    for item in (await self._fetch_tree(tree_sha))['tree']
+                ]
+            })
+
+        # The last tree's structure is rewritten w/o the target folder, all others
+        # in the hierarchy are simply updated to reflect this change.
+        tree = trees.pop()
+        if tree['target'] == '':
+            # Git Empty SHA
+            tree_sha = GIT_EMPTY_SHA
+        else:
+            # Delete the folder from the tree cast to list iterator over all values
+            current_tree = tree['tree']
+            tree['tree'] = list(filter(lambda x: x['path'] != tree['target'], tree['tree']))
+            if current_tree == tree['tree']:
+                raise exceptions.NotFoundError(str(path))
+
+            tree_data = await self._create_tree({'tree': tree['tree']})
+            tree_sha = tree_data['sha']
+
+            # Update parent tree(s)
+            for tree in reversed(trees):
+                for item in tree['tree']:
+                    if item['path'] == tree['target']:
+                        item['sha'] = tree_sha
+                        break
+                tree_data = await self._create_tree({'tree': tree['tree']})
+                tree_sha = tree_data['sha']
+
+        # Create a new commit which references our top most tree change.
+        message = message or settings.DELETE_FOLDER_MESSAGE
+        commit_resp = await self.make_request(
+            'POST',
+            self.build_repo_url('git', 'commits'),
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps({
+                'message': message,
+                'committer': self.committer,
+                'tree': tree_sha,
+                'parents': [
+                    old_commit_sha,
+                ],
+            }),
+            expects=(201, ),
+            throws=exceptions.DeleteError,
+        )
+        commit_data = await commit_resp.json()
+        commit_sha = commit_data['sha']
+
+        # Update repository reference, point to the newly created commit.
+        # No need to store data, rely on expects to raise exceptions
+        resp = await self.make_request(
+            'PATCH',
+            self.build_repo_url('git', 'refs', 'heads', path.identifier[0]),
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps({'sha': commit_sha}),
+            expects=(200, ),
+            throws=exceptions.DeleteError,
+        )
+        await resp.release()
+
+    async def _delete_root_folder_contents(self, path, message=None, **kwargs):
+        """Delete the contents of the root folder.
+
+        :param GitHubPath path: GitHubPath path object for folder
+        :param str message: Commit message
+        """
+        branch_data = await self._fetch_branch(path.identifier[0])
+        old_commit_sha = branch_data['commit']['sha']
+        tree_sha = GIT_EMPTY_SHA
+        message = message or settings.DELETE_FOLDER_MESSAGE
+        commit_resp = await self.make_request(
+            'POST',
+            self.build_repo_url('git', 'commits'),
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps({
+                'message': message,
+                'committer': self.committer,
+                'tree': tree_sha,
+                'parents': [
+                    old_commit_sha,
+                ],
+            }),
+            expects=(201, ),
+            throws=exceptions.DeleteError,
+        )
+        commit_data = await commit_resp.json()
+        commit_sha = commit_data['sha']
+
+        # Update repository reference, point to the newly created commit.
+        # No need to store data, rely on expects to raise exceptions
+        await self.make_request(
+            'PATCH',
+            self.build_repo_url('git', 'refs', 'heads', path.identifier[0]),
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps({'sha': commit_sha}),
+            expects=(200, ),
+            throws=exceptions.DeleteError,
+        )
+
+    async def _fetch_branch(self, branch):
+        resp = await self.make_request(
+            'GET',
+            self.build_repo_url('branches', branch)
+        )
+        return (await resp.json())
+
+    async def _fetch_contents(self, path, ref=None):
+        url = furl.furl(self.build_repo_url('contents', path.path))
+        if ref:
+            url.args.update({'ref': ref})
+        resp = await self.make_request(
+            'GET',
+            url.url,
+            expects=(200, ),
+            throws=exceptions.MetadataError
+        )
+        return (await resp.json())
+
+    async def _fetch_repo(self):
+        resp = await self.make_request(
+            'GET',
+            self.build_repo_url(),
+            expects=(200, ),
+            throws=exceptions.MetadataError
+        )
+        return (await resp.json())
+
+    async def _fetch_tree(self, sha, recursive=False):
+        url = furl.furl(self.build_repo_url('git', 'trees', sha))
+        if recursive:
+            url.args.update({'recursive': 1})
+        resp = await self.make_request(
+            'GET',
+            url.url,
+            expects=(200, ),
+            throws=exceptions.MetadataError
+        )
+        tree = await resp.json()
+
+        if tree['truncated']:
+            raise GitLabUnsupportedRepoError
+
+        return tree
+
+    async def _search_tree_for_path(self, path, tree_sha, recursive=True):
+        """Search through the given tree for an entity matching the name and type of `path`.
+        """
+        tree = await self._fetch_tree(tree_sha, recursive=True)
+
+        if tree['truncated']:
+            raise GitLabUnsupportedRepoError
+
+        implicit_type = 'tree' if path.endswith('/') else 'blob'
+
+        for entity in tree['tree']:
+            if entity['path'] == path.strip('/') and entity['type'] == implicit_type:
+                return entity
+
+        raise exceptions.NotFoundError(str(path))
+
+    async def _create_tree(self, tree):
+        resp = await self.make_request(
+            'POST',
+            self.build_repo_url('git', 'trees'),
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps(tree),
+            expects=(201, ),
+            throws=exceptions.ProviderError,
+        )
+        return (await resp.json())
+
+    async def _create_commit(self, commit):
+        resp = await self.make_request(
+            'POST',
+            self.build_repo_url('git', 'commits'),
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps(commit),
+            expects=(201, ),
+            throws=exceptions.ProviderError,
+        )
+        return (await resp.json())
+
+    async def _create_blob(self, stream):
+        blob_stream = streams.JSONStream({
+            'encoding': 'base64',
+            'content': streams.Base64EncodeStream(stream),
+        })
+
+        resp = await self.make_request(
+            'POST',
+            self.build_repo_url('git', 'blobs'),
+            data=blob_stream,
+            headers={
+                'Content-Type': 'application/json',
+                'Content-Length': str(blob_stream.size),
+            },
+            expects=(201, ),
+            throws=exceptions.UploadError,
+        )
+        return (await resp.json())
+
+    def _is_sha(self, ref):
+        # sha1 is always 40 characters in length
+        try:
+            if len(ref) != 40:
+                return False
+            # sha1 is always base 16 (hex)
+            int(ref, 16)
+        except (TypeError, ValueError, ):
+            return False
+        return True
+
+    def _web_view(self, path):
+        segments = (self.owner, self.repo, 'blob', path.identifier[0], path.path)
+        return provider.build_url(settings.VIEW_URL, *segments)
+
+    async def _metadata_folder(self, path, recursive=False, **kwargs):
+        # if we have a sha or recursive lookup specified we'll need to perform
+        # the operation using the git/trees api which requires a sha.
+
+        if not (self._is_sha(path.identifier[0]) or recursive):
+            try:
+                data = await self._fetch_contents(path, ref=path.identifier[0])
+            except exceptions.MetadataError as e:
+                if e.data.get('message') == 'This repository is empty.':
+                    data = []
+                else:
+                    raise
+
+            if isinstance(data, dict):
+                raise exceptions.MetadataError(
+                    'Could not retrieve folder "{0}"'.format(str(path)),
+                    code=404,
+                )
+
+            ret = []
+            for item in data:
+                if item['type'] == 'dir':
+                    ret.append(GitLabFolderContentMetadata(item))
+                else:
+                    ret.append(GitLabFileContentMetadata(item, web_view=item['html_url']))
+            return ret
+
+    async def _metadata_file(self, path, revision=None, ref=None, **kwargs):
+        resp = await self.make_request(
+            'GET',
+            self.build_repo_url('commits', path=path.path, sha=revision or ref or path.identifier[0]),
+            expects=(200, ),
+            throws=exceptions.MetadataError,
+        )
+
+        commits = await resp.json()
+
+        if not commits:
+            raise exceptions.NotFoundError(str(path))
+
+        latest = commits[0]
+        tree = await self._fetch_tree(latest['commit']['tree']['sha'], recursive=True)
+
+        try:
+            data = next(
+                x for x in tree['tree']
+                if x['path'] == path.path
+            )
+        except StopIteration:
+            raise exceptions.NotFoundError(str(path))
+
+        if isinstance(data, list):
+            raise exceptions.MetadataError(
+                'Could not retrieve file "{0}"'.format(str(path)),
+                code=404,
+            )
+
+        return GitLabFileTreeMetadata(data, commit=latest['commit'], web_view=self._web_view(path))
+
+    async def _get_latest_sha(self, ref='master'):
+        resp = await self.make_request(
+            'GET',
+            self.build_repo_url('git', 'refs', 'heads', ref),
+            expects=(200, ),
+            throws=exceptions.ProviderError
+        )
+        data = await resp.json()
+        return data['object']['sha']
+
+    async def _update_ref(self, sha, ref='master'):
+        resp = await self.make_request(
+            'POST',
+            self.build_repo_url('git', 'refs', 'heads', ref),
+            data=json.dumps({
+                'sha': sha,
+            }),
+            expects=(200, ),
+            throws=exceptions.ProviderError
+        )
+        return (await resp.json())
+
+    async def _do_intra_move_or_copy(self, src_path, dest_path, is_copy):
+
+        # ON PATHS:
+        #   WB and GH use slightly different default conventions for their paths, so we often
+        #   have to munge our WB paths before comparison. Here is a quick overview:
+        #     WB (dirs):  wb_dir.path == 'foo/bar/'     str(wb_dir) == '/foo/bar/'
+        #     WB (file):  wb_file.path = 'foo/bar.txt'  str(wb_file) == '/foo/bar.txt'
+        #     GH (dir):   'foo/bar'
+        #     GH (file):  'foo/bar.txt'
+
+        branch = src_path.identifier[0]
+        branch_data = await self._fetch_branch(branch)
+
+        old_commit_sha = branch_data['commit']['sha']
+        old_commit_tree_sha = branch_data['commit']['commit']['tree']['sha']
+
+        tree = await self._fetch_tree(old_commit_tree_sha, recursive=True)
+        exists = any(x['path'] == dest_path.path.rstrip('/') for x in tree['tree'])
+
+        # these are the blobs to copy/move
+        blobs = [
+            item
+            for item in tree['tree']
+            if src_path.is_dir and item['path'].startswith(src_path.path) or
+            src_path.is_file and item['path'] == src_path.path
+        ]
+
+        # if we're overwriting an existing dir, we must remove its blobs from the tree
+        if dest_path.is_dir:
+            tree['tree'] = [
+                item
+                for item in tree['tree']
+                if not item['path'].startswith(dest_path.path)
+            ]
+
+        if len(blobs) == 0:
+            raise exceptions.NotFoundError(str(src_path))
+
+        if src_path.is_file:
+            assert len(blobs) == 1, 'Found multiple targets'
+
+        # if this is a copy, duplicate and append our source blobs. The originals will be updated
+        # with the new destination path.
+        if is_copy:
+            tree['tree'].extend([copy.deepcopy(blob) for blob in blobs])
+
+        # see, I told you they'd be overwritten
+        for blob in blobs:
+            blob['path'] = blob['path'].replace(src_path.path, dest_path.path, 1)
+
+        # github infers tree contents from blob paths
+        # see: http://www.levibotelho.com/development/commit-a-file-with-the-github-api/
+        tree['tree'] = [item for item in tree['tree'] if item['type'] != 'tree']
+        new_tree_data = await self._create_tree({'tree': tree['tree']})
+        new_tree_sha = new_tree_data['sha']
+
+        # Create a new commit which references our top most tree change.
+        commit_resp = await self.make_request(
+            'POST',
+            self.build_repo_url('git', 'commits'),
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps({
+                'tree': new_tree_sha,
+                'parents': [old_commit_sha],
+                'committer': self.committer,
+                'message': settings.COPY_MESSAGE if is_copy else settings.MOVE_MESSAGE
+            }),
+            expects=(201, ),
+            throws=exceptions.DeleteError,
+        )
+
+        commit = await commit_resp.json()
+
+        # Update repository reference, point to the newly created commit.
+        # No need to store data, rely on expects to raise exceptions
+        resp = await self.make_request(
+            'PATCH',
+            self.build_repo_url('git', 'refs', 'heads', branch),
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps({'sha': commit['sha']}),
+            expects=(200, ),
+            throws=exceptions.DeleteError,
+        )
+        await resp.release()
+
+        if dest_path.is_file:
+            assert len(blobs) == 1, 'Destination file should have exactly one candidate'
+            return GitLabFileTreeMetadata(blobs[0], commit=commit), not exists
+
+        folder = GitLabFolderTreeMetadata({
+            'path': dest_path.path.strip('/')
+        }, commit=commit)
+
+        folder.children = []
+
+        for item in blobs:
+            if item['path'] == src_path.path.rstrip('/'):
+                continue
+            if item['type'] == 'tree':
+                folder.children.append(GitLabFolderTreeMetadata(item))
+            else:
+                folder.children.append(GitLabFileTreeMetadata(item))
+
+        return folder, not exists

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -11,27 +11,9 @@ from waterbutler.core.path import WaterButlerPath
 
 from waterbutler.providers.gitlab import settings
 from waterbutler.providers.gitlab.metadata import GitLabRevision
-from waterbutler.providers.gitlab.metadata import GitLabFileContentMetadata
-from waterbutler.providers.gitlab.metadata import GitLabFolderContentMetadata
-from waterbutler.providers.gitlab.metadata import GitLabFileTreeMetadata
-
-
-class GitLabPath(WaterButlerPath):
-    """WB and GL use slightly different default conventions for their paths, so we
-    often have to munge our WB paths before comparison. Here is a quick overview::
-
-        WB (dirs):  wb_dir.path == 'foo/bar/'     str(wb_dir) == '/foo/bar/'
-        WB (file):  wb_file.path = 'foo/bar.txt'  str(wb_file) == '/foo/bar.txt'
-        GL (dir):   'foo/bar'
-        GL (file):  'foo/bar.txt'
-    """
-
-    def __init__(self, path):
-        wb_path = path
-        if path is not '/':
-            if not path.startswith('/'):
-                wb_path = "/{}".format(path)
-        super().__init__(wb_path)
+from waterbutler.providers.gitlab.metadata import GitLabFileMetadata
+from waterbutler.providers.gitlab.metadata import GitLabFolderMetadata
+from waterbutler.providers.gitlab.path import GitLabPath
 
 
 class GitLabProvider(provider.BaseProvider):
@@ -67,8 +49,8 @@ class GitLabProvider(provider.BaseProvider):
         self.owner = self.settings['owner']
         self.repo = self.settings['repo']
         self.repo_id = self.settings['repo_id']
-        self.BASE_URL = self.settings['base_url']
-        self.VIEW_URL = self.settings['view_url']
+        self.BASE_URL = self.settings['host'] + '/api/v3'
+        self.VIEW_URL = self.settings['host']
 
     @property
     def default_headers(self):
@@ -76,7 +58,7 @@ class GitLabProvider(provider.BaseProvider):
 
         :rtype: :class:`dict` with `Authorization` token
         """
-        return {'Authorization': 'Bearer {}'.format(self.token)}
+        return {'Authorization': 'Bearer {}'.format(self.token), 'Accept': 'text/json'}
 
     @property
     def committer(self):
@@ -98,12 +80,9 @@ class GitLabProvider(provider.BaseProvider):
                                   file_path=path,
                                   ref=ref)
 
-        headers = {'Authorization': 'Bearer {}'.format(self.token), 'Accept': 'text/json'}
-
         resp = await self.make_request(
             'GET',
             url,
-            headers=headers,
             expects=(200,),
             throws=exceptions.NotFoundError(path.full_path)
         )
@@ -114,17 +93,25 @@ class GitLabProvider(provider.BaseProvider):
     async def _fetch_tree_contents(self, path, ref):
 
         url = self.build_repo_url('repository', 'tree', path=path, ref=ref)
-        headers = {'Authorization': 'Bearer {}'.format(self.token), 'Accept': 'text/json'}
 
         resp = await self.make_request(
             'GET',
             url,
-            headers=headers,
-            expects=(200,),
+            expects=(200, 404),
             throws=exceptions.NotFoundError(path.full_path)
         )
 
-        return await resp.json()
+        data = await resp.json()
+
+        if isinstance(data, dict):
+            # Empty Project
+            if data['message'] == '404 Tree Not Found':
+                return []
+            # True Not Found
+            elif resp.status == 404:
+                raise exceptions.NotFoundError(path.full_path)
+
+        return data
 
     async def validate_v1_path(self, path, **kwargs):
         """Ensure path is in Waterbutler v1 format.
@@ -135,7 +122,7 @@ class GitLabProvider(provider.BaseProvider):
         """
 
         if 'ref' not in kwargs:
-            raise exceptions.NotFoundError('you must specify the ref branch')
+            raise exceptions.InvalidPathError('you must specify the ref branch')
 
         ref = kwargs['ref']
 
@@ -187,12 +174,9 @@ class GitLabProvider(provider.BaseProvider):
         url = self.build_repo_url('repository', 'files', file_path=path.full_path,
                                   ref=kwargs['branch'])
 
-        headers = {"Authorization": 'Bearer {}'.format(self.token)}
-
         resp = await self.make_request(
             'GET',
             url,
-            headers=headers,
             expects=(200, ),
             throws=exceptions.DownloadError,
         )
@@ -217,60 +201,19 @@ class GitLabProvider(provider.BaseProvider):
         return streams.ResponseStreamReader(resp, len(raw))
 
     async def upload(self, stream, path, message=None, branch=None, **kwargs):
-        """Uploads the given stream to GitLab.
-
-        :param waterbutler.core.streams.RequestWrapper stream: The stream to put to GitLab
-        :param str path: The full path of the key to upload to/into
-        :param str message: The commit message
-        :param str branch: The branch which the ``stream`` will be added
-        :param dict kwargs: Ignored
-
-        :rtype: dict, bool
-        :raises: :class:`waterbutler.core.exceptions.UploadError`
-        """
-        assert self.name is not None
-        assert self.email is not None
-
-        insert = False
-        try:
-            metadata = await self.metadata(path, ref=branch)
-        except:
-            insert = True
-
-        try:
-            await self._upsert_blob(stream, path.path, branch, insert)
-            metadata = await self.metadata(path, ref=branch)
-        except:
-            raise exceptions.UploadError
-
-        return metadata, insert
+        raise NotImplementedError
 
     async def delete(self, path, sha=None, message=None, branch=None,
                confirm_delete=0, **kwargs):
-        """Delete file, folder, or provider root contents.
-
-        :param GitLabPath path: GitLabPath path object for file, folder, or root
-        :param str sha: SHA-1 checksum of file/folder object
-        :param str message: Commit message
-        :param str branch: Repository branch
-        :param int confirm_delete: Must be 1 to confirm root folder delete
-        :raises: :class:`waterbutler.core.exceptions.DeleteError`
-        """
-        assert self.name is not None
-        assert self.email is not None
-
-        if path.is_dir:
-            await self._delete_folder(path, message, branch)
-        else:
-            await self._delete_file(path, message, branch)
+        raise NotImplementedError
 
     async def metadata(self, path, ref=None, recursive=False, **kwargs):
         """Get Metadata about the requested file or folder.
 
         :param GitLabPath path: The path to a file or folder
         :param str ref: A branch or a commit SHA
-        :rtype: :class:`GitLabFileTreeMetadata`
-        :rtype: :class:`list` of :class:`GitLabFileContentMetadata` or :class:`GitLabFolderContentMetadata`
+        :rtype: :class:`GitLabFileMetadata`
+        :rtype: :class:`list` of :class:`GitLabFileMetadata` or :class:`GitLabFolderMetadata`
         :raises: :class:`waterbutler.core.exceptions.MetadataError`
         """
         try:
@@ -305,140 +248,7 @@ class GitLabProvider(provider.BaseProvider):
         return [GitLabRevision(item) for item in (await resp.json())]
 
     async def create_folder(self, path, branch=None, message=None, **kwargs):
-        """Create a folder at `path`. Returns a `GitLabFolderContentMetadata` object
-        if successful.
-
-        :param str path: user-supplied path to create. must be a directory
-        :param str branch: user-supplied repository git branch to create folder
-        :param str message: user-supplied message used as commit message
-        :rtype: :class:`GitLabFolderContentMetadata`
-        :raises: :class:`waterbutler.core.exceptions.FolderCreationError`
-        """
-        GitLabPath.validate_folder(path)
-
-        message = message or settings.UPLOAD_FILE_MESSAGE
-        branch = branch or path.branch_ref
-
-        keep_path = path.child('.gitkeep')
-
-        content = ''
-        stream = streams.StringStream(content)
-
-        try:
-            resp, insert = await self.upload(stream, keep_path, message, branch, **kwargs)
-        except:
-            raise exceptions.FolderCreationError
-
-        raw = {'name': path.path.strip('/').split('/')[-1]}
-        return GitLabFolderContentMetadata(raw, thepath=path.parent)
-
-    async def _delete_file(self, path, message=None, branch=None, **kwargs):
-
-        if branch is None:
-            raise exceptions.DeleteError(
-                'you must specify the branch to delete the file',
-                code=400,
-            )
-
-        if message is None:
-            message = 'File {} deleted'.format(path.full_path)
-
-        url = self.build_repo_url('repository', 'files', file_path=path.full_path,
-                                  branch_name=branch, commit_message=message)
-
-        headers = {"Authorization": 'Bearer {}'.format(self.token)}
-
-        resp = await self.make_request(
-            'DELETE',
-            url,
-            headers=headers,
-            expects=(200, ),
-            throws=exceptions.DeleteError,
-        )
-        await resp.release()
-
-    async def _delete_folder(self, path, message=None, branch=None, **kwargs):
-
-        if branch is None:
-            raise exceptions.DeleteError(
-                'you must specify the branch to delete the file',
-                code=400,
-            )
-
-        if message is None:
-            message = 'Folder {} deleted'.format(path.full_path)
-
-        try:
-            contents = await self._fetch_contents(path, ref=branch)
-        except:
-            raise exceptions.DeleteError('error on fetch the folder content', code=400)
-
-        for data in contents:
-            if data['type'] == 'blob':
-                sub_path = await self.validate_path(data['path'])
-                await self._delete_file(sub_path, branch=branch, message=message)
-            if data['type'] == 'tree':
-                sub_path = await self.validate_path("{}/".format(data['path']))
-                await self._delete_folder(sub_path, branch=branch, message=message)
-
-    async def _fetch_contents(self, path, ref=None):
-        url = furl.furl(self.build_repo_url('repository', 'tree'))
-
-        if path.full_path:
-            url.add({'path': path.full_path})
-
-        if ref:
-            url.args.update({'ref_name': ref})
-
-        resp = await self.make_request(
-            'GET',
-            url.url,
-            expects=(200, 404),
-            throws=exceptions.NotFoundError(path.full_path)
-        )
-
-        data = await resp.json()
-
-        if isinstance(data, dict):
-            # Empty Project
-            if data['message'] == '404 Tree Not Found':
-                return []
-            # True Not Found
-            elif resp.status == 404:
-                raise exceptions.NotFoundError(path.full_path)
-
-        return data
-
-    async def _upsert_blob(self, stream, filepath, branchname, insert=True):
-        if type(stream) is not streams.Base64EncodeStream:
-            stream = streams.Base64EncodeStream(stream)
-
-        if insert:
-            message = 'File {0} created'.format(filepath)
-            method = 'POST'
-        else:
-            message = 'File {0} updated'.format(filepath)
-            method = 'PUT'
-
-        blob_stream = streams.JSONStream({
-            'file_path': filepath,
-            'branch_name': branchname,
-            'commit_message': message,
-            'encoding': 'base64',
-            'content': stream
-        })
-
-        resp = await self.make_request(
-            method,
-            self.build_repo_url('repository', 'files'),
-            data=blob_stream,
-            headers={
-                'Content-Type': 'application/json',
-                'Content-Length': str(blob_stream.size),
-            },
-            throws=exceptions.UploadError,
-        )
-        return (await resp.json())
+        raise NotImplementedError
 
     def _is_sha(self, ref):
         # sha1 is always 40 characters in length
@@ -451,44 +261,35 @@ class GitLabProvider(provider.BaseProvider):
             return False
         return True
 
-    def _web_view(self, path):
-        segments = (self.owner, self.repo, 'blob', path.branch_ref, path.path)
-        return provider.build_url(settings.VIEW_URL, *segments)
-
     async def _metadata_folder(self, path, recursive=False, ref=None, **kwargs):
         # if we have a sha or recursive lookup specified we'll need to perform
         # the operation using the git/trees api which requires a sha.
 
         if not (self._is_sha(ref) or recursive):
 
-            data = await self._fetch_contents(path, ref=ref)
+            data = await self._fetch_tree_contents(path, ref=ref)
 
             ret = []
             for item in data:
                 commit = ref or item['id']
                 if item['type'] == 'tree':
-                    ret.append(GitLabFolderContentMetadata(item, thepath=path, commit=commit))
+                    ret.append(GitLabFolderMetadata(item, thepath=path, commit=commit))
                 else:
-                    ret.append(GitLabFileContentMetadata(item, web_view=item['name'],
+                    ret.append(GitLabFileMetadata(item, web_view=item['name'],
                                                          thepath=path, commit=commit))
             return ret
 
     async def _metadata_file(self, path, revision=None, ref='master', **kwargs):
 
-        resp = await self.make_request(
-            'GET',
-            self.build_repo_url('repository', 'files', file_path=path.full_path, ref=ref),
-            expects=(200, ),
-            throws=exceptions.MetadataError,
-        )
+        resp = await self._fetch_file_contents(path, ref)
 
-        commits = await resp.json()
+        data = await resp.json()
 
-        if not commits:
+        if not data:
             raise exceptions.NotFoundError(str(path))
 
-        data = {'name': commits['file_name'], 'id': commits['blob_id'],
-                'path': commits['file_path'], 'size': commits['size']}
+        data = {'name': data['file_name'], 'id': data['blob_id'],
+                'path': data['file_path'], 'size': data['size']}
 
-        return GitLabFileTreeMetadata(data, commit=commits['commit_id'],
-                                      thepath=commits['file_path'])
+        return GitLabFileMetadata(data, commit=data['commit_id'],
+                                      thepath=data['file_path'])

--- a/waterbutler/providers/gitlab/settings.py
+++ b/waterbutler/providers/gitlab/settings.py
@@ -6,9 +6,6 @@ except ImportError:
 config = settings.get('GITLAB_PROVIDER_CONFIG', {})
 
 
-BASE_URL = config.get('BASE_URL', 'https://gitlab.com/api/v3')
-VIEW_URL = config.get('VIEW_URL', 'https://gitlab.com/')
-
 MOVE_MESSAGE = config.get('MOVE_MESSAGE', 'Moved on behalf of WaterButler')
 COPY_MESSAGE = config.get('COPY_MESSAGE', 'Copied on behalf of WaterButler')
 DELETE_FILE_MESSAGE = config.get('DELETE_FILE_MESSAGE', 'File deleted on behalf of WaterButler')

--- a/waterbutler/providers/gitlab/settings.py
+++ b/waterbutler/providers/gitlab/settings.py
@@ -1,0 +1,17 @@
+try:
+    from waterbutler import settings
+except ImportError:
+    settings = {}
+
+config = settings.get('GITLAB_PROVIDER_CONFIG', {})
+
+
+BASE_URL = config.get('BASE_URL', 'https://gitlab.com/api/v3')
+VIEW_URL = config.get('VIEW_URL', 'https://gitlab.com/')
+
+MOVE_MESSAGE = config.get('MOVE_MESSAGE', 'Moved on behalf of WaterButler')
+COPY_MESSAGE = config.get('COPY_MESSAGE', 'Copied on behalf of WaterButler')
+DELETE_FILE_MESSAGE = config.get('DELETE_FILE_MESSAGE', 'File deleted on behalf of WaterButler')
+UPDATE_FILE_MESSAGE = config.get('UPDATE_FILE_MESSAGE', 'File updated on behalf of WaterButler')
+UPLOAD_FILE_MESSAGE = config.get('UPLOAD_FILE_MESSAGE', 'File uploaded on behalf of WaterButler')
+DELETE_FOLDER_MESSAGE = config.get('DELETE_FOLDER_MESSAGE', 'Folder deleted on behalf of WaterButler')

--- a/waterbutler/providers/gitlab/settings.py
+++ b/waterbutler/providers/gitlab/settings.py
@@ -1,9 +1,6 @@
-try:
-    from waterbutler import settings
-except ImportError:
-    settings = {}
+from waterbutler import settings
 
-config = settings.get('GITLAB_PROVIDER_CONFIG', {})
+config = settings.child('GITLAB_PROVIDER_CONFIG')
 
 
 MOVE_MESSAGE = config.get('MOVE_MESSAGE', 'Moved on behalf of WaterButler')


### PR DESCRIPTION
# Purpose

Implement the GitLab addon according to the GitLab Integration Grant Spec at https://gist.github.com/felliott/cc3d48a492c174545b7f
# Changes

Adds the GitLab provider.
To communicate with a GitLab instance, this provider receives the GitLab instance URL and an OAuth2 token to use the API as the desired user.
# Side effects
# Roadmap
- [x] Browse files from default branch from repository
- [x] Browse files from any branch from repository
- [x] List repository branches
- [x] File action: Download
- [x] File action: Delete
- [x] File action: Create folder
- [x] File action: Upload
- [x] File action: View
- [x] File action: Move file (waiting issue - https://gitlab.com/gitlab-org/gitlab-ce/issues/21102)
- [x] Tests
- [x] Documentation
