### PR TITLE
[SVCS-101] Fix read the docs python 3.5 incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,7 @@
 
 ### Documentation
 
-*Note: https://readthedocs.org/ is currently unable to build documentation for Python 3.5 projects.*  The documentation available at https://waterbutler.readthedocs.io/en/latest/ is outdated (v0.15.1). For the most up-to-date documentation, build locally. Within your checkout, run:
-
-```bash
-pip install -r doc-requirements.txt
-cd docs
-make
-open _build/html/index.html
-```
+Documentation available at https://waterbutler.readthedocs.io/en/latest/
 
 ### Setting up
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,10 +41,6 @@ coverage_ignore_functions = []
 
 html_favicon = 'favicon.ico'
 
-latex_documents = [
-    ('documentation', False),
-]
-
 # HACK: sphinx has limited support for substitutions with the |version|
 # variable, but there doesn't appear to be any way to use this in a link
 # target.

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,16 @@
+name: py35
+dependencies:
+- openssl=1.0.2g=0
+- pip=8.1.1=py35_0
+- python=3.5.1=0
+- readline=6.2=2
+- setuptools=20.3=py35_0
+- sqlite=3.9.2=0
+- tk=8.5.18=0
+- wheel=0.29.0=py35_0
+- xz=5.0.5=1
+- zlib=1.2.8=0
+- pip:
+  - momoko>=2.2.3
+  - psycopg2>=2.6.1
+  - tornado==4.3

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,2 @@
+conda:
+    file: environment.yml


### PR DESCRIPTION
# Purpose

Allow readthedocs.md to build docs for waterbutler despite python 3.5 incompatibility. 

# Changes

modifies config files so anaconda can work properly with 3.5

# Side Effects

None that I know of.

# Ticket

https://openscience.atlassian.net/browse/SVCS-101