### PR TITLE
[SVCS-236] Fix broken revision handling for Github

### DIFF
--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -94,10 +94,10 @@ class GitHubProvider(provider.BaseProvider):
         if path == '/':
             return GitHubPath(path, _ids=[(branch_ref, '')])
 
-        branch_data = await self._fetch_branch(branch_ref)
-
-        # throws Not Found if path not in tree
-        await self._search_tree_for_path(path, branch_data['commit']['commit']['tree']['sha'])
+        if not kwargs.get('ref'):
+            branch_data = await self._fetch_branch(branch_ref)
+            # throws Not Found if path not in tree
+            await self._search_tree_for_path(path, branch_data['commit']['commit']['tree']['sha'])
 
         path = GitHubPath(path)
         for part in path.parts:

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -77,29 +77,30 @@ class GitHubProvider(provider.BaseProvider):
             self._repo = await self._fetch_repo()
             self.default_branch = self._repo['default_branch']
 
-        branch_ref, ref_from = None, None
+        branch_ref, ref_from = None, []
         if kwargs.get('ref'):
             branch_ref = kwargs.get('ref')
-            ref_from = 'query_ref'
-        elif kwargs.get('branch'):
+            ref_from += ['query_ref']
+
+        if kwargs.get('branch'):
             branch_ref = kwargs.get('branch')
-            ref_from = 'query_branch'
+            ref_from += ['query_branch']
         else:
             branch_ref = self.default_branch
-            ref_from = 'default_branch'
+            ref_from += ['default_branch']
         if isinstance(branch_ref, list):
             raise exceptions.InvalidParameters('Only one ref or branch may be given.')
-        self.metrics.add('branch_ref_from', ref_from)
+        self.metrics.add('branch_ref_from', ','.join(ref_from))
 
         if path == '/':
             return GitHubPath(path, _ids=[(branch_ref, '')])
 
-        if not kwargs.get('ref'):
-            branch_data = await self._fetch_branch(branch_ref)
-            # throws Not Found if path not in tree
-            await self._search_tree_for_path(path, branch_data['commit']['commit']['tree']['sha'])
+        branch_data = await self._fetch_branch(branch_ref)
+        # throws Not Found if path not in tree
+        await self._search_tree_for_path(path, branch_data['commit']['commit']['tree']['sha'])
 
         path = GitHubPath(path)
+        print(self.default_branch)
         for part in path.parts:
             part._id = (branch_ref, None)
 


### PR DESCRIPTION
# Purpose 

Stop the 404s that occur when attempting to view github revisions.

# Changes

Astonishingly simple change stops WB from searching whole tree when it only needs single commit. The problem is caused by unnecessarily grabbing the tree for revisions where the metadata for a single commit is all that's needed.

# Side Effects

None that I know of.

# Ticket

https://openscience.atlassian.net/browse/SVCS-236