### PR TITLE
invoke wheelhouse fails building a Docker image when `pty` is `True` 

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -25,21 +25,21 @@ def monkey_patch():
 
 
 @task
-def wheelhouse(develop=False):
+def wheelhouse(develop=False, pty=True):
     req_file = 'dev-requirements.txt' if develop else 'requirements.txt'
     cmd = 'pip wheel --find-links={} -r {} --wheel-dir={}'.format(WHEELHOUSE_PATH, req_file, WHEELHOUSE_PATH)
-    run(cmd, pty=True)
+    run(cmd, pty=pty)
 
 
 @task
-def install(develop=False):
+def install(develop=False, pty=True):
     run('python setup.py develop')
     req_file = 'dev-requirements.txt' if develop else 'requirements.txt'
     cmd = 'pip install --upgrade -r {}'.format(req_file)
 
     if WHEELHOUSE_PATH:
         cmd += ' --no-index --find-links={}'.format(WHEELHOUSE_PATH)
-    run(cmd, pty=True)
+    run(cmd, pty=pty)
 
 
 @task


### PR DESCRIPTION
# Summary

`invoke wheelhouse` or `invoke install` will error out when executed from a Dockerfile `RUN` instruction in an attempt to create a Docker image.  This error (build log [attached][0]) prevents the Docker image from being created, so it is a blocker in our environment.

Updating the `wheelhouse` and `install` tasks to **not** allocate a `pty` fixes this issue.

# Purpose

Expose the allocation of a `pty` as an option by the `wheelhouse` and `install` tasks, allowing the allocation of a `pty` to be disabled with `--no-pty` when executing `invoke`.  This will allow the Docker image build to succed.

# Changes

Adds a `pty` flag to the `install` and `wheelhouse` tasks, defaulting to a value of `True`.  This maintains current behavior.

# Side Effects

None.

# Discussion

The build of the Docker image goes smoothly until it is time to run `invoke wheelhouse`.  Initially, `invoke wheelhouse` appears to succeed, but then fails with an error:

    Step 20 : RUN invoke wheelhouse --develop
     ---> Running in be1c93b7cd82
    Collecting agent==0.1.2 (from -r requirements.txt (line 1))
      Downloading agent-0.1.2.tar.gz
    Collecting aiohttp==0.18.2 (from -r requirements.txt (line 2))
      Downloading aiohttp-0.18.2.tar.gz (2.2MB)

    <.... and so on ....>

    Successfully built agent aiohttp boto cryptography furl humanfriendly oauthlib pyjwe tornado xmltodict python-geoip-geolite2 ipdb chardet billiard cffi orderedmultidict python-geoip simplegeneric coverage anyjson pycparser


However, the process errors out just after emitting the `Successfully build ...` message with:

    Traceback (most recent call last):
    File "/usr/bin/invoke", line 11, in <module>
    sys.exit(program.run())
    File "/usr/lib/python3.5/site-packages/invoke/program.py", line 270, in run
    self.execute()
    File "/usr/lib/python3.5/site-packages/invoke/program.py", line 379, in execute
    executor.execute(*self.tasks)
    File "/usr/lib/python3.5/site-packages/invoke/executor.py", line 114, in execute
    result = call.task(*args, **call.kwargs)
    File "/usr/lib/python3.5/site-packages/invoke/tasks.py", line 113, in __call__
    result = self.body(*args, **kwargs)
    File "/shared/code/waterbutler/tasks.py", line 31, in wheelhouse
    run(cmd, pty=pty)
    File "/usr/lib/python3.5/site-packages/invoke/__init__.py", line 27, in run
    return Context().run(command, **kwargs)
    File "/usr/lib/python3.5/site-packages/invoke/context.py", line 53, in run
    return runner_class(context=self).run(command, **kwargs)
    File "/usr/lib/python3.5/site-packages/invoke/runners.py", line 280, in run
    raise ThreadException(exceptions)
    invoke.exceptions.ThreadException: 
    Saw 1 exceptions within threads (OSError):
    Thread args: {'kwargs': {'buffer_': [ <..... buffer from the entire wheelhouse install here ....> ],
      'hide': False,
                'output': <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>},
     'target': <bound method Runner.handle_stdout of <invoke.runners.Local object at 0x7ff644135eb8>>}

    Traceback (most recent call last):

      File "/usr/lib/python3.5/site-packages/invoke/runners.py", line 861, in run
        super(_IOThread, self).run()

      File "/usr/lib/python3.5/threading.py", line 862, in run
        self._target(*self._args, **self._kwargs)

      File "/usr/lib/python3.5/site-packages/invoke/runners.py", line 416, in handle_stdout
        indices=threading.local(),

      File "/usr/lib/python3.5/site-packages/invoke/runners.py", line 378, in _handle_output
        get(), self.encoding, errors='replace'

      File "/usr/lib/python3.5/codecs.py", line 1038, in iterdecode
        for input in iterator:

      File "/usr/lib/python3.5/site-packages/invoke/runners.py", line 372, in get
        data = reader(self.read_chunk_size)

      File "/usr/lib/python3.5/site-packages/invoke/runners.py", line 681, in read_stdout
        data = os.read(self.parent_fd, num_bytes)

    OSError: [Errno 5] I/O error

I have no idea why this error occurs, I'm completely baffled by it.  However, if the `wheelhouse` task does **not** allocate a pty, the `invoke wheelhouse` command will succeed.  I suspect this is some sort of odd interaction between my terminal emulation, the Docker environment, and Python, but I don't know for sure.  I reported a [similar issue](https://github.com/CenterForOpenScience/osf.io/issues/5739) for the OSF, so there is some (weird) precedent for this behavior.

My platform info:

    esm:~$ echo $TERM
    xterm-256color
    esm:~$ uname -a
    Darwin Elliots-iMac.fios-router.home 15.6.0 Darwin Kernel Version 15.6.0: Thu Jun 23 18:25:34 PDT 2016; root:xnu-3248.60.10~1/RELEASE_X86_64 x86_64
    esm:~$ docker -v
    Docker version 1.10.3, build 20f81dd
    esm:~$ docker-machine ls |grep osf-docker-test
    osf-docker-test   *        virtualbox   Running   tcp://192.168.99.100:2376           v1.12.0   
    esm:~$ 

# Attachments
[build.txt](https://github.com/CenterForOpenScience/waterbutler/files/451133/build.txt)

[0]: https://github.com/CenterForOpenScience/waterbutler/files/451133/build.txt "build.txt"
