### PR TITLE
Set created_utc to None in GoogleDriveFileRevisionMetadata

### DIFF
--- a/waterbutler/providers/googledrive/metadata.py
+++ b/waterbutler/providers/googledrive/metadata.py
@@ -157,6 +157,10 @@ class GoogleDriveFileRevisionMetadata(GoogleDriveFileMetadata):
         return self.raw['modifiedDate']
 
     @property
+    def created_utc(self):
+        return None
+
+    @property
     def content_type(self):
         return self.raw['mimeType']
 


### PR DESCRIPTION
## Purpose:
[SVCS-171](https://openscience.atlassian.net/browse/SVCS-171)
Some GoogleDrive requests are failing with a KeyError
GoogleDrive API does not return createdDate for Revisions.

## Changes:
Updated waterbutler/providers/googledrive/metadata.py Set created_utc to None in GoogleDriveFileRevisionMetadata

## Side effects
None

[SVCS-171]