### PR TITLE
Pass user id on file download for analytics [OSF-3628]

### DIFF
--- a/tests/providers/osfstorage/test_provider.py
+++ b/tests/providers/osfstorage/test_provider.py
@@ -18,6 +18,7 @@ from waterbutler.core.path import WaterButlerPath
 from waterbutler.providers.osfstorage import OSFStorageProvider
 from waterbutler.providers.osfstorage.settings import FILE_PATH_COMPLETE
 
+import pdb
 
 @pytest.fixture
 def file_content():
@@ -184,9 +185,29 @@ def file_lineage():
 
 @pytest.mark.asyncio
 @pytest.mark.aiohttpretty
-async def test_download(monkeypatch, provider_and_mock, osf_response, mock_path, mock_time):
+async def test_download_with_auth(monkeypatch, provider_and_mock, osf_response, mock_path, mock_time):
     provider, inner_provider = provider_and_mock
     params = {'user': 'cat'}
+    base_url = provider.build_url(mock_path.identifier, 'download', version=None, mode=None)
+    url, _, params = provider.build_signed_url('GET', base_url, params=params)
+
+    aiohttpretty.register_json_uri('GET', url, params=params, body=osf_response)
+
+    await provider.download(mock_path)
+
+    assert provider.make_provider.called
+    assert inner_provider.download.called
+
+    assert aiohttpretty.has_call(method='GET', uri=url, params=params)
+    provider.make_provider.assert_called_once_with(osf_response['settings'])
+    inner_provider.download.assert_called_once_with(path=WaterButlerPath('/test/path'), displayName='unrelatedpath')
+
+@pytest.mark.asyncio
+@pytest.mark.aiohttpretty
+async def test_download_without_auth(monkeypatch, provider_and_mock, osf_response, mock_path, mock_time):
+    provider, inner_provider = provider_and_mock
+    provider.auth = {} # Remove auth for test
+    params = {}
     base_url = provider.build_url(mock_path.identifier, 'download', version=None, mode=None)
     url, _, params = provider.build_signed_url('GET', base_url, params=params)
 

--- a/tests/providers/osfstorage/test_provider.py
+++ b/tests/providers/osfstorage/test_provider.py
@@ -186,9 +186,9 @@ def file_lineage():
 @pytest.mark.aiohttpretty
 async def test_download(monkeypatch, provider_and_mock, osf_response, mock_path, mock_time):
     provider, inner_provider = provider_and_mock
-
+    params = {'user': 'cat'}
     base_url = provider.build_url(mock_path.identifier, 'download', version=None, mode=None)
-    url, _, params = provider.build_signed_url('GET', base_url)
+    url, _, params = provider.build_signed_url('GET', base_url, params=params)
 
     aiohttpretty.register_json_uri('GET', url, params=params, body=osf_response)
 

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -226,6 +226,7 @@ class OSFStorageProvider(provider.BaseProvider):
             'GET',
             self.build_url(path.identifier, 'download', version=version, mode=mode),
             expects=(200, ),
+            params={'user': self.auth['id']},
             throws=exceptions.DownloadError,
         ) as resp:
             data = await resp.json()

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -221,12 +221,17 @@ class OSFStorageProvider(provider.BaseProvider):
             # version could be 0 here
             version = revision
 
+        # Capture user_id for analytics if user is logged in
+        user_param = {}
+        if self.auth.get('id', None):
+            user_param = {'user': self.auth['id']}
+
         # osf storage metadata will return a virtual path within the provider
         async with self.signed_request(
             'GET',
             self.build_url(path.identifier, 'download', version=version, mode=mode),
             expects=(200, ),
-            params={'user': self.auth['id']},
+            params=user_param,
             throws=exceptions.DownloadError,
         ) as resp:
             data = await resp.json()


### PR DESCRIPTION
## Purpose

Send auth information (user id) on download so that analytics can know whether the downloader is a contributor to the file's project or not. As part of [https://openscience.atlassian.net/browse/OSF-3628](https://openscience.atlassian.net/browse/OSF-3628).

## Changes

- Pass the ```{'user': auth['id']}``` if it exists or ```{}``` as param in ```async with self.signed_request``` for ```async def download(self, path, version=None, revision=None, mode=None, **kwargs)```.

- Added tests for new behavior: replaced ```test_download``` with ```test_download_with_auth``` and ```test_download_without_auth```.

## Side Effects

None visible.

## Ticket

[https://openscience.atlassian.net/browse/OSF-3628](https://openscience.atlassian.net/browse/OSF-3628)

