### PR TITLE
Remove setuptools ... a lot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ RUN mkdir -p /code
 WORKDIR /code
 
 RUN pip install -U pip
+RUN pip uninstall -y setuptools
+RUN rm -f /usr/local/lib/python3.5/site-packages/waterbutler-nspkg.pth
 RUN pip install setuptools==30.4.0
 
 COPY ./requirements.txt /code/


### PR DESCRIPTION
The osf docker-compose script was giving some people `__version__` errors still. I believe this fixes them. I built a docker image locally and was able to start it and run the server. The uninstall and delete is probably overkill but why not delete it as many times as possible. h/t @felliott Your commit comment gave me enough to figure it out.