### PR TITLE
Update intra_move and intra_copy to return folder's children.

### DIFF
--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -169,7 +169,10 @@ class OSFStorageProvider(provider.BaseProvider):
         if data['kind'] == 'file':
             return OsfStorageFileMetadata(data, str(dest_path)), dest_path.identifier is None
 
-        return OsfStorageFolderMetadata(data, str(dest_path)), dest_path.identifier is None
+        folder = OsfStorageFolderMetadata(data, str(dest_path))
+        folder.children = await self._children_metadata(await self.validate_v1_path(data['path']))
+
+        return folder, dest_path.identifier is None
 
     async def intra_copy(self, dest_provider, src_path, dest_path):
         if dest_path.identifier:
@@ -195,7 +198,10 @@ class OSFStorageProvider(provider.BaseProvider):
         if data['kind'] == 'file':
             return OsfStorageFileMetadata(data, str(dest_path)), dest_path.identifier is None
 
-        return OsfStorageFolderMetadata(data, str(dest_path)), dest_path.identifier is None
+        folder = OsfStorageFolderMetadata(data, str(dest_path))
+        folder.children = await self._children_metadata(await self.validate_v1_path(data['path']))
+
+        return folder, dest_path.identifier is None
 
     def build_signed_url(self, method, url, data=None, params=None, ttl=100, **kwargs):
         signer = signing.Signer(settings.HMAC_SECRET, settings.HMAC_ALGORITHM)


### PR DESCRIPTION
## Purpose:

[SVCS-229](https://openscience.atlassian.net/browse/SVCS-229)
WB API: OSFStorage intra_move/_copy does not return children

## Changes:

update  waterbutler/providers/osfstorage/provider.py
- def intra_move update to return children
- def intra_copy update to return children

## Side effects:

None

[#SVCS-229]