### PR TITLE
[RFR][OSF-6484]Update provider metadata.py to return "created_utc"

### DIFF
--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -36,6 +36,7 @@ class TestBaseMetadata:
             'contentType': 'application/octet-stream',
             'modified': 'never',
             'modified_utc': 'never',
+            'created_utc': 'always',
             'size': 1337,
             'resource': 'n0d3z',
         }
@@ -89,6 +90,7 @@ class TestBaseMetadata:
             'contentType': 'application/octet-stream',
             'modified': 'never',
             'modified_utc': 'never',
+            'created_utc': 'always',
             'size': 1337,
         }
 

--- a/tests/tasks/test_copy.py
+++ b/tests/tasks/test_copy.py
@@ -210,6 +210,7 @@ class TestCopyTask:
             'extra': metadata.extra,
             'modified': metadata.modified,
             'modified_utc': metadata.modified_utc,
+            'created_utc': metadata.created_utc,
             'size': metadata.size,
         }
 

--- a/tests/tasks/test_move.py
+++ b/tests/tasks/test_move.py
@@ -209,6 +209,7 @@ class TestMoveTask:
             'extra': metadata.extra,
             'modified': metadata.modified,
             'modified_utc': metadata.modified_utc,
+            'created_utc': metadata.created_utc,
             'size': metadata.size,
         }
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,6 +28,7 @@ class MockFileMetadata(metadata.BaseFileMetadata):
     path = '/Foo.name'
     modified = 'never'
     modified_utc = 'never'
+    created_utc = 'always'
     content_type = 'application/octet-stream'
 
     def __init__(self):
@@ -52,6 +53,7 @@ class MockFileRevisionMetadata(metadata.BaseFileRevisionMetadata):
     version_identifier = 'versions'
     modified = 'never'
     modified_utc = 'never'
+    created_utc = 'always'
 
     def __init__(self):
         super().__init__({})

--- a/waterbutler/core/metadata.py
+++ b/waterbutler/core/metadata.py
@@ -206,6 +206,7 @@ class BaseFileMetadata(BaseMetadata):
             'contentType': self.content_type,
             'modified': self.modified,
             'modified_utc': self.modified_utc,
+            'created_utc': self.created_utc,
             'size': self.size,
         })
 
@@ -239,6 +240,12 @@ class BaseFileMetadata(BaseMetadata):
         """ Date the file was last modified, as reported by the provider,
         converted to UTC, in format (YYYY-MM-DDTHH:MM:SS+00:00). """
         return utils.normalize_datetime(self.modified)
+
+    @property
+    def created_utc(self):
+        """ Date the file was created, as reported by the provider,
+        converted to UTC, in format (YYYY-MM-DDTHH:MM:SS+00:00). """
+        raise NotImplementedError
 
     @abc.abstractproperty
     def size(self):
@@ -284,6 +291,8 @@ class BaseFileRevisionMetadata(metaclass=abc.ABCMeta):
 
     @property
     def modified_utc(self):
+        """ Date the revision was last modified, as reported by the provider,
+        converted to UTC, in format (YYYY-MM-DDTHH:MM:SS+00:00). """
         return utils.normalize_datetime(self.modified)
 
     @abc.abstractproperty

--- a/waterbutler/providers/box/metadata.py
+++ b/waterbutler/providers/box/metadata.py
@@ -1,4 +1,4 @@
-from waterbutler.core import metadata
+from waterbutler.core import metadata, utils
 
 
 class BaseBoxMetadata(metadata.BaseMetadata):
@@ -44,6 +44,10 @@ class BoxFileMetadata(BaseBoxMetadata, metadata.BaseFileMetadata):
     @property
     def modified(self):
         return self.raw.get('modified_at')
+
+    @property
+    def created_utc(self):
+        return utils.normalize_datetime(self.raw.get('created_at'))
 
     @property
     def content_type(self):

--- a/waterbutler/providers/cloudfiles/metadata.py
+++ b/waterbutler/providers/cloudfiles/metadata.py
@@ -29,6 +29,10 @@ class CloudFilesFileMetadata(BaseCloudFilesMetadata, metadata.BaseFileMetadata):
         return self.raw['last_modified']
 
     @property
+    def created_utc(self):
+        return None
+
+    @property
     def content_type(self):
         return self.raw['content_type']
 
@@ -58,6 +62,10 @@ class CloudFilesHeaderMetadata(BaseCloudFilesMetadata, metadata.BaseFileMetadata
     @property
     def modified(self):
         return self.raw['Last-Modified']
+
+    @property
+    def created_utc(self):
+        return None
 
     @property
     def content_type(self):

--- a/waterbutler/providers/dataverse/metadata.py
+++ b/waterbutler/providers/dataverse/metadata.py
@@ -47,6 +47,10 @@ class DataverseFileMetadata(BaseDataverseMetadata, metadata.BaseFileMetadata):
         return None
 
     @property
+    def created_utc(self):
+        return None
+
+    @property
     def etag(self):
         return '{}::{}'.format(self.dataset_version, self.file_id)
 

--- a/waterbutler/providers/dropbox/metadata.py
+++ b/waterbutler/providers/dropbox/metadata.py
@@ -56,6 +56,10 @@ class DropboxFileMetadata(BaseDropboxMetadata, metadata.BaseFileMetadata):
         return self.raw['modified']
 
     @property
+    def created_utc(self):
+        return None
+
+    @property
     def content_type(self):
         return self.raw['mime_type']
 

--- a/waterbutler/providers/figshare/metadata.py
+++ b/waterbutler/providers/figshare/metadata.py
@@ -65,6 +65,10 @@ class FigshareFileMetadata(BaseFigshareMetadata, metadata.BaseFileMetadata):
         return None
 
     @property
+    def created_utc(self):
+        return None
+
+    @property
     def can_delete(self):
         """Files can be deleted if private or if containing fileset contains
         two or more files.
@@ -114,6 +118,10 @@ class FigshareArticleMetadata(BaseFigshareMetadata, metadata.BaseMetadata):
 
     @property
     def modified(self):
+        return None
+
+    @property
+    def created_utc(self):
         return None
 
     @property

--- a/waterbutler/providers/filesystem/metadata.py
+++ b/waterbutler/providers/filesystem/metadata.py
@@ -54,6 +54,10 @@ class FileSystemFileMetadata(BaseFileSystemMetadata, metadata.BaseFileMetadata):
         return self.raw['modified_utc']
 
     @property
+    def created_utc(self):
+        return None
+
+    @property
     def content_type(self):
         return self.raw['mime_type']
 

--- a/waterbutler/providers/github/metadata.py
+++ b/waterbutler/providers/github/metadata.py
@@ -71,6 +71,10 @@ class BaseGitHubFileMetadata(BaseGitHubMetadata, metadata.BaseFileMetadata):
         return self.commit['author']['date']
 
     @property
+    def created_utc(self):
+        return None
+
+    @property
     def content_type(self):
         return None
 
@@ -146,6 +150,10 @@ class GitHubRevision(metadata.BaseFileRevisionMetadata):
     @property
     def modified(self):
         return self.raw['commit']['author']['date']
+
+    @property
+    def created_utc(self):
+        return None
 
     @property
     def version(self):

--- a/waterbutler/providers/googledrive/metadata.py
+++ b/waterbutler/providers/googledrive/metadata.py
@@ -1,4 +1,5 @@
 from waterbutler.core import metadata
+import waterbutler.core.utils as core_utils
 
 from waterbutler.providers.googledrive import utils
 
@@ -67,6 +68,10 @@ class GoogleDriveFileMetadata(BaseGoogleDriveMetadata, metadata.BaseFileMetadata
     @property
     def modified(self):
         return self.raw['modifiedDate']
+
+    @property
+    def created_utc(self):
+        return core_utils.normalize_datetime(self.raw['createdDate'])
 
     @property
     def content_type(self):

--- a/waterbutler/providers/osfstorage/metadata.py
+++ b/waterbutler/providers/osfstorage/metadata.py
@@ -51,6 +51,21 @@ class OsfStorageFileMetadata(BaseOsfStorageItemMetadata, metadata.BaseFileMetada
             return parsed_datetime.isoformat()
 
     @property
+    def created_utc(self):
+        try:
+            return self.raw['created_utc']
+        except KeyError:
+            if self.raw['created'] is None:
+                return None
+
+            # Kludge for OSF, whose created attribute does not include
+            # tzinfo but is assumed to be UTC.
+            parsed_datetime = dateutil.parser.parse(self.raw['created'])
+            if not parsed_datetime.tzinfo:
+                parsed_datetime = parsed_datetime.replace(tzinfo=pytz.UTC)
+            return parsed_datetime.isoformat()
+
+    @property
     def size(self):
         return self.raw['size']
 

--- a/waterbutler/providers/owncloud/metadata.py
+++ b/waterbutler/providers/owncloud/metadata.py
@@ -36,6 +36,10 @@ class BaseOwnCloudMetadata(metadata.BaseMetadata):
     def modified(self):
         return self.attributes['{DAV:}getlastmodified']
 
+    @property
+    def created_utc(self):
+        return None
+
 
 class OwnCloudFileMetadata(BaseOwnCloudMetadata, metadata.BaseFileMetadata):
 

--- a/waterbutler/providers/s3/metadata.py
+++ b/waterbutler/providers/s3/metadata.py
@@ -39,6 +39,10 @@ class S3FileMetadataHeaders(S3Metadata, metadata.BaseFileMetadata):
         return self.raw['LAST-MODIFIED']
 
     @property
+    def created_utc(self):
+        return None
+
+    @property
     def etag(self):
         return self.raw['ETAG'].replace('"', '')
 
@@ -63,6 +67,10 @@ class S3FileMetadata(S3Metadata, metadata.BaseFileMetadata):
     @property
     def modified(self):
         return self.raw['LastModified']
+
+    @property
+    def created_utc(self):
+        return None
 
     @property
     def content_type(self):


### PR DESCRIPTION
## Purpose:
[OSF-6484](https://openscience.atlassian.net/browse/OSF-6484)
[WB API] Add "created_utc" attribute to file response

## Changes:
	modified:   tests/core/test_metadata.py
	modified:   tests/tasks/test_copy.py
	modified:   tests/tasks/test_move.py
	modified:   tests/utils.py
	modified:   waterbutler/core/metadata.py
	modified:   waterbutler/providers/box/metadata.py
	modified:   waterbutler/providers/cloudfiles/metadata.py
	modified:   waterbutler/providers/dataverse/metadata.py
	modified:   waterbutler/providers/dropbox/metadata.py
	modified:   waterbutler/providers/figshare/metadata.py
	modified:   waterbutler/providers/filesystem/metadata.py
	modified:   waterbutler/providers/github/metadata.py
	modified:   waterbutler/providers/googledrive/metadata.py
	modified:   waterbutler/providers/osfstorage/metadata.py
	modified:   waterbutler/providers/owncloud/metadata.py
	modified:   waterbutler/providers/s3/metadata.py

## Side effects
None

## Warning
This PR must be merged into WB only after [OSF PR 6537](https://github.com/CenterForOpenScience/osf.io/pull/6537) is merged into the corresponding OSF instance.

[#OSF-6484]