### PR TITLE
[SVCS-229] Add children to folder metadata for intra_move and intra_copy

### DIFF
--- a/tests/providers/osfstorage/test_provider.py
+++ b/tests/providers/osfstorage/test_provider.py
@@ -1,6 +1,7 @@
 import os
 import io
 import time
+import json
 import asyncio
 from http import client
 from unittest import mock
@@ -16,6 +17,7 @@ from waterbutler.core import exceptions
 from waterbutler.server import settings
 from waterbutler.core.path import WaterButlerPath
 from waterbutler.providers.osfstorage import OSFStorageProvider
+from waterbutler.providers.osfstorage.metadata import OsfStorageFolderMetadata
 from waterbutler.providers.osfstorage.settings import FILE_PATH_COMPLETE
 
 
@@ -80,6 +82,26 @@ def provider_and_mock(monkeypatch, auth, credentials, settings):
     mock_provider.upload = utils.MockCoroutine()
     mock_provider.download = utils.MockCoroutine()
     mock_provider.metadata = utils.MockCoroutine()
+    mock_provider.validate_v1_path = utils.MockCoroutine()
+    mock_provider._children_metadata = utils.MockCoroutine()
+
+    mock_make_provider = mock.Mock(return_value=mock_provider)
+    monkeypatch.setattr(OSFStorageProvider, 'make_provider', mock_make_provider)
+    return OSFStorageProvider(auth, credentials, settings), mock_provider
+
+
+@pytest.fixture
+def provider_and_mock2(monkeypatch, auth, credentials, settings):
+    mock_provider = utils.MockProvider1({}, {}, {})
+
+    mock_provider.copy = utils.MockCoroutine()
+    mock_provider.move = utils.MockCoroutine()
+    mock_provider.delete = utils.MockCoroutine()
+    mock_provider.upload = utils.MockCoroutine()
+    mock_provider.download = utils.MockCoroutine()
+    mock_provider.metadata = utils.MockCoroutine()
+    mock_provider.validate_v1_path = utils.MockCoroutine()
+    mock_provider._children_metadata = utils.MockCoroutine()
 
     mock_make_provider = mock.Mock(return_value=mock_provider)
     monkeypatch.setattr(OSFStorageProvider, 'make_provider', mock_make_provider)
@@ -90,6 +112,27 @@ def provider_and_mock(monkeypatch, auth, credentials, settings):
 def provider(provider_and_mock):
     provider, _ = provider_and_mock
     return provider
+
+
+@pytest.fixture
+def children_response():
+    return [{"etag": "d0a8d038885dd14d8ac25b80ac179a727d11da34d4a685804",
+             "size": 11839,
+             "name": "arch.zip",
+             "path": "/58c959e9cae5b6000bb09810",
+             "created_utc": "2017-03-13T15:43:02+00:00",
+             "contentType": None,
+             "extra": {"checkout": None,
+                       "downloads": 0,
+                       "hashes": {"sha256": "ba2b5a5fbd8aa1dff221b6438d2b7d38ea",
+                                  "md5": "51ca5a238854030ae5272d5c8cda8188"},
+                       "guid": None,
+                       "version": 1},
+             "modified": "2017-03-13T15:43:02+00:00",
+             "provider": "osfstorage",
+             "kind": "file",
+             "materialized": "/folder1/arch.zip",
+             "modified_utc": "2017-03-13T15:43:02+00:00"}]
 
 
 @pytest.fixture
@@ -291,6 +334,88 @@ async def test_provider_metadata(monkeypatch, provider, mock_folder_path, mock_t
 
     assert aiohttpretty.has_call(method='GET', uri=url, params=params)
 
+@pytest.mark.asyncio
+@pytest.mark.aiohttpretty
+async def test_intra_copy_folder(provider_and_mock, provider_and_mock2,
+                                 children_response):
+    src_provider, src_mock = provider_and_mock
+    src_mock.intra_copy = src_provider.intra_copy
+
+    dest_provider, dest_mock = provider_and_mock2
+    dest_mock.nid = 'abcde'
+    dest_mock._children_metadata = utils.MockCoroutine(return_value=children_response)
+    dest_mock.validate_v1_path = utils.MockCoroutine(return_value=WaterButlerPath('/folder1/', _ids=('rootId', 'folder1')))
+
+    src_path = WaterButlerPath('/folder1/', _ids=['RootId', 'folder1'],
+                               folder=True)
+    dest_path = WaterButlerPath('/folder1/', folder=True)
+
+    data=json.dumps({
+        'user': src_provider.auth['id'],
+        'source': src_path.identifier,
+        'destination': {
+            'name': dest_path.name,
+            'node': dest_provider.nid,
+            'parent': dest_path.parent.identifier
+        }
+    })
+    url, _, params = src_provider.build_signed_url('POST',
+                                                   'https://waterbutler.io/hooks/copy/',
+                                                   data=data)
+
+    body = {'path': '/folder1/', 'id': 'folder1', 'kind': 'folder', 'name': 'folder1'}
+    aiohttpretty.register_json_uri('POST', url, params=params, status=201, body=body)
+
+    folder_meta, created = await src_mock.intra_copy(dest_mock, src_path, dest_path)
+    assert created == True
+    assert isinstance(folder_meta, OsfStorageFolderMetadata)
+    assert len(folder_meta.children) == 1
+    dest_mock._children_metadata.assert_called_once_with(WaterButlerPath('/folder1/'))
+    assert dest_mock.validate_v1_path.call_count == 1
+
+    src_mock._children_metadata.assert_not_called()
+    src_mock.validate_v1_path.assert_not_called()
+
+@pytest.mark.asyncio
+@pytest.mark.aiohttpretty
+async def test_intra_move_folder(provider_and_mock, provider_and_mock2,
+                                 children_response):
+    src_provider, src_mock = provider_and_mock
+    src_mock.intra_move = src_provider.intra_move
+
+    dest_provider, dest_mock = provider_and_mock2
+    dest_mock.nid = 'abcde'
+    dest_mock._children_metadata = utils.MockCoroutine(return_value=children_response)
+    dest_mock.validate_v1_path = utils.MockCoroutine(return_value=WaterButlerPath('/folder1/', _ids=('rootId', 'folder1')))
+
+    src_path = WaterButlerPath('/folder1/', _ids=['RootId', 'folder1'], folder=True)
+    dest_path = WaterButlerPath('/folder1/', _ids=['RootId', 'folder1'], folder=True)
+
+    data=json.dumps({
+        'user': src_provider.auth['id'],
+        'source': src_path.identifier,
+        'destination': {
+            'name': dest_path.name,
+            'node': dest_provider.nid,
+            'parent': dest_path.parent.identifier
+        }
+    })
+    url, _, params = src_provider.build_signed_url('POST',
+                                                   'https://waterbutler.io/hooks/move/',
+                                                   data=data)
+
+    body = {'path': '/folder1/', 'id': 'folder1', 'kind': 'folder', 'name': 'folder1'}
+    aiohttpretty.register_json_uri('POST', url, params=params, status=201, body=body)
+
+    folder_meta, created = await src_mock.intra_move(dest_mock, src_path, dest_path)
+    assert created == False
+    assert isinstance(folder_meta, OsfStorageFolderMetadata)
+    assert len(folder_meta.children) == 1
+    dest_mock._children_metadata.assert_called_once_with(WaterButlerPath('/folder1/'))
+    assert dest_mock.validate_v1_path.call_count == 1
+
+    src_mock._children_metadata.assert_not_called()
+    src_mock.validate_v1_path.assert_not_called()
 
 class TestValidatePath:
 

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -146,7 +146,9 @@ class OSFStorageProvider(provider.BaseProvider):
         return isinstance(other, self.__class__)
 
     async def intra_move(self, dest_provider, src_path, dest_path):
+        created = True
         if dest_path.identifier:
+            created = False
             await dest_provider.delete(dest_path)
 
         async with self.signed_request(
@@ -169,10 +171,16 @@ class OSFStorageProvider(provider.BaseProvider):
         if data['kind'] == 'file':
             return OsfStorageFileMetadata(data, str(dest_path)), dest_path.identifier is None
 
-        return OsfStorageFolderMetadata(data, str(dest_path)), dest_path.identifier is None
+        folder_meta = OsfStorageFolderMetadata(data, str(dest_path))
+        dest_path = await dest_provider.validate_v1_path(data['path'])
+        folder_meta.children = await dest_provider._children_metadata(dest_path)
+
+        return folder_meta, created
 
     async def intra_copy(self, dest_provider, src_path, dest_path):
+        created = True
         if dest_path.identifier:
+            created = False
             await dest_provider.delete(dest_path)
 
         async with self.signed_request(
@@ -195,7 +203,11 @@ class OSFStorageProvider(provider.BaseProvider):
         if data['kind'] == 'file':
             return OsfStorageFileMetadata(data, str(dest_path)), dest_path.identifier is None
 
-        return OsfStorageFolderMetadata(data, str(dest_path)), dest_path.identifier is None
+        folder_meta = OsfStorageFolderMetadata(data, str(dest_path))
+        dest_path = await dest_provider.validate_v1_path(data['path'])
+        folder_meta.children = await dest_provider._children_metadata(dest_path)
+
+        return folder_meta, created
 
     def build_signed_url(self, method, url, data=None, params=None, ttl=100, **kwargs):
         signer = signing.Signer(settings.HMAC_SECRET, settings.HMAC_ALGORITHM)


### PR DESCRIPTION
## Purpose:

[SVCS-229](https://openscience.atlassian.net/browse/SVCS-229)
WB API: OSFStorage intra_move/_copy does not return children

## Changes:

update  waterbutler/providers/osfstorage/provider.py
- def intra_move update to return children
- def intra_copy update to return children

## Side effects:

None

[#SVCS-229]