### PR TITLE
Add undeletable_contents metadata field

### DIFF
--- a/waterbutler/providers/osfstorage/metadata.py
+++ b/waterbutler/providers/osfstorage/metadata.py
@@ -80,7 +80,7 @@ class OsfStorageFolderMetadata(BaseOsfStorageItemMetadata, metadata.BaseFolderMe
     @property
     def extra(self):
         return {
-            'undeletable_contents': self.raw.get('undeletable_contents', []),
+            'undeletableContents': self.raw.get('undeletable_contents', []),
         }
 
 

--- a/waterbutler/providers/osfstorage/metadata.py
+++ b/waterbutler/providers/osfstorage/metadata.py
@@ -77,7 +77,11 @@ class OsfStorageFileMetadata(BaseOsfStorageItemMetadata, metadata.BaseFileMetada
 
 
 class OsfStorageFolderMetadata(BaseOsfStorageItemMetadata, metadata.BaseFolderMetadata):
-    pass
+    @property
+    def extra(self):
+        return {
+            'undeletable_contents': self.raw.get('undeletable_contents', []),
+        }
 
 
 class OsfStorageRevisionMetadata(BaseOsfStorageMetadata, metadata.BaseFileRevisionMetadata):


### PR DESCRIPTION
## Purpose
In OSFStorage has two kinds of undeletable files, preprints and checked out files. Currently to find out if a folder is deletable, every nested file and folder must be explored. By adding this field, the fangorn logic can be simplified and also handle situations where the folder has not been fully loaded.

## Changes
This adds `undeletable_contents` to the osfstorage extra metadata field. The field returns a list of ids of folder contents that are undeletable

## Side effects
None known