### PR TITLE
[SVCS-21] Add exception to prevent accessing gdoc files without file extension

### DIFF
--- a/tests/providers/googledrive/test_provider.py
+++ b/tests/providers/googledrive/test_provider.py
@@ -108,10 +108,14 @@ def actual_folder_response():
     }
 
 def _build_title_search_query(provider, entity_name, is_folder=True):
-        return "title = '{}' " \
+    return "title = '{}' " \
             "and trashed = false " \
             "and mimeType != 'application/vnd.google-apps.form' " \
             "and mimeType != 'application/vnd.google-apps.map' " \
+            "and mimeType != 'application/vnd.google-apps.document' " \
+            "and mimeType != 'application/vnd.google-apps.drawing' " \
+            "and mimeType != 'application/vnd.google-apps.presentation' " \
+            "and mimeType != 'application/vnd.google-apps.spreadsheet' " \
             "and mimeType {} '{}'".format(
                 entity_name,
                 '=' if is_folder else '!=',

--- a/waterbutler/core/exceptions.py
+++ b/waterbutler/core/exceptions.py
@@ -64,11 +64,6 @@ class ProviderNotFound(ProviderError):
         super().__init__('Provider "{}" not found'.format(provider), code=404)
 
 
-class ExtensionNotIncluded(ProviderError):
-    def __init__(self, provider):
-        super().__init__('We require you include an extension for this type of file for {}'.format(provider), code=400)
-
-
 class CopyError(ProviderError):
     pass
 

--- a/waterbutler/core/exceptions.py
+++ b/waterbutler/core/exceptions.py
@@ -64,6 +64,11 @@ class ProviderNotFound(ProviderError):
         super().__init__('Provider "{}" not found'.format(provider), code=404)
 
 
+class ExtensionNotIncluded(ProviderError):
+    def __init__(self, provider):
+        super().__init__('We require you include an extension for this type of file for {}'.format(provider), code=400)
+
+
 class CopyError(ProviderError):
     pass
 

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -412,6 +412,10 @@ class GoogleDriveProvider(provider.BaseProvider):
                         "and trashed = false " \
                         "and mimeType != 'application/vnd.google-apps.form' " \
                         "and mimeType != 'application/vnd.google-apps.map' " \
+                        "and mimeType != 'application/vnd.google-apps.document' " \
+                        "and mimeType != 'application/vnd.google-apps.drawing' " \
+                        "and mimeType != 'application/vnd.google-apps.presentation' " \
+                        "and mimeType != 'application/vnd.google-apps.spreadsheet' " \
                         "and mimeType {} '{}'".format(
                             clean_query(part_name),
                             '=' if part_is_folder else '!=',
@@ -444,11 +448,6 @@ class GoogleDriveProvider(provider.BaseProvider):
                 throws=exceptions.MetadataError,
             ) as resp:
                 ret.append(await resp.json())
-
-        content_type = ret[-1]['mimeType']
-        if not ext and 'application/vnd.google-apps' in content_type and content_type != 'application/vnd.google-apps.folder':
-            raise exceptions.NotFoundError(path=path)
-
         return ret
 
     async def _resolve_id_to_parts(self, _id, accum=None):

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -447,7 +447,7 @@ class GoogleDriveProvider(provider.BaseProvider):
 
         content_type = ret[-1]['mimeType']
         if not ext and 'application/vnd.google-apps' in content_type and content_type != 'application/vnd.google-apps.folder':
-            raise exceptions.ExtensionNotIncluded(provider=self.NAME)
+            raise exceptions.NotFoundError(path=path)
 
         return ret
 

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -445,6 +445,10 @@ class GoogleDriveProvider(provider.BaseProvider):
             ) as resp:
                 ret.append(await resp.json())
 
+        content_type = ret[-1]['mimeType']
+        if not ext and 'application/vnd.google-apps' in content_type and content_type != 'application/vnd.google-apps.folder':
+            raise exceptions.ExtensionNotIncluded(provider=self.NAME)
+
         return ret
 
     async def _resolve_id_to_parts(self, _id, accum=None):


### PR DESCRIPTION
# Purpose
Google Doc files stored via the google drive WB provider are currently api-accessible both with and without extension. This forces you to use an extension.

# Changes
Adds new exception that's called when extension-less gdoc is called.

# Side Effects
None that I know of.

# Tickets
https://openscience.atlassian.net/browse/SVCS-21