### PR TITLE
[OSF-6584]Convert Dropbox provider to Dropbox v2 API

### DIFF
--- a/tests/providers/dropbox/test_provider.py
+++ b/tests/providers/dropbox/test_provider.py
@@ -12,6 +12,7 @@ from waterbutler.core.path import WaterButlerPath
 
 from waterbutler.providers.dropbox import DropboxProvider
 from waterbutler.providers.dropbox.metadata import DropboxFileMetadata
+from waterbutler.providers.dropbox.exceptions import DropboxNamingConflictError
 
 
 @pytest.fixture
@@ -53,65 +54,61 @@ def file_stream(file_like):
 
 
 @pytest.fixture
+def folder_children():
+    return {"entries":
+               [
+                   {".tag": "file",
+                    "name": "flower.jpg",
+                    "path_lower": "/photos/flower.jpg",
+                    "path_display": "/Photos/flower.jpg",
+                    "id": "id:8y8sAJlrhuAAAAAAAAAAAQ",
+                    "client_modified": "2016-06-13T19:08:17Z",
+                    "server_modified": "2016-06-13T19:08:17Z",
+                    "rev": "38af1b183490",
+                    "size": 124778}
+               ],
+            "cursor": "AAGFHXqUgavlrBd2TBDxKNdV2rnu48QeThbxccGEvaSwiAAIt5-iho9P8EJIIVdSh6RKRNHq-An2lyyjJ34yCOhyBcIa6Gh6tYOko_okZgZTP_Ga0-kqHtm1HaQOQNdOmPPoNwiXB_rflzSLwq6AXi_F",
+            "has_more": False
+           }
+
+
+@pytest.fixture
 def folder_metadata():
     return {
-        "size": "0 bytes",
-        "hash": "37eb1ba1849d4b0fb0b28caf7ef3af52",
-        "bytes": 0,
-        "thumb_exists": False,
-        "rev": "714f029684fe",
-        "modified": "Wed, 27 Apr 2011 22:18:51 +0000",
-        "path": "/Photos",
-        "is_dir": True,
-        "icon": "folder",
-        "root": "dropbox",
-        "contents": [
-            {
-                "size": "2.3 MB",
-                "rev": "38af1b183490",
-                "thumb_exists": True,
-                "bytes": 2453963,
-                "modified": "Mon, 07 Apr 2014 23:13:16 +0000",
-                "client_mtime": "Thu, 29 Aug 2013 01:12:02 +0000",
-                "path": "/Photos/flower.jpg",
-                "photo_info": {
-                "lat_long": [
-                    37.77256666666666,
-                    -122.45934166666667
-                ],
-                "time_taken": "Wed, 28 Aug 2013 18:12:02 +0000"
-                },
-                "is_dir": False,
-                "icon": "page_white_picture",
-                "root": "dropbox",
-                "mime_type": "image/jpeg",
-                "revision": 14511
-            }
-        ],
-        "revision": 29007
+        ".tag": "folder",
+        "name": "newfolder",
+        "path_lower": "/newfolder",
+        "path_display": "/newfolder",
+        "id": "id:67BLXqRKo-gAAAAAAAADZg"
     }
 
 
 @pytest.fixture
 def file_metadata():
     return {
-        "size": "225.4KB",
-        "rev": "35e97029684fe",
-        "thumb_exists": False,
-        "bytes": 230783,
-        "modified": "Tue, 19 Jul 2011 21:55:38 +0000",
-        "client_mtime": "Mon, 18 Jul 2011 18:04:35 +0000",
-        "path": "/Photos/Getting_Started.pdf",
-        "is_dir": False,
-        "icon": "page_white_acrobat",
-        "root": "dropbox",
-        "mime_type": "application/pdf",
-        "revision": 220823
+        ".tag": "file",
+        "name": "Getting_Started.pdf",
+        "path_lower": "/photos/getting_started.pdf",
+        "path_display": "/Photos/Getting_Started.pdf",
+        "id": "id:8y8sAJlrhuAAAAAAAAAAAQ",
+        "client_modified": "2016-06-13T19:08:17Z",
+        "server_modified": "2016-06-13T19:08:17Z",
+        "rev": "2ba1017a0c1e",
+        "size": 124778
     }
 
 
-def build_folder_metadata_params(path):
-    return {'root': 'auto', 'path': path.full_path}
+def build_folder_metadata_data(path):
+    return {'path': path.full_path}
+
+
+@pytest.fixture
+def not_found_metadata_data():
+    return {"error_summary": "path/not_found/",
+            "error": {".tag": "path",
+                      "path": {".tag": "not_found"}
+                     }
+           }
 
 
 class TestValidatePath:
@@ -120,22 +117,24 @@ class TestValidatePath:
     @pytest.mark.aiohttpretty
     @pytest.mark.parametrize('settings', [{'folder': '/'}])
     async def test_validate_v1_path_file(self, provider, file_metadata):
-        file_path = 'Photos/Getting_Started.pdf'
+        file_path = '/Photos/Getting_Started.pdf'
+        data = {"path": file_path}
 
-        metadata_url = provider.build_url('metadata', 'auto', file_path)
-        aiohttpretty.register_json_uri('GET', metadata_url, body=file_metadata)
+        metadata_url = provider.build_url('files', 'get_metadata')
+        aiohttpretty.register_json_uri('POST', metadata_url, data=data,
+                                       body=file_metadata)
 
         try:
-            wb_path_v1 = await provider.validate_v1_path('/' + file_path)
+            wb_path_v1 = await provider.validate_v1_path(file_path)
         except Exception as exc:
             pytest.fail(str(exc))
 
         with pytest.raises(exceptions.NotFoundError) as exc:
-            await provider.validate_v1_path('/' + file_path + '/')
+            await provider.validate_v1_path(file_path + '/')
 
         assert exc.value.code == client.NOT_FOUND
 
-        wb_path_v0 = await provider.validate_path('/' + file_path)
+        wb_path_v0 = await provider.validate_path(file_path)
 
         assert wb_path_v1 == wb_path_v0
 
@@ -143,22 +142,24 @@ class TestValidatePath:
     @pytest.mark.aiohttpretty
     @pytest.mark.parametrize('settings', [{'folder': '/'}])
     async def test_validate_v1_path_folder(self, provider, folder_metadata):
-        folder_path = 'Photos'
+        folder_path = '/Photos'
+        data = {"path": folder_path}
 
-        metadata_url = provider.build_url('metadata', 'auto', folder_path)
-        aiohttpretty.register_json_uri('GET', metadata_url, body=folder_metadata)
+        metadata_url = provider.build_url('files', 'get_metadata')
+        aiohttpretty.register_json_uri('POST', metadata_url, data=data,
+                                       body=folder_metadata)
 
         try:
-            wb_path_v1 = await provider.validate_v1_path('/' + folder_path + '/')
+            wb_path_v1 = await provider.validate_v1_path(folder_path + '/')
         except Exception as exc:
             pytest.fail(str(exc))
 
         with pytest.raises(exceptions.NotFoundError) as exc:
-            await provider.validate_v1_path('/' + folder_path)
+            await provider.validate_v1_path(folder_path)
 
         assert exc.value.code == client.NOT_FOUND
 
-        wb_path_v0 = await provider.validate_path('/' + folder_path + '/')
+        wb_path_v0 = await provider.validate_path(folder_path + '/')
 
         assert wb_path_v1 == wb_path_v0
 
@@ -187,8 +188,8 @@ class TestCRUD:
     @pytest.mark.aiohttpretty
     async def test_download(self, provider):
         path = WaterButlerPath('/triangles.txt', prepend=provider.folder)
-        url = provider._build_content_url('files', 'auto', path.full_path)
-        aiohttpretty.register_uri('GET', url, body=b'better', auto_length=True)
+        url = provider._build_content_url('files', 'download')
+        aiohttpretty.register_uri('POST', url, body=b'better', auto_length=True)
         result = await provider.download(path)
         content = await result.response.read()
 
@@ -196,56 +197,63 @@ class TestCRUD:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_download_not_found(self, provider):
+    async def test_download_not_found(self, provider, not_found_metadata_data):
         path = await provider.validate_path('/vectors.txt')
-        url = provider._build_content_url('files', 'auto', path.full_path)
-        aiohttpretty.register_uri('GET', url, status=404)
+        url = provider._build_content_url('files', 'download')
+        aiohttpretty.register_json_uri('POST', url, status=409,
+                                       body=not_found_metadata_data)
 
-        with pytest.raises(exceptions.DownloadError) as e:
+        with pytest.raises(exceptions.NotFoundError) as e:
             await provider.download(path)
 
         assert e.value.code == 404
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_upload(self, provider, file_metadata, file_stream, settings):
+    async def test_upload(self, provider, file_metadata,
+                          not_found_metadata_data, file_stream, settings):
         path = await provider.validate_path('/phile')
 
-        metadata_url = provider.build_url('metadata', 'auto', path.full_path)
-        url = provider._build_content_url('files_put', 'auto', path.full_path)
+        metadata_url = provider.build_url('files', 'get_metadata')
+        data = {'path': path.full_path}
+        url = provider._build_content_url('files', 'upload')
 
-        aiohttpretty.register_uri('GET', metadata_url, status=404)
-        aiohttpretty.register_json_uri('PUT', url, status=200, body=file_metadata)
+        aiohttpretty.register_json_uri('POST', metadata_url, data=data,
+                                       status=409, body=not_found_metadata_data)
+        aiohttpretty.register_json_uri('POST', url, status=200,
+                                       body=file_metadata)
 
         metadata, created = await provider.upload(file_stream, path)
         expected = DropboxFileMetadata(file_metadata, provider.folder)
 
         assert created is True
         assert metadata == expected
-        assert aiohttpretty.has_call(method='PUT', uri=url)
+        assert aiohttpretty.has_call(method='POST', uri=url)
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_delete_file(self, provider, file_metadata):
-        url = provider.build_url('fileops', 'delete')
+        url = provider.build_url('files', 'delete')
         path = await provider.validate_path('/The past')
+        data = {'path': path.full_path}
 
-        aiohttpretty.register_uri('POST', url, status=200)
+        aiohttpretty.register_json_uri('POST', url, data=data, status=200)
 
         await provider.delete(path)
 
-        data = {'root': 'auto', 'path': path.full_path}
-        assert aiohttpretty.has_call(method='POST', uri=url, data=data)
+        assert aiohttpretty.has_call(method='POST', uri=url)
 
 
 class TestMetadata:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_metadata(self, provider, folder_metadata):
+    async def test_metadata(self, provider, folder_children):
         path = await provider.validate_path('/')
-        url = provider.build_url('metadata', 'auto', path.full_path)
-        aiohttpretty.register_json_uri('GET', url, body=folder_metadata)
+        url = provider.build_url('files', 'list_folder')
+        data = {'path': path.full_path}
+        aiohttpretty.register_json_uri('POST', url, data=data,
+                                       body=folder_children)
         result = await provider.metadata(path)
 
         assert isinstance(result, list)
@@ -258,8 +266,10 @@ class TestMetadata:
     @pytest.mark.aiohttpretty
     async def test_metadata_root_file(self, provider, file_metadata):
         path = WaterButlerPath('/pfile', prepend=provider.folder)
-        url = provider.build_url('metadata', 'auto', path.full_path)
-        aiohttpretty.register_json_uri('GET', url, body=file_metadata)
+        url = provider.build_url('files', 'get_metadata')
+        data = {'path': path.full_path}
+        aiohttpretty.register_json_uri('POST', url, data=data,
+                                       body=file_metadata)
         result = await provider.metadata(path)
 
         assert isinstance(result, metadata.BaseMetadata)
@@ -269,12 +279,14 @@ class TestMetadata:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_metadata_missing(self, provider):
+    async def test_metadata_missing(self, provider, not_found_metadata_data):
         path = WaterButlerPath('/pfile', prepend=provider.folder)
-        url = provider.build_url('metadata', 'auto', path.full_path)
-        aiohttpretty.register_uri('GET', url, status=404)
+        url = provider.build_url('files', 'get_metadata')
+        data = {"path": "/pfile"}
+        aiohttpretty.register_json_uri('POST', url, data=data, status=409,
+                                       body=not_found_metadata_data)
 
-        with pytest.raises(exceptions.MetadataError):
+        with pytest.raises(exceptions.NotFoundError):
             await provider.metadata(path)
 
 
@@ -284,29 +296,32 @@ class TestCreateFolder:
     @pytest.mark.aiohttpretty
     async def test_already_exists(self, provider):
         path = WaterButlerPath('/newfolder/', prepend=provider.folder)
-        url = provider.build_url('fileops', 'create_folder')
-        params = build_folder_metadata_params(path)
+        url = provider.build_url('files', 'create_folder')
+        data = build_folder_metadata_data(path)
+        body = {"error_summary": "path/conflict/folder/...",
+                "error": {".tag": "path",
+                          "path": {".tag": "conflict",
+                                   "conflict": {".tag": "folder"}
+                                  }
+                         }
+               }
+        aiohttpretty.register_json_uri('POST', url, data=data, status=409,
+                                       body=body)
 
-        aiohttpretty.register_json_uri('POST', url, params=params, status=403, body={
-            'error': 'because a file or folder already exists at path'
-        })
-
-        with pytest.raises(exceptions.FolderNamingConflict) as e:
+        with pytest.raises(DropboxNamingConflictError) as e:
             await provider.create_folder(path)
 
         assert e.value.code == 409
-        assert e.value.message == 'Cannot create folder "newfolder" because a file or folder already exists at path "/newfolder/"'
+        assert e.value.message == 'Cannot complete action: file or folder already exists in this location'
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_forbidden(self, provider):
         path = WaterButlerPath('/newfolder/', prepend=provider.folder)
-        url = provider.build_url('fileops', 'create_folder')
-        params = build_folder_metadata_params(path)
+        url = provider.build_url('files', 'create_folder')
+        data = build_folder_metadata_data(path)
 
-        aiohttpretty.register_json_uri('POST', url, params=params, status=403, body={
-            'error': 'because I hate you'
-        })
+        aiohttpretty.register_json_uri('POST', url, data=data, status=403, body={ 'error': 'because I hate you' })
 
         with pytest.raises(exceptions.CreateFolderError) as e:
             await provider.create_folder(path)
@@ -318,10 +333,10 @@ class TestCreateFolder:
     @pytest.mark.aiohttpretty
     async def test_raises_on_errors(self, provider):
         path = WaterButlerPath('/newfolder/', prepend=provider.folder)
-        url = provider.build_url('fileops', 'create_folder')
-        params = build_folder_metadata_params(path)
+        url = provider.build_url('files', 'create_folder')
+        data = build_folder_metadata_data(path)
 
-        aiohttpretty.register_json_uri('POST', url, params=params, status=418, body={})
+        aiohttpretty.register_json_uri('POST', url, data=data, status=418, body={})
 
         with pytest.raises(exceptions.CreateFolderError) as e:
             await provider.create_folder(path)
@@ -330,13 +345,12 @@ class TestCreateFolder:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_returns_metadata(self, provider, file_metadata):
-        file_metadata['path'] = '/newfolder'
+    async def test_returns_metadata(self, provider, folder_metadata):
         path = WaterButlerPath('/newfolder/', prepend=provider.folder)
-        url = provider.build_url('fileops', 'create_folder')
-        params = build_folder_metadata_params(path)
+        url = provider.build_url('files', 'create_folder')
+        data = build_folder_metadata_data(path)
 
-        aiohttpretty.register_json_uri('POST', url, params=params, status=200, body=file_metadata)
+        aiohttpretty.register_json_uri('POST', url, data=data, status=200, body=folder_metadata)
 
         resp = await provider.create_folder(path)
 

--- a/waterbutler/providers/dropbox/exceptions.py
+++ b/waterbutler/providers/dropbox/exceptions.py
@@ -1,0 +1,13 @@
+from waterbutler.core.exceptions import ProviderError
+
+
+class DropboxUnhandledConflictError(ProviderError):
+    def __init__(self, error_data):
+        message = ('Dropbox has many unique error messages for code 409(Conflict), this one was not specifically handled in the provider: {}'.format(error_data))
+        super().__init__(message, code=409)
+
+
+class DropboxNamingConflictError(ProviderError):
+    def __init__(self, error_data):
+        message = ('Cannot complete action: file or folder already exists in this location')
+        super().__init__(message, code=409)

--- a/waterbutler/providers/dropbox/metadata.py
+++ b/waterbutler/providers/dropbox/metadata.py
@@ -19,49 +19,50 @@ class BaseDropboxMetadata(metadata.BaseMetadata):
             path = path[len(self._folder):]
         return super().build_path(path)
 
-    @property
-    def extra(self):
-        return {
-            'revisionId': self.raw['rev']
-        }
-
 
 class DropboxFolderMetadata(BaseDropboxMetadata, metadata.BaseFolderMetadata):
 
     @property
     def name(self):
-        return os.path.split(self.raw['path'])[1]
+        return os.path.split(self.raw['path_display'])[1]
 
     @property
     def path(self):
-        return self.build_path(self.raw['path'])
+        return self.build_path(self.raw['path_display'])
 
 
 class DropboxFileMetadata(BaseDropboxMetadata, metadata.BaseFileMetadata):
 
     @property
     def name(self):
-        return os.path.split(self.raw['path'])[1]
+        return os.path.split(self.raw['path_display'])[1]
 
     @property
     def path(self):
-        return self.build_path(self.raw['path'])
+        return self.build_path(self.raw['path_display'])
 
     @property
     def size(self):
-        return self.raw['bytes']
+        return self.raw['size']
 
     @property
     def modified(self):
-        return self.raw['modified']
+        return self.raw['server_modified']
 
     @property
     def content_type(self):
-        return self.raw['mime_type']
+        # return self.raw['mime_type']
+        return 'dropbox/whatarewegonnadowithyou'
 
     @property
     def etag(self):
         return self.raw['rev']
+
+    @property
+    def extra(self):
+        return {
+            'revisionId': self.raw['rev']
+        }
 
 
 # TODO dates!
@@ -77,4 +78,10 @@ class DropboxRevision(metadata.BaseFileRevisionMetadata):
 
     @property
     def modified(self):
-        return self.raw['modified']
+        return self.raw['server_modified']
+
+    @property
+    def extra(self):
+        return {
+            'revisionId': self.raw['rev']
+        }

--- a/waterbutler/providers/dropbox/metadata.py
+++ b/waterbutler/providers/dropbox/metadata.py
@@ -51,8 +51,7 @@ class DropboxFileMetadata(BaseDropboxMetadata, metadata.BaseFileMetadata):
 
     @property
     def content_type(self):
-        # return self.raw['mime_type']
-        return 'dropbox/whatarewegonnadowithyou'
+        return None
 
     @property
     def etag(self):

--- a/waterbutler/providers/dropbox/metadata.py
+++ b/waterbutler/providers/dropbox/metadata.py
@@ -60,7 +60,8 @@ class DropboxFileMetadata(BaseDropboxMetadata, metadata.BaseFileMetadata):
     @property
     def extra(self):
         return {
-            'revisionId': self.raw['rev']
+            'revisionId': self.raw['rev'],
+            'id': self.raw['id']
         }
 
 
@@ -82,5 +83,6 @@ class DropboxRevision(metadata.BaseFileRevisionMetadata):
     @property
     def extra(self):
         return {
-            'revisionId': self.raw['rev']
+            'revisionId': self.raw['rev'],
+            'id': self.raw['id']
         }

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -10,15 +10,17 @@ from waterbutler.providers.dropbox import settings
 from waterbutler.providers.dropbox.metadata import DropboxRevision
 from waterbutler.providers.dropbox.metadata import DropboxFileMetadata
 from waterbutler.providers.dropbox.metadata import DropboxFolderMetadata
+from waterbutler.providers.dropbox.exceptions import DropboxNamingConflictError
+from waterbutler.providers.dropbox.exceptions import DropboxUnhandledConflictError
 
 
 class DropboxProvider(provider.BaseProvider):
     """Provider for the Dropbox.com cloud storage service.
 
-    This provider uses the v1 Dropbox API.  An ID-based v2 API is available, but the provider
-    has not yet been updated.
+    This provider uses the v2 Dropbox API. Files and folders are assigned IDs and some API calls can use IDs in place of paths.
+    But this has not yet been implemented.
 
-    API docs: https://www.dropbox.com/developers-v1/core/docs
+    API docs: https://www.dropbox.com/developers/documentation/http/documentation
 
     Quirks:
 
@@ -32,23 +34,46 @@ class DropboxProvider(provider.BaseProvider):
         self.token = self.credentials['token']
         self.folder = self.settings['folder']
 
+    async def dropbox_request(self,
+                              url,
+                              body,
+                              throws,
+                              expects=(200, 409,)):
+        try:
+            async with self.request(
+                'POST',
+                url,
+                headers={},
+                data=body,
+                expects=expects,
+                throws=throws
+            ) as resp:
+                data = await resp.json()
+                if resp.status == 409:
+                        self.dropbox_conflict_error_handler(data)
+        except:
+            raise
+        return data
+
+    def dropbox_conflict_error_handler(self, data):
+        if 'error' in data.keys():
+            if data['error'][data['error']['.tag']]['.tag'] == 'not_found':
+                raise exceptions.NotFoundError(data['error_summary'])
+            if data['error'][data['error']['.tag']]['conflict']:
+                raise DropboxNamingConflictError(data['error_summary'])
+        raise DropboxUnhandledConflictError(str(data))
+
     async def validate_v1_path(self, path, **kwargs):
         if path == '/':
             return WaterButlerPath(path, prepend=self.folder)
-
         implicit_folder = path.endswith('/')
-
-        resp = await self.make_request(
-            'GET', self.build_url('metadata', 'auto', self.folder + path),
-            expects=(200,),
-            throws=exceptions.MetadataError
-        )
-
-        data = await resp.json()
-        explicit_folder = data['is_dir']
+        url = self.build_url('files', 'get_metadata')
+        body = json.dumps({'path': self.folder.rstrip('/') + path.rstrip('/')})
+        throws = exceptions.MetadataError
+        data = await self.dropbox_request(url, body, throws)
+        explicit_folder = data['.tag'] == 'folder'
         if explicit_folder != implicit_folder:
             raise exceptions.NotFoundError(str(path))
-
         return WaterButlerPath(path, prepend=self.folder)
 
     async def validate_path(self, path, **kwargs):
@@ -59,67 +84,49 @@ class DropboxProvider(provider.BaseProvider):
 
     @property
     def default_headers(self):
-        return {
-            'Authorization': 'Bearer {}'.format(self.token),
-        }
+        return {'Authorization': 'Bearer {}'.format(self.token),
+                'Content-Type': 'application/json'}
 
     async def intra_copy(self, dest_provider, src_path, dest_path):
         dest_folder = dest_provider.folder
-
         try:
             if self == dest_provider:
-                resp = await self.make_request(
-                    'POST',
-                    self.build_url('fileops', 'copy'),
-                    data={
-                        'root': 'auto',
-                        'from_path': src_path.full_path,
-                        'to_path': dest_path.full_path,
-                    },
-                    expects=(200, 201),
-                    throws=exceptions.IntraCopyError,
-                )
+                url = self.build_url('files', 'copy')
+                body = json.dumps({'from_path': src_path.full_path.rstrip('/'),
+                                   'to_path': dest_path.full_path.rstrip('/')
+                                   })
+                throws = exceptions.IntraCopyError
+                expects = (200, 201, 409)
+                data = await self.dropbox_request(url,
+                                                  body,
+                                                  throws,
+                                                  expects=expects)
             else:
-                from_ref_resp = await self.make_request(
-                    'GET',
-                    self.build_url('copy_ref', 'auto', src_path.full_path),
-                )
-                from_ref_data = await from_ref_resp.json()
-                resp = await self.make_request(
-                    'POST',
-                    self.build_url('fileops', 'copy'),
-                    data={
-                        'root': 'auto',
-                        'from_copy_ref': from_ref_data['copy_ref'],
-                        'to_path': dest_path,
-                    },
-                    headers=dest_provider.default_headers,
-                    expects=(200, 201),
-                    throws=exceptions.IntraCopyError,
-                )
-        except exceptions.IntraCopyError as e:
-            if e.code != 403:
-                raise
-
+                # This case is for project/component links containing Dropbox
+                # providers with different owners
+                throws = exceptions.IntraCopyError
+                url = self.build_url('files', 'copy_reference', 'get')
+                body = json.dumps({'path': src_path.full_path.rstrip('/')})
+                from_ref_data = await self.dropbox_request(url, body, throws)
+                from_ref = from_ref_data['copy_reference']
+                url = self.build_url('files', 'copy_reference', 'save')
+                body = json.dumps({"copy_reference": from_ref,
+                                   'path': dest_path.full_path.rstrip('/')})
+                expects = (200, 201, 409)
+                data = await dest_provider.dropbox_request(url,
+                                                           body,
+                                                           throws,
+                                                           expects=expects)
+                data = data['metadata']
+        except exceptions.DropboxNamingConflictError:
             await dest_provider.delete(dest_path)
             resp, _ = await self.intra_copy(dest_provider, src_path, dest_path)
             return resp, False
 
-        # TODO Refactor into a function
-        data = await resp.json()
-
-        if not data['is_dir']:
+        if data['.tag'] == 'file':
             return DropboxFileMetadata(data, dest_folder), True
-
         folder = DropboxFolderMetadata(data, dest_folder)
-
-        folder.children = []
-        for item in data['contents']:
-            if item['is_dir']:
-                folder.children.append(DropboxFolderMetadata(item, dest_folder))
-            else:
-                folder.children.append(DropboxFileMetadata(item, dest_folder))
-
+        folder.children = [item for item in await dest_provider.metadata(dest_path)]
         return folder, True
 
     async def intra_move(self, dest_provider, src_path, dest_path):
@@ -127,79 +134,66 @@ class DropboxProvider(provider.BaseProvider):
             # Dropbox does not support changing the casing in a file name
             raise exceptions.InvalidPathError('In Dropbox to change case, add or subtract other characters.')
 
-        dest_folder = dest_provider.folder
-
+        url = self.build_url('files', 'move')
+        body = json.dumps({'from_path': src_path.full_path,
+                           'to_path': dest_path.full_path})
+        throws = exceptions.IntraMoveError
         try:
-            resp = await self.make_request(
-                'POST',
-                self.build_url('fileops', 'move'),
-                data={
-                    'root': 'auto',
-                    'to_path': dest_path.full_path,
-                    'from_path': src_path.full_path,
-                },
-                expects=(200, ),
-                throws=exceptions.IntraMoveError,
-            )
-        except exceptions.IntraMoveError as e:
-            if e.code != 403:
-                raise
-
+            data = await self.dropbox_request(url, body, throws)
+        except exceptions.DropboxNamingConflictError:
             await dest_provider.delete(dest_path)
             resp, _ = await self.intra_move(dest_provider, src_path, dest_path)
             return resp, False
 
-        data = await resp.json()
-
-        if not data['is_dir']:
+        dest_folder = dest_provider.folder
+        if data['.tag'] == 'file':
             return DropboxFileMetadata(data, dest_folder), True
-
         folder = DropboxFolderMetadata(data, dest_folder)
-
-        folder.children = []
-        for item in data['contents']:
-            if item['is_dir']:
-                folder.children.append(DropboxFolderMetadata(item, dest_folder))
-            else:
-                folder.children.append(DropboxFileMetadata(item, dest_folder))
-
+        folder.children = [item for item in await dest_provider.metadata(dest_path)]
         return folder, True
 
     async def download(self, path, revision=None, range=None, **kwargs):
         if revision:
-            url = self._build_content_url('files', 'auto', path.full_path, rev=revision)
+            path_arg = {'path': 'rev: ' + revision}
         else:
-            # Dont add unused query parameters
-            url = self._build_content_url('files', 'auto', path.full_path)
-
+            path_arg = '{"path":"' + path.full_path + '"}'
+        url = self._build_content_url('files', 'download')
         resp = await self.make_request(
-            'GET',
+            'POST',
             url,
+            headers={'Dropbox-API-Arg': path_arg},
             range=range,
-            expects=(200, 206),
+            skip_auto_headers=['Content-Type'],
+            expects=(200, 206, 409,),
             throws=exceptions.DownloadError,
         )
-
+        if resp.status == 409:
+            data = await resp.json()
+            self.dropbox_conflict_error_handler(data)
         if 'Content-Length' not in resp.headers:
-            size = json.loads(resp.headers['X-DROPBOX-METADATA'])['bytes']
+            size = json.loads(resp.headers['dropbox-api-result'])['size']
         else:
             size = None
-
         return streams.ResponseStreamReader(resp, size=size)
 
     async def upload(self, stream, path, conflict='replace', **kwargs):
         path, exists = await self.handle_name_conflict(path, conflict=conflict)
-
+        url = self._build_content_url('files', 'upload')
+        path_arg = '{"path":"' + path.full_path + '"}'
+        headers = {'Content-Type': 'application/octet-stream',
+                   'Dropbox-API-Arg': path_arg,
+                   'Content-Length': str(stream.size)}
         resp = await self.make_request(
-            'PUT',
-            self._build_content_url('files_put', 'auto', path.full_path),
-            headers={'Content-Length': str(stream.size)},
+            'POST',
+            url,
+            headers=headers,
             data=stream,
-            expects=(200, ),
+            expects=(200, 409,),
             throws=exceptions.UploadError,
         )
-
         data = await resp.json()
+        if resp.status == 409:
+            self.dropbox_conflict_error_handler(data)
         return DropboxFileMetadata(data, self.folder), not exists
 
     async def delete(self, path, confirm_delete=0, **kwargs):
@@ -217,76 +211,75 @@ class DropboxProvider(provider.BaseProvider):
                     'confirm_delete=1 is required for deleting root provider folder',
                     code=400
                 )
-
-        async with self.request(
-            'POST',
-            self.build_url('fileops', 'delete'),
-            data={'root': 'auto', 'path': path.full_path},
-            expects=(200, ),
-            throws=exceptions.DeleteError,
-        ):
-            return  # release resp
+        url = self.build_url('files', 'delete')
+        body = json.dumps({'path': self.folder.rstrip('/') + '/' + path.path.rstrip('/')})
+        throws = exceptions.DeleteError
+        await self.dropbox_request(url, body, throws)
 
     async def metadata(self, path, revision=None, **kwargs):
+        full_path = path.full_path.rstrip('/')
+        throws = exceptions.MetadataError,
         if revision:
-            url = self.build_url('revisions', 'auto', path.full_path, rev_limit=250)
-
+            url = self.build_url('files', 'get_metadata')
+            body = json.dumps({'path': 'rev:' + revision})
+        elif path.is_folder:
+            url = self.build_url('files', 'list_folder')
+            body = json.dumps({'path': full_path})
         else:
-            url = self.build_url('metadata', 'auto', path.full_path)
-        resp = await self.make_request(
-            'GET', url,
-            expects=(200, ),
-            throws=exceptions.MetadataError
-        )
+            url = self.build_url('files', 'get_metadata')
+            body = json.dumps({'path': full_path})
 
-        data = await resp.json()
+        if path.is_folder:
+            ret = []
+            has_more = True
+            while has_more:
+                data = await self.dropbox_request(url, body, throws)
+                for entry in data['entries']:
+                    if entry['.tag'] == 'folder':
+                        ret.append(DropboxFolderMetadata(entry, self.folder))
+                    else:
+                        ret.append(DropboxFileMetadata(entry, self.folder))
+                if not data['has_more']:
+                    has_more = False
+                else:
+                    url = self.build_url('files', 'list_folder', 'continue')
+                    body = json.dumps({'cursor': data['cursor']})
+            return ret
 
-        if revision:
-            try:
-                data = next(v for v in (await resp.json()) if v['rev'] == revision)
-            except StopIteration:
-                raise exceptions.NotFoundError(str(path))
+        data = await self.dropbox_request(url, body, throws)
+        # Dropbox v2 API will not indicate file/folder if path "deleted"
+        if data['.tag'] == 'deleted':
+            raise exceptions.MetadataError(
+                "Could not retrieve '{}'".format(path),
+                code=http.client.NOT_FOUND,
+            )
 
         # Dropbox will match a file or folder by name within the requested path
-        if path.is_file and data['is_dir']:
+        if path.is_file and data['.tag'] == 'folder':
             raise exceptions.MetadataError(
                 "Could not retrieve file '{}'".format(path),
                 code=http.client.NOT_FOUND,
             )
 
-        if data.get('is_deleted'):
-            raise exceptions.MetadataError(
-                "Could not retrieve {kind} '{path}'".format(
-                    kind='folder' if data['is_dir'] else 'file',
-                    path=path,
-                ),
-                code=http.client.NOT_FOUND,
-            )
-
-        if data['is_dir']:
-            ret = []
-            for item in data['contents']:
-                if item['is_dir']:
-                    ret.append(DropboxFolderMetadata(item, self.folder))
-                else:
-                    ret.append(DropboxFileMetadata(item, self.folder))
-            return ret
-
         return DropboxFileMetadata(data, self.folder)
 
     async def revisions(self, path, **kwargs):
-        response = await self.make_request(
-            'GET',
-            self.build_url('revisions', 'auto', path.full_path, rev_limit=250),
-            expects=(200, ),
-            throws=exceptions.RevisionsError
-        )
-        data = await response.json()
-
+        # Dropbox v2 API limits the number of revisions returned to a maximum
+        # of 100, default 10. Previously we had set the limit to 250.
+        url = self.build_url('files', 'list_revisions')
+        body = json.dumps({'path': path.full_path.rstrip('/'),
+                           'limit': 100})
+        throws = exceptions.RevisionsError
+        data = await self.dropbox_request(url, body, throws)
+        if data['is_deleted'] is True:
+            raise exceptions.RevisionsError(
+                "Could not retrieve '{}'".format(path),
+                code=http.client.NOT_FOUND,
+            )
         return [
             DropboxRevision(item)
-            for item in data
-            if not item.get('is_deleted')
+            for item in data['entries']
+            if not item['.tag'] == 'deleted'
         ]
 
     async def create_folder(self, path, **kwargs):
@@ -294,25 +287,10 @@ class DropboxProvider(provider.BaseProvider):
         :param str path: The path to create a folder at
         """
         WaterButlerPath.validate_folder(path)
-
-        response = await self.make_request(
-            'POST',
-            self.build_url('fileops', 'create_folder'),
-            params={
-                'root': 'auto',
-                'path': path.full_path
-            },
-            expects=(200, 403),
-            throws=exceptions.CreateFolderError
-        )
-
-        data = await response.json()
-
-        if response.status == 403:
-            if 'because a file or folder already exists at path' in data.get('error'):
-                raise exceptions.FolderNamingConflict(str(path))
-            raise exceptions.CreateFolderError(data, code=403)
-
+        url = self.build_url('files', 'create_folder')
+        body = json.dumps({'path': path.full_path.rstrip('/')})
+        throws = exceptions.CreateFolderError
+        data = await self.dropbox_request(url, body, throws)
         return DropboxFolderMetadata(data, self.folder)
 
     def can_intra_copy(self, dest_provider, path=None):

--- a/waterbutler/providers/dropbox/settings.py
+++ b/waterbutler/providers/dropbox/settings.py
@@ -6,5 +6,5 @@ except ImportError:
 config = settings.get('DROPBOX_PROVIDER_CONFIG', {})
 
 
-BASE_URL = config.get('BASE_URL', 'https://api.dropboxapi.com/1/')
-BASE_CONTENT_URL = config.get('BASE_CONTENT_URL', 'https://content.dropboxapi.com/1/')
+BASE_URL = config.get('BASE_URL', 'https://api.dropboxapi.com/2')
+BASE_CONTENT_URL = config.get('BASE_CONTENT_URL', 'https://content.dropboxapi.com/2/')


### PR DESCRIPTION
## Purpose:

[OSF-6584](https://openscience.atlassian.net/browse/OSF-6584)
Convert Dropbox provider to Dropbox v2 API
## Changes:

Update tests/providers/dropbox/test_provider.py update uris and responses for v2 API
Added waterbutler/providers/dropbox/exceptions.py added exceptions for v2 409s
Updated  waterbutler/providers/dropbox/metadata.py updated for v2 API returns
Updated waterbutler/providers/dropbox/provider.py extensive changes throughout for v2 API
## Side effects:

Dropbox no longer returns MimeType
OSF still needs to convert to v2 API before deadline
list_revisions limit has been reduced from 1,000 to 100. We previously set limit to 250.
Dropbox now imposes a hard limit of 10,000 files/folders during any one operation. returns "too_many_files Void The operation would involve more than 10,000 files and folders."
## QA note:

During QA be sure to test large quantities of files (>2000) in a single folder. folder metadata call now involves pagination in 2000 result increments.

[#OSF-6584]
