### PR TITLE
[SVCS-236] Fix broken revision handling for Github

### DIFF
--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -79,9 +79,12 @@ class GitHubProvider(provider.BaseProvider):
 
         branch_ref, ref_from = None, None
         if kwargs.get('ref'):
-            branch_ref = kwargs.get('ref')
+            ref = kwargs.get('ref')
             ref_from = 'query_ref'
-        elif kwargs.get('branch'):
+            if isinstance(ref, list):
+                raise exceptions.InvalidParameters('Only one ref or branch may be given.')
+
+        if kwargs.get('branch'):
             branch_ref = kwargs.get('branch')
             ref_from = 'query_branch'
         else:


### PR DESCRIPTION
# Purpose 

Stop the 404s that occur when attempting to view github revisions.

# Changes

Astonishingly simple change stops WB from searching whole tree when it only needs single commit. The problem is caused by unnecessarily grabbing the tree for revisions where the metadata for a single commit is all that's needed.

# Side Effects

None that I know of.

# Ticket

https://openscience.atlassian.net/browse/SVCS-236

# Related PR

#190 