### PR TITLE
Add ownCloud as a supported provider to WB

### DIFF
--- a/docs/provider.owncloud.rst
+++ b/docs/provider.owncloud.rst
@@ -1,0 +1,13 @@
+Metadata
+--------
+
+.. automodule:: waterbutler.providers.owncloud.metadata
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: waterbutler.providers.owncloud.provider
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :inherited-members:

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -14,3 +14,4 @@ Providers
    provider.github
    provider.googledrive
    provider.osfstorage
+   provider.owncloud

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
             'filesystem = waterbutler.providers.filesystem:FileSystemProvider',
             'github = waterbutler.providers.github:GitHubProvider',
             'osfstorage = waterbutler.providers.osfstorage:OSFStorageProvider',
+            'owncloud = waterbutler.providers.owncloud:OwnCloudProvider',
             's3 = waterbutler.providers.s3:S3Provider',
             'dataverse = waterbutler.providers.dataverse:DataverseProvider',
             'box = waterbutler.providers.box:BoxProvider',

--- a/tests/providers/owncloud/test_provider.py
+++ b/tests/providers/owncloud/test_provider.py
@@ -190,7 +190,7 @@ class TestCRUD:
         path = WaterButlerPath('/phile', prepend=provider.folder)
         url = provider._webdav_url_ + path.full_path
         aiohttpretty.register_uri('PROPFIND', url, body=file_metadata, auto_length=True, status=207)
-        aiohttpretty.register_uri('PUT', url, body=b'squares', auto_length=True)
+        aiohttpretty.register_uri('PUT', url, body=b'squares', auto_length=True, status=201)
         metadata, created = await provider.upload(file_stream, path)
         expected = OwnCloudFileMetadata('dissertation.aux','/owncloud/remote.php/webdav/Documents/phile',
         {'{DAV:}getetag':'&quot;a3c411808d58977a9ecd7485b5b7958e&quot;',

--- a/tests/providers/owncloud/test_provider.py
+++ b/tests/providers/owncloud/test_provider.py
@@ -1,0 +1,239 @@
+import pytest
+
+import io
+from http import client
+
+import aiohttpretty
+
+from waterbutler.core import streams
+from waterbutler.core import exceptions
+from waterbutler.core.path import WaterButlerPath
+
+from waterbutler.providers.owncloud import OwnCloudProvider
+from waterbutler.providers.owncloud.metadata import OwnCloudFileMetadata
+from waterbutler.providers.owncloud.metadata import OwnCloudFolderMetadata
+
+@pytest.fixture
+def auth():
+    return {
+        'name': 'cat',
+        'email': 'cat@cat.com',
+    }
+
+@pytest.fixture
+def credentials():
+    return {'username':'cat',
+            'password':'cat',
+            'host':'https://cat/owncloud'}
+
+@pytest.fixture
+def settings():
+    return {'folder': '/my_folder', 'verify_ssl':False}
+
+@pytest.fixture
+def provider(auth, credentials, settings):
+    return OwnCloudProvider(auth, credentials, settings)
+
+@pytest.fixture
+def folder_list():
+    return b'''<?xml version="1.0" ?>
+    <d:multistatus xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns" xmlns:s="http://sabredav.org/ns">
+        <d:response>
+            <d:href>/owncloud/remote.php/webdav/</d:href>
+            <d:propstat>
+                <d:prop>
+                    <d:getlastmodified>Tue, 21 Jun 2016 00:44:03 GMT</d:getlastmodified>
+                    <d:resourcetype>
+                         <d:collection/>
+                    </d:resourcetype>
+                    <d:quota-used-bytes>714783</d:quota-used-bytes>
+                    <d:quota-available-bytes>-3</d:quota-available-bytes>
+                    <d:getetag>&quot;57688dd358fb7&quot;</d:getetag>
+                </d:prop>
+                <d:status>HTTP/1.1 200 OK</d:status>
+            </d:propstat>
+        </d:response>
+        <d:response>
+            <d:href>/owncloud/remote.php/webdav/Documents/</d:href>
+            <d:propstat>
+                <d:prop>
+                    <d:getlastmodified>Tue, 21 Jun 2016 00:44:03 GMT</d:getlastmodified>
+                    <d:resourcetype>
+                        <d:collection/>
+                    </d:resourcetype>
+                    <d:quota-used-bytes>36227</d:quota-used-bytes>
+                    <d:quota-available-bytes>-3</d:quota-available-bytes>
+                    <d:getetag>&quot;57688dd3584b0&quot;</d:getetag>
+                </d:prop>
+                <d:status>HTTP/1.1 200 OK</d:status>
+            </d:propstat>
+        </d:response>
+        <d:response>
+            <d:href>/owncloud/remote.php/webdav/Photos/</d:href>
+            <d:propstat>
+                <d:prop>
+                    <d:getlastmodified>Wed, 15 Jun 2016 22:49:40 GMT</d:getlastmodified>
+                    <d:resourcetype>
+                        <d:collection/>
+                    </d:resourcetype>
+                    <d:quota-used-bytes>678556</d:quota-used-bytes>
+                    <d:quota-available-bytes>-3</d:quota-available-bytes>
+                    <d:getetag>&quot;5761db8485325&quot;</d:getetag>
+                </d:prop>
+                <d:status>HTTP/1.1 200 OK</d:status>
+            </d:propstat>
+        </d:response>
+     </d:multistatus>'''
+
+
+@pytest.fixture
+def folder_metadata():
+    return b'''<?xml version="1.0" ?>
+    <d:multistatus xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns" xmlns:s="http://sabredav.org/ns">
+        <d:response>
+            <d:href>/owncloud/remote.php/webdav/Documents/</d:href>
+            <d:propstat>
+                <d:prop>
+                    <d:getlastmodified>Tue, 21 Jun 2016 00:44:03 GMT</d:getlastmodified>
+                    <d:resourcetype>
+                        <d:collection/>
+                    </d:resourcetype>
+                    <d:quota-used-bytes>36227</d:quota-used-bytes>
+                    <d:quota-available-bytes>-3</d:quota-available-bytes>
+                    <d:getetag>&quot;57688dd3584b0&quot;</d:getetag>
+                </d:prop>
+                <d:status>HTTP/1.1 200 OK</d:status>
+            </d:propstat>
+        </d:response>
+     </d:multistatus>'''
+
+@pytest.fixture
+def file_metadata():
+    return b'''<?xml version="1.0"?>
+            <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
+                <d:response>
+                    <d:href>/owncloud/remote.php/webdav/Documents/dissertation.aux</d:href>
+                    <d:propstat>
+                        <d:prop>
+                            <d:getlastmodified>Sun, 10 Jul 2016 23:28:31 GMT</d:getlastmodified>
+                            <d:getcontentlength>3011</d:getcontentlength>
+                            <d:resourcetype/>
+                            <d:getetag>&quot;a3c411808d58977a9ecd7485b5b7958e&quot;</d:getetag>
+                            <d:getcontenttype>application/octet-stream</d:getcontenttype>
+                        </d:prop>
+                        <d:status>HTTP/1.1 200 OK</d:status>
+                    </d:propstat>
+                </d:response>
+            </d:multistatus>'''
+
+@pytest.fixture
+def file_content():
+    return b'SLEEP IS FOR THE WEAK GO SERVE STREAMS'
+
+@pytest.fixture
+def file_like(file_content):
+    return io.BytesIO(file_content)
+
+@pytest.fixture
+def file_stream(file_like):
+    return streams.FileStreamReader(file_like)
+
+
+class TestValidatePath:
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_validate_v1_path_file(self, provider, file_metadata):
+        path = WaterButlerPath('/triangles.txt', prepend=provider.folder)
+        url = provider._webdav_url_ + path.full_path
+        aiohttpretty.register_uri('PROPFIND', url, body=file_metadata, auto_length=True, status=207)
+        try:
+            wb_path_v1 = await provider.validate_v1_path('/triangles.txt')
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        wb_path_v0 = await provider.validate_path('/triangles.txt')
+
+        assert wb_path_v1 == wb_path_v0
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_validate_v1_path_folder(self, provider, folder_metadata):
+        path = WaterButlerPath('/myfolder/', prepend=provider.folder)
+        url = provider._webdav_url_ + path.full_path
+        aiohttpretty.register_uri('PROPFIND', url, body=folder_metadata, auto_length=True, status=207)
+        try:
+            wb_path_v1 = await provider.validate_v1_path('/myfolder/')
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        wb_path_v0 = await provider.validate_path('/myfolder/')
+
+        assert wb_path_v1 == wb_path_v0
+
+class TestCRUD:
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download(self, provider, file_metadata, file_like):
+        path = WaterButlerPath('/triangles.txt', prepend=provider.folder)
+        url = provider._webdav_url_ + path.full_path
+        aiohttpretty.register_uri('PROPFIND', url, body=file_metadata, auto_length=True, status=207)
+        aiohttpretty.register_uri('GET', url, body=b'squares', auto_length=True, status=200)
+        result = await provider.download(path)
+        content = await result.response.read()
+        assert content == b'squares'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_upload(self, provider, file_stream, file_metadata):
+        path = WaterButlerPath('/phile', prepend=provider.folder)
+        url = provider._webdav_url_ + path.full_path
+        aiohttpretty.register_uri('PROPFIND', url, body=file_metadata, auto_length=True, status=207)
+        aiohttpretty.register_uri('PUT', url, body=b'squares', auto_length=True)
+        metadata, created = await provider.upload(file_stream, path)
+        expected = OwnCloudFileMetadata('dissertation.aux','/owncloud/remote.php/webdav/Documents/phile',
+        {'{DAV:}getetag':'&quot;a3c411808d58977a9ecd7485b5b7958e&quot;',
+        '{DAV:}getlastmodified':'Sun, 10 Jul 2016 23:28:31 GMT',
+        '{DAV:}getcontentlength':3011})
+        assert created is True
+        assert metadata.name == expected.name
+        assert metadata.size == expected.size
+        assert aiohttpretty.has_call(method='PUT', uri=url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_delete(self, provider, file_metadata):
+        path = WaterButlerPath('/phile', prepend=provider.folder)
+        url = provider._webdav_url_ + path.full_path
+        aiohttpretty.register_uri('PROPFIND', url, body=file_metadata, auto_length=True, status=207)
+        path = await provider.validate_path('/phile')
+        url = provider._webdav_url_ + path.full_path
+        aiohttpretty.register_uri('DELETE', url, status=204)
+        await provider.delete(path)
+
+class TestMetadata:
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata(self, provider, folder_list):
+        path = WaterButlerPath('/', prepend=provider.folder)
+        url = provider._webdav_url_ + path.full_path
+        aiohttpretty.register_uri('PROPFIND', url, body=folder_list, auto_length=True, status=207)
+        path = await provider.validate_path('/')
+        url = provider._webdav_url_ + path.full_path
+        aiohttpretty.register_uri('PROPFIND', url, body=folder_list, status=207)
+        result = await provider.metadata(path)
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0].kind == 'folder'
+        assert result[0].name == 'Documents'
+
+class TestOperations:
+
+    async def test_can_intra_copy(self, provider):
+        assert provider.can_intra_copy(provider)
+
+    async def test_can_intra_move(self, provider):
+        assert provider.can_intra_move(provider)

--- a/waterbutler/providers/owncloud/__init__.py
+++ b/waterbutler/providers/owncloud/__init__.py
@@ -1,0 +1,1 @@
+from .provider import OwnCloudProvider  # noqa

--- a/waterbutler/providers/owncloud/metadata.py
+++ b/waterbutler/providers/owncloud/metadata.py
@@ -53,3 +53,25 @@ class OwnCloudFolderMetadata(BaseOwnCloudMetadata, metadata.BaseFolderMetadata):
         if '{DAV:}getcontenttype' in self.attributes:
             return str(self.attributes['{DAV:}getcontenttype'])
         return 'httpd/unix-directory'
+
+
+class OwnCloudFileRevisionMetadata(metadata.BaseFileRevisionMetadata):
+
+    def __init__(self, modified):
+        self._modified = modified
+
+    @classmethod
+    def from_metadata(cls, metadata):
+        return OwnCloudFileRevisionMetadata(modified=metadata.modified)
+
+    @property
+    def version_identifier(self):
+        return 'revision'
+
+    @property
+    def version(self):
+        return 'latest'
+
+    @property
+    def modified(self):
+        return self._modified

--- a/waterbutler/providers/owncloud/metadata.py
+++ b/waterbutler/providers/owncloud/metadata.py
@@ -1,0 +1,55 @@
+from waterbutler.core import metadata
+
+
+class BaseOwnCloudMetadata(metadata.BaseMetadata):
+
+    def __init__(self, href, folder, attributes=None):
+        super(BaseOwnCloudMetadata, self).__init__(None)
+        self.attributes = attributes or {}
+        self._folder = folder
+        self._href = href
+
+    @property
+    def provider(self):
+        return 'owncloud'
+
+    @property
+    def name(self):
+        return self._href.strip('/').split('/')[-1]
+
+    @property
+    def path(self):
+        path = self._href[len(self._folder) - 1:]
+        return path
+
+    @property
+    def size(self):
+        if '{DAV:}getcontentlength' in self.attributes:
+            return str(int(self.attributes['{DAV:}getcontentlength']))
+        return None
+
+    @property
+    def etag(self):
+        return str(self.attributes['{DAV:}getetag'])
+
+    @property
+    def modified(self):
+        return self.attributes['{DAV:}getlastmodified']
+
+
+class OwnCloudFileMetadata(BaseOwnCloudMetadata, metadata.BaseFileMetadata):
+
+    @property
+    def content_type(self):
+        if '{DAV:}getcontenttype' in self.attributes:
+            return str(self.attributes['{DAV:}getcontenttype'])
+        return None
+
+
+class OwnCloudFolderMetadata(BaseOwnCloudMetadata, metadata.BaseFolderMetadata):
+
+    @property
+    def content_type(self):
+        if '{DAV:}getcontenttype' in self.attributes:
+            return str(self.attributes['{DAV:}getcontenttype'])
+        return 'httpd/unix-directory'

--- a/waterbutler/providers/owncloud/provider.py
+++ b/waterbutler/providers/owncloud/provider.py
@@ -155,14 +155,14 @@ class OwnCloudProvider(provider.BaseProvider):
             self._webdav_url_ + path.full_path,
             data=stream,
             headers={'Content-Length': str(stream.size)},
-            expects=(200, 201,),
+            expects=(201, 204,),
             throws=exceptions.UploadError,
             auth=self._auth,
             connector=self.connector
         )
         await response.release()
         meta = await self.metadata(path)
-        return meta, response.status == 200
+        return meta, response.status == 201
 
     async def delete(self, path, **kwargs):
         """

--- a/waterbutler/providers/owncloud/provider.py
+++ b/waterbutler/providers/owncloud/provider.py
@@ -1,0 +1,296 @@
+import aiohttp
+
+from waterbutler.core import streams
+from waterbutler.core import provider
+from waterbutler.core import exceptions
+from waterbutler.core.path import WaterButlerPath
+
+from waterbutler.providers.owncloud import utils
+
+
+class OwnCloudProvider(provider.BaseProvider):
+    """
+        Provider for the ownCloud cloud storage service.
+
+        This provider uses the OCS1.7 standard for communication
+
+        API docs: https://www.freedesktop.org/wiki/Specifications/open-collaboration-services-1.7/
+
+        Required settings fields:
+            * folder
+            * verify_ssl
+
+        Required credentials fields:
+            * host
+            * username
+            * password
+
+        Quirks:
+
+            * User credentials are stored in a aiohttp.BasicAuth object. At the
+            moment, there isn't a better way to do this.
+
+            * Intra_move and Intra_copy fail at make_request when run inside of a
+            celery worker with a bland
+            RunTimeException("Non-thread-safe operation invoked on an event loop other than the current one").
+            This has been "solved" by using the `is` keyword in can_intra_move/copy.
+    """
+    NAME = 'owncloud'
+
+    def __init__(self, auth, credentials, settings):
+        super().__init__(auth, credentials, settings)
+
+        self.folder = settings['folder']
+        self.url = credentials['host']
+        self._auth = aiohttp.BasicAuth(
+            credentials['username'],
+            credentials['password']
+        )
+        self.connector = aiohttp.TCPConnector(verify_ssl=settings['verify_ssl'])
+
+    @property
+    def _webdav_url_(self):
+        """
+            Formats the outgoing url appropriately. This accounts for some differences
+            in oc server software.
+        """
+        if self.url[-1] != '/':
+            return self.url + '/remote.php/webdav/'
+        return self.url + 'remote.php/webdav/'
+
+    async def validate_v1_path(self, path, **kwargs):
+        """
+            Verifies if a path exists and if so, returns a waterbutler path object.
+            WebDAV returns 200 for a single file, 207 for a multipart (folder) and
+            404 for DNE.
+
+            :param str path: user-supplied path to validate
+            :returns :class:`waterbutler.core.path.WaterButlerPath`: WaterButlerPath representation of path
+            :raises: :class:`waterbutler.core.exceptions.NotFoundError`
+        """
+        if path == '/':
+            return WaterButlerPath(path, prepend=self.folder)
+        full_path = WaterButlerPath(path, prepend=self.folder)
+
+        response = await self.make_request('PROPFIND',
+            self._webdav_url_ + full_path.full_path,
+            expects=(200, 207, 404),
+            throws=exceptions.MetadataError,
+            auth=self._auth,
+            connector=self.connector
+        )
+        content = await response.content.read()
+        await response.release()
+        if response.status == 404:
+            raise exceptions.NotFoundError(str(full_path.full_path))
+
+        try:
+            item = await utils.parse_dav_response(content, '/')
+        except exceptions.NotFoundError:
+            # Re-raise with the proper path
+            raise exceptions.NotFoundError(str(full_path.full_path))
+        if full_path.kind != item[0].kind:
+            raise exceptions.NotFoundError(full_path.full_path)
+        return full_path
+
+    async def validate_path(self, path, **kwargs):
+        """
+            The primary difference between `validate_path` and `validate_v1_path`
+            is that the 404 is not raised here in case the file is not found,
+            which is the case for paths checked before uploads.
+        """
+        if path == '/':
+            return WaterButlerPath(path, prepend=self.folder)
+        full_path = WaterButlerPath(path, prepend=self.folder)
+        response = await self.make_request('PROPFIND',
+            self._webdav_url_ + full_path.full_path,
+            expects=(200, 207, 404),
+            throws=exceptions.MetadataError,
+            auth=self._auth,
+            connector=self.connector
+        )
+        content = await response.content.read()
+        await response.release()
+
+        try:
+            await utils.parse_dav_response(content, '/')
+        except exceptions.NotFoundError:
+            pass
+        return full_path
+
+    async def download(self, path, accept_url=False, range=None, **kwargs):
+        """
+            Creates a stream for downloading files from the remote host.
+            If the metadata query for the file has no size metadata, downloads
+            to memory.
+
+            :param str path: user-supplied path to download.
+            :raises: :class:`waterbutler.core.exceptions.UploadError`
+        """
+        download_resp = await self.make_request(
+            'GET',
+            self._webdav_url_ + path.full_path,
+            range=range,
+            expects=(200,),
+            throws=exceptions.DownloadError,
+            auth=self._auth,
+            connector=self.connector
+        )
+        return streams.ResponseStreamReader(download_resp)
+
+    async def upload(self, stream, path, conflict='replace', **kwargs):
+        """
+            Utilizes default name conflict handling behavior then adds the
+            appropriate headers and creates the upload request.
+
+            :param str path: user-supplied path to upload.
+            :raises: :class:`waterbutler.core.exceptions.UploadError`
+        """
+        if path.identifier and conflict == 'keep':
+            path, _ = await self.handle_name_conflict(path, conflict=conflict, kind='folder')
+            path._parts[-1]._id = None
+
+        response = await self.make_request(
+            'PUT',
+            self._webdav_url_ + path.full_path,
+            data=stream,
+            headers={'Content-Length': str(stream.size)},
+            expects=(200, 201,),
+            throws=exceptions.UploadError,
+            auth=self._auth,
+            connector=self.connector
+        )
+        await response.release()
+        meta = await self.metadata(path)
+        return meta, response.status == 200
+
+    async def delete(self, path, **kwargs):
+        """
+            Deletes path on remote host
+
+            :param str path: user-supplied path to delete.
+            :raises: :class:`waterbutler.core.exceptions.DeleteError`
+        """
+
+        delete_resp = await self.make_request(
+            'DELETE',
+            self._webdav_url_ + path.full_path,
+            expects=(204,),
+            throws=exceptions.DeleteError,
+            auth=self._auth,
+            connector=self.connector
+        )
+        await delete_resp.release()
+        return
+
+    async def metadata(self, path, **kwargs):
+        """
+            Queries the remote host for metadata and returns metadata objects
+            based on the return value.
+
+            :param str path: user-supplied path to query.
+            :raises: :class:`waterbutler.core.exceptions.MetadataError`
+        """
+        if path.is_dir:
+            return (await self._metadata_folder(path, **kwargs))
+        else:
+            return (await self._metadata_file(path, **kwargs))
+
+    async def _metadata_file(self, path, **kwargs):
+
+        items = await self._metadata_folder(path, skip_first=False, **kwargs)
+        return items[0]
+
+    async def _metadata_folder(self, path, skip_first=True, **kwargs):
+        """
+            Performs the actual query against oC. In this case the return code depends
+            on the content:
+
+            * 204: Empty response
+            * 207: Multipart response
+        """
+        response = await self.make_request('PROPFIND',
+            self._webdav_url_ + path.full_path,
+            expects=(204, 207),
+            throws=exceptions.MetadataError,
+            auth=self._auth,
+            connector=self.connector
+        )
+
+        items = []
+        if response.status == 207:
+            content = await response.content.read()
+            items = await utils.parse_dav_response(content, self.folder, skip_first)
+        await response.release()
+        return items
+
+    async def create_folder(self, path, **kwargs):
+        """
+            Create a folder in the current provider at `path`.
+            Returns a `OwnCloudFolderMetadata` object
+            if successful.
+
+            :param str path: user-supplied path to create. must be a directory.
+            :param boolean precheck_folder: flag to check for folder before attempting create
+            :rtype: :class:`waterbutler.core.metadata.BaseFolderMetadata`
+            :raises: :class:`waterbutler.core.exceptions.FolderCreationError`
+        """
+        resp = await self.make_request(
+            'MKCOL',
+            self._webdav_url_ + self.folder + path.path,
+            expects=(201, 405),
+            throws=exceptions.CreateFolderError,
+            auth=self._auth,
+            connector=self.connector
+        )
+        await resp.release()
+        if resp.status == 405:
+            raise exceptions.FolderNamingConflict(path)
+        # get the folder metadata
+        meta = await self.metadata(path.parent)
+        return [m for m in meta if m.path == path.materialized_path][0]
+
+    def can_duplicate_names(self):
+        return True
+
+    def can_intra_copy(self, dest_provider, path=None):
+        return self is dest_provider
+
+    def can_intra_move(self, dest_provider, path=None):
+        return self is dest_provider
+
+    async def intra_copy(self, dest_provider, src_path, dest_path):
+        return await self._do_dav_move_copy(src_path, dest_path, 'COPY')
+
+    async def intra_move(self, dest_provider, src_path, dest_path):
+        return await self._do_dav_move_copy(src_path, dest_path, 'MOVE')
+
+    async def _do_dav_move_copy(self, src_path, dest_path, operation):
+        """
+            Performs a quick copy or move operation on the remote host.
+
+            :param str src_path: user-supplied path to the source object
+            :param str dest_path: user-supplied path to the destination object
+            :param str operation: Either `COPY` or `MOVE`
+            :rtype: :class:`waterbutler.core.waterbutler.metadata.OwnCloudFileMetadata`
+            :raises: :class:`waterbutler.core.exceptions.IntraCopyError`
+        """
+        if operation != 'MOVE' and operation != 'COPY':
+            raise NotImplementedError("ownCloud move/copy only supports MOVE and COPY endpoints")
+
+        resp = await self.make_request(
+            operation,
+            self._webdav_url_ + self.folder + src_path.path,
+            expects=(200, 201),
+            throws=exceptions.IntraCopyError,
+            auth=self._auth,
+            connector=self.connector,
+            headers={'Destination': dest_path.full_path}
+        )
+        content = await resp.content.read()
+        items = utils.parse_dav_response(content, self.folder)
+        if len(items) == 1:
+            return items[0], True
+        meta = self.metadata(dest_path)
+        meta.children = items
+        return resp, resp.status == 200

--- a/waterbutler/providers/owncloud/provider.py
+++ b/waterbutler/providers/owncloud/provider.py
@@ -131,7 +131,7 @@ class OwnCloudProvider(provider.BaseProvider):
             'GET',
             self._webdav_url_ + path.full_path,
             range=range,
-            expects=(200,),
+            expects=(200, 206,),
             throws=exceptions.DownloadError,
             auth=self._auth,
             connector=self.connector

--- a/waterbutler/providers/owncloud/provider.py
+++ b/waterbutler/providers/owncloud/provider.py
@@ -6,6 +6,7 @@ from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
 
 from waterbutler.providers.owncloud import utils
+from waterbutler.providers.owncloud.metadata import OwnCloudFileRevisionMetadata
 
 
 class OwnCloudProvider(provider.BaseProvider):
@@ -294,3 +295,7 @@ class OwnCloudProvider(provider.BaseProvider):
         meta = self.metadata(dest_path)
         meta.children = items
         return resp, resp.status == 200
+
+    async def revisions(self, path, **kwargs):
+        metadata = await self.metadata(path)
+        return [OwnCloudFileRevisionMetadata.from_metadata(metadata)]

--- a/waterbutler/providers/owncloud/settings.py
+++ b/waterbutler/providers/owncloud/settings.py
@@ -1,0 +1,6 @@
+try:
+    from waterbutler import settings
+except ImportError:
+    settings = {}
+
+config = settings.get('OWNCLOUD_PROVIDER_CONFIG', {})

--- a/waterbutler/providers/owncloud/utils.py
+++ b/waterbutler/providers/owncloud/utils.py
@@ -1,0 +1,64 @@
+import xml.etree.ElementTree as ET
+from urllib import parse
+from waterbutler.core import exceptions
+from waterbutler.providers.owncloud.metadata import OwnCloudFileMetadata
+from waterbutler.providers.owncloud.metadata import OwnCloudFolderMetadata
+
+
+def strip_dav_path(path):
+    """
+        Removes the leading "remote.php/webdav" path from the given path
+
+        :param path: path containing the remote DAV path "remote.php/webdav"
+        :type path: str
+        :returns: path stripped of the remote DAV path
+    """
+    if 'remote.php/webdav' in path:
+        return path.split('remote.php/webdav')[1]
+    return path
+
+
+async def parse_dav_response(content, folder, skip_first=False):
+    """
+        Parses the xml content returned from WebDAV and returns the metadata
+        equivalent. By default, WebDAV returns the metadata of the queried item
+        first. If the root directory is selected, then WebDAV returns server
+        information first. Hence, a `skip_first` option is included in the
+        parameters.
+
+        :param content: Body content from WebDAV response
+        :type content: str
+        :param folder: Parent folder for content
+        :type folder: str
+        :param skip_first: WebDav returns server information in first result.
+        This strips off the first result
+        :type skip_first: bool
+        :returns: List of metadata responses.
+    """
+    items = []
+    tree = ET.fromstring(content)
+
+    if skip_first:
+        tree = tree[1:]
+
+    for child in tree:
+        href = ''
+        try:
+            href = parse.unquote(strip_dav_path(child.find('{DAV:}href').text))
+        except AttributeError:
+            raise exceptions.NotFoundError(folder)
+        file_type = 'file'
+        if href[-1] == '/':
+            file_type = 'dir'
+
+        file_attrs = {}
+        attrs = child.find('{DAV:}propstat').find('{DAV:}prop')
+
+        for attr in attrs:
+            file_attrs[attr.tag] = attr.text
+
+        if file_type == 'file':
+            items.append(OwnCloudFileMetadata(href, folder, file_attrs))
+        else:
+            items.append(OwnCloudFolderMetadata(href, folder, file_attrs))
+    return items


### PR DESCRIPTION
## Purpose / Changes

This PR will add @kwierman's ownCloud provider (#164) to WaterButler.  It does *not* depend on [the OSF-side PR](https://github.com/CenterForOpenScience/osf.io/pull/6316), but will be useless until that is merged.  Both PRs are being maintained as feature branches for testing purposes, and will be merged to develop later.

## Testing

This is a full-feature read+write provider and will have to pass all the same tests that our other providers do.  The runscope tests will need to be updated, and manual testing of create/read/update/delete/move/copy operations done to make sure the v0 API is exercised