### PR TITLE
Update config and README for local docker development

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ invoke celery
 
 ### Configuring
 
+### For Docker setup use 192.168.168.167 instead of localhost
+
 WaterButler configuration is done through a JSON file (`waterbutler-test.json`) that lives in the `.cos` directory of your home directory.  If this is your first time setting up WaterButler or its sister project, [MFR](https://github.com/CenterForOpenScience/modular-file-renderer/), you probably do not have this directory and will need to create it:
 
 ```bash

--- a/waterbutler/auth/osf/settings.py
+++ b/waterbutler/auth/osf/settings.py
@@ -5,7 +5,7 @@ config = settings.child('OSF_AUTH_CONFIG')
 
 JWT_EXPIRATION = int(config.get('JWT_EXPIRATION', 15))
 JWT_ALGORITHM = config.get('JWT_ALGORITHM', 'HS256')
-API_URL = config.get('API_URL', 'http://localhost:5000/api/v1/files/auth/')
+API_URL = config.get('API_URL', 'http://192.168.168.167:5000/api/v1/files/auth/')
 
 JWE_SALT = config.get('JWE_SALT')
 JWE_SECRET = config.get('JWE_SECRET')


### PR DESCRIPTION
## Purpose:
[SVCS-245](https://openscience.atlassian.net/browse/SVCS-245)
Update local development Docker config and doc for WB

## Changes:
Update Documentation and `API_URL` to reflect use of 192.168.168.167 instead of localhost

## Side effects
None

## This PR is tied to OSF.io [PR#6812](https://github.com/CenterForOpenScience/osf.io/pull/6812)   . Though they should not have to be merged at the same time.
