### PR TITLE
Update handling of WaitTimoutError to log level INFO at Sentry

### DIFF
--- a/waterbutler/server/api/v1/core.py
+++ b/waterbutler/server/api/v1/core.py
@@ -24,6 +24,7 @@ class BaseHandler(utils.CORsMixin, utils.UtilMixin, tornado.web.RequestHandler, 
             finish_args = [exc.data] if exc.data else [{'code': exc.code, 'message': exc.message}]
         elif issubclass(etype, tasks.WaitTimeOutError):
             self.set_status(202)
+            exception_kwargs = {'data': {'level': 'info'}}
         else:
             finish_args = [{'code': status_code, 'message': self._reason}]
 


### PR DESCRIPTION
## Purpose:

[SVCS-2](https://openscience.atlassian.net/browse/SVCS-2)
Don't log expected WaitTimeOutError to Sentry:
  Configure Sentry to log WaitTimeOutError at log level INFO

## Changes:

update waterbutler/server/api/v1/core.py class BaseHandler add {'level': 'info'} to WaitTimeOutError catch.

## Side effects:

None

[#SVCS-2]