### PR TITLE
[RFR] [SVCS-252] Update provider base path removal to be more strict.

### DIFF
--- a/tests/providers/dropbox/test_provider.py
+++ b/tests/providers/dropbox/test_provider.py
@@ -360,8 +360,14 @@ class TestCreateFolder:
 
 class TestOperations:
 
-    async def test_can_intra_copy(self, provider):
+    def test_can_intra_copy(self, provider):
         assert provider.can_intra_copy(provider)
 
-    async def test_can_intra_move(self, provider):
+    def test_can_intra_move(self, provider):
         assert provider.can_intra_move(provider)
+
+    def test_conflict_error_handler_not_found(self, provider, not_found_metadata_data):
+        error_path = '/Photos/folder/file'
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            provider.dropbox_conflict_error_handler(not_found_metadata_data, error_path=error_path)
+        assert str(exc.value).endswith(' /folder/file')

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -89,7 +89,10 @@ class DropboxProvider(provider.BaseProvider):
         :param str error_path: the path where the error occurred. Base folder will be stripped.
         """
 
-        error_path = '/{}'.format(error_path.lstrip(self.folder))
+        if error_path.startswith(self.folder):
+            error_path = error_path[len(self.folder):]
+        if not error_path.startswith('/'):
+            error_path = '/{}'.format(error_path)
 
         if 'error' in data:
             error_class = data['error']['.tag']


### PR DESCRIPTION
## Purpose:

[SVCS-252](https://openscience.atlassian.net/browse/SVCS-252)
Fix poor error handling in Dropbox provider.

## Changes:

update  waterbutler/providers/dropbox/provider.py
  Improve logic for provider base folder removal in def dropbox_conflict_error_handler

## Side effects:

None

[SVCS-252]
