### PR TITLE
[SVCS-259] Files with conflicting hash maps return oldest modified date

### DIFF
--- a/tests/providers/osfstorage/test_provider.py
+++ b/tests/providers/osfstorage/test_provider.py
@@ -515,6 +515,20 @@ class TestUploads:
         inner_provider.move.return_value = (utils.MockFileMetadata(), True)
         inner_provider.metadata.side_effect = exceptions.MetadataError('Boom!', code=404)
 
+        signed_url, _, params = provider.build_signed_url('GET', provider.build_url(path.identifier, revision=''))
+
+        metadata_resp = {
+            'name': 'OtherTest',
+            'path': '/OtherTest',
+            'kind': 'file',
+            'version': 10,
+            'downloads': 1,
+            'md5': '1234',
+            'sha256': 'old_sha',
+        }
+
+        aiohttpretty.register_json_uri('GET', signed_url, params=params, status=200, body=metadata_resp)
+
         aiohttpretty.register_json_uri('POST', url, status=200, body={'data': {'downloads': 10, 'version': 8, 'path': '/24601', 'checkout': 'hmoco', 'md5': '1234', 'sha256': '2345'}})
 
         res, created = await provider.upload(file_stream, path)
@@ -538,6 +552,20 @@ class TestUploads:
         basepath = 'waterbutler.providers.osfstorage.provider.{}'
         path = WaterButlerPath('/foopath', _ids=('Test', 'OtherTest'))
         url = 'https://waterbutler.io/{}/children/'.format(path.parent.identifier)
+
+        signed_url, _, params = provider.build_signed_url('GET', provider.build_url(path.identifier, revision=''))
+
+        metadata_resp = {
+            'name': 'OtherTest',
+            'path': '/OtherTest',
+            'kind': 'file',
+            'version': 10,
+            'downloads': 1,
+            'md5': '1234',
+            'sha256': 'old_sha',
+        }
+
+        aiohttpretty.register_json_uri('GET', signed_url, params=params, status=200, body=metadata_resp)
 
         mock_parity = mock.Mock()
         mock_backup = mock.Mock()

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -3,6 +3,7 @@ import json
 import uuid
 import shutil
 import hashlib
+import datetime
 
 from waterbutler.core import utils
 from waterbutler.core import signing
@@ -335,6 +336,12 @@ class OSFStorageProvider(provider.BaseProvider):
 
         metadata = metadata.serialized()
 
+        old_sha = (await self.metadata(path)).raw['sha256']
+        if metadata['name'] != old_sha:
+            modified = datetime.datetime.now()
+            metadata['modified'] = modified.strftime('%a, %d %b %Y %H:%M:%S %z')
+            metadata['modified_utc'] = modified.isoformat()
+
         # Due to cross volume movement in unix we leverage shutil.move which properly handles this case.
         # http://bytes.com/topic/python/answers/41652-errno-18-invalid-cross-device-link-using-os-rename#post157964
         shutil.move(local_pending_path, local_complete_path)
@@ -387,7 +394,6 @@ class OSFStorageProvider(provider.BaseProvider):
             'path': data['data']['path'],
             'sha256': data['data']['sha256'],
             'version': data['data']['version'],
-            'modified': data['data'].get('modified'),
             'downloads': data['data']['downloads'],
             'checkout': data['data']['checkout'],
         })

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -337,11 +337,11 @@ class OSFStorageProvider(provider.BaseProvider):
         preupload_metadata = await self.exists(path)  # checks if revision
         if preupload_metadata:
             if preupload_metadata.raw['sha256'] == complete_name:  # upload with no changes
-                return OsfStorageFileMetadata(preupload_metadata, str(path)), False
+                return OsfStorageFileMetadata(preupload_metadata.raw, str(path)), False
             else:
-                modified = datetime.datetime.now()
-                metadata.modified = modified.strftime('%a, %d %b %Y %H:%M:%S %z')
-                metadata.modified_utc = modified.isoformat()
+                modified = datetime.datetime.now().replace(tzinfo=datetime.timezone.utc)
+                metadata.raw['modified'] = modified.strftime('%a, %d %b %Y %H:%M:%S %z')
+                metadata.raw['modified_utc'] = modified.isoformat()
 
         metadata = metadata.serialized()
 

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -375,6 +375,7 @@ class OSFStorageProvider(provider.BaseProvider):
             'path': data['data']['path'],
             'sha256': data['data']['sha256'],
             'version': data['data']['version'],
+            'modified': data['data']['modified'],
             'downloads': data['data']['downloads'],
             'checkout': data['data']['checkout'],
         })

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -375,7 +375,7 @@ class OSFStorageProvider(provider.BaseProvider):
             'path': data['data']['path'],
             'sha256': data['data']['sha256'],
             'version': data['data']['version'],
-            'modified': data['data']['modified'],
+            'modified': data['data'].get('modified'),
             'downloads': data['data']['downloads'],
             'checkout': data['data']['checkout'],
         })


### PR DESCRIPTION
## Purpose

Files with the same hashes all have the same dates. They have the date of the first that was uploaded.

## Changes

This problem was apparently caused by the fact that files with the same hash inherit a lot of the metadata for thier twin, much of the metadata is over-written with new metadata, but date modified is left out.

## Side Effects
This requires another PR in osf.io to be fully effective. 
https://github.com/CenterForOpenScience/osf.io/pull/6986

## Ticket
https://openscience.atlassian.net/browse/SVCS-259