### PR TITLE
[SVCS-273] Send better message for permissions and fix extensions dissambiguation agian

### DIFF
--- a/tests/providers/googledrive/fixtures.py
+++ b/tests/providers/googledrive/fixtures.py
@@ -220,7 +220,7 @@ docs_file_metadata = {
         'application/vnd.oasis.opendocument.text': 'https://docs.google.com/feeds/download/documents/export/Export?id=12go3hvnFZN5IuMWtz-2dft4EcPa5ti21pQYH1rjcxfQ&exportFormat=odt', 'text/html': 'https://docs.google.com/feeds/download/documents/export/Export?id=12go3hvnFZN5IuMWtz-2dft4EcPa5ti21pQYH1rjcxfQ&exportFormat=html', 'application/pdf': 'https://docs.google.com/feeds/download/documents/export/Export?id=12go3hvnFZN5IuMWtz-2dft4EcPa5ti21pQYH1rjcxfQ&exportFormat=pdf',
         'text/plain': 'https://docs.google.com/feeds/download/documents/export/Export?id=12go3hvnFZN5IuMWtz-2dft4EcPa5ti21pQYH1rjcxfQ&exportFormat=txt'
     },
-    'id': '12go3hvnFZN5IuMWtz-2dft4EcPa5ti21pQYH1rjcxfQ',
+    'id': '1GwpK7IozbO01RiyC5aPd66v7ShEViqggvT6ur5_pZMFo-ZzQHOgkyoU3ztjf0ytKt0HSdvUg6O2nmoYR',
     'modifiedDate': '2015-02-23T18:00:56.343Z',
     'etag': '"zWM2D6PBtLRQKuDNbaQNSNEy5BE/MTQyNDcxNDQ1NjM0Mw"',
     'ownerNames': ['Joshua Carp'],
@@ -311,7 +311,27 @@ revisions_list = {
     'etag': '"zWM2D6PBtLRQKuDNbaQNSNEy5BE/PeANBe5F3yk-YAzsoQO4pYPA5W8"',
     'selfLink': 'https://www.googleapis.com/drive/v2/files/1GwpK7IozbO01RiyC5aPd66v7ShEViqggvT6ur5_pZMFo-ZzQHOgkyoU3ztjf0ytKt0HSdvUg6O2nmoYR/revisions',
     'items': [
-        {'selfLink': 'https://www.googleapis.com/drive/v2/files/1GwpK7IozbO01RiyC5aPd66v7ShEViqggvT6ur5_pZMFo-ZzQHOgkyoU3ztjf0ytKt0HSdvUg6O2nmoYR/revisions/1DVR6FVQGOSpUrtHjxCKb4-2R0chGVJFG6wVPQwq1o-gay_tqwA', 'md5Checksum': '43c5a01efeaea6bfd0433fa516a0d71f', 'pinned': False, 'etag': '"zWM2D6PBtLRQKuDNbaQNSNEy5BE/sdQBhqMbZWHR5JnnXwR2jMjJYa4"', 'id': '1DVR6FVQGOSpUrtHjxCKb4-2R0chGVJFG6wVPQwq1o-gay_tqwA', 'kind': 'drive#revision', 'lastModifyingUserName': 'Joshua Carp', 'mimeType': 'application/pdf', 'fileSize': '918668', 'lastModifyingUser': {'kind': 'drive#user', 'emailAddress': 'jm.carp@gmail.com', 'permissionId': '07992110234966807597', 'picture': {'url': 'https://lh3.googleusercontent.com/-ndG-yHyqonM/AAAAAAAAAAI/AAAAAAAAADs/wUR8YhDe3vY/s64/photo.jpg'}, 'displayName': 'Joshua Carp', 'isAuthenticatedUser': True}, 'downloadUrl': 'https://doc-0g-5k-docs.googleusercontent.com/docs/securesc/6l6ti67c1gnej8b4rr55nfimce1282lr/nccdohm8rrrqmabek0d1ot5alel2768g/1424959200000/07992110234966807597/07992110234966807597/1GwpK7IozbO01RiyC5aPd66v7ShEViqggvT6ur5_pZMFo-ZzQHOgkyoU3ztjf0ytKt0HSdvUg6O2nmoYR?rid=1DVR6FVQGOSpUrtHjxCKb4-2R0chGVJFG6wVPQwq1o-gay_tqwA&e=download&gd=true', 'modifiedDate': '2015-01-01T16:54:58.929Z', 'published': False}
+        {'selfLink': 'https://www.googleapis.com/drive/v2/files/1GwpK7IozbO01RiyC5aPd66v7ShEViqggvT6ur5_pZMFo-ZzQHOgkyoU3ztjf0ytKt0HSdvUg6O2nmoYR/revisions/1DVR6FVQGOSpUrtHjxCKb4-2R0chGVJFG6wVPQwq1o-gay_tqwA',
+         'md5Checksum': '43c5a01efeaea6bfd0433fa516a0d71f', 'pinned': False, 'etag': '"zWM2D6PBtLRQKuDNbaQNSNEy5BE/sdQBhqMbZWHR5JnnXwR2jMjJYa4"',
+         'id': '1DVR6FVQGOSpUrtHjxCKb4-2R0chGVJFG6wVPQwq1o-gay_tqwA',
+         'kind': 'drive#revision',
+         'lastModifyingUserName': 'Joshua Carp',
+         'mimeType': 'application/pdf',
+         'fileSize': '918668',
+         'lastModifyingUser': {
+             'kind': 'drive#user',
+             'emailAddress': 'jm.carp@gmail.com',
+             'permissionId': '07992110234966807597',
+             'picture': {
+                 'url': 'https://lh3.googleusercontent.com/-ndG-yHyqonM/AAAAAAAAAAI/AAAAAAAAADs/wUR8YhDe3vY/s64/photo.jpg'
+             },
+             'displayName': 'Joshua Carp',
+             'isAuthenticatedUser': True
+         },
+         'downloadUrl': 'https://doc-0g-5k-docs.googleusercontent.com/docs/securesc/6l6ti67c1gnej8b4rr55nfimce1282lr/nccdohm8rrrqmabek0d1ot5alel2768g/1424959200000/07992110234966807597/07992110234966807597/1GwpK7IozbO01RiyC5aPd66v7ShEViqggvT6ur5_pZMFo-ZzQHOgkyoU3ztjf0ytKt0HSdvUg6O2nmoYR?rid=1DVR6FVQGOSpUrtHjxCKb4-2R0chGVJFG6wVPQwq1o-gay_tqwA&e=download&gd=true',
+         'modifiedDate': '2015-01-01T16:54:58.929Z',
+         'published': False
+         }
     ]
 }
 
@@ -321,3 +341,62 @@ revisions_list_empty = {
     'selfLink': 'https://www.googleapis.com/drive/v2/files/1GwpK7IozbO01RiyC5aPd66v7ShEViqggvT6ur5_pZMFo-ZzQHOgkyoU3ztjf0ytKt0HSdvUg6O2nmoYR/revisions',
     'items': []
 }
+
+folder_list = {
+     'etag': '"CHXJyqSTqQN6k2cni3iCrLmxCRE/nA8diRclF5h28_wXMjjcKYxo6h8"',
+     'incompleteSearch': False,
+     'items': [{'alternateLink': 'https://drive.google.com/drive/folders/0B1wCl2fPFhPoUHk2SzY0dnF3Nk0',
+                'appDataContents': False,
+                'capabilities': {'canCopy': False, 'canEdit': True},
+                'copyable': False,
+                'createdDate': '2017-02-10T15:50:46.914Z',
+                'editable': True,
+                'embedLink': 'https://drive.google.com/embeddedfolderview?id=0B1wCl2fPFhPoUHk2SzY0dnF3Nk0',
+                'etag': '"CHXJyqSTqQN6k2cni3iCrLmxCRE/MTQ4Njc0MTg0NjkxNA"',
+                'explicitlyTrashed': False,
+                'iconLink': 'https://ssl.gstatic.com/docs/doclist/images/icon_11_collection_list_1.png',
+                'id': '0B1wCl2fPFhPoUHk2SzY0dnF3Nk0',
+                'kind': 'drive#file',
+                'labels': {'hidden': False,
+                           'restricted': False,
+                           'starred': False,
+                           'trashed': False,
+                           'viewed': True},
+                'lastModifyingUser': {'displayName': 'John Tordoff',
+                                      'emailAddress': 'john@cos.io',
+                                      'isAuthenticatedUser': True,
+                                      'kind': 'drive#user',
+                                      'permissionId': '06821444256322263786'},
+                'lastModifyingUserName': 'John Tordoff',
+                'lastViewedByMeDate': '2017-03-23T16:06:07.621Z',
+                'markedViewedByMeDate': '1970-01-01T00:00:00.000Z',
+                'mimeType': 'application/vnd.google-apps.folder',
+                'modifiedByMeDate': '2017-02-10T15:50:46.914Z',
+                'modifiedDate': '2017-02-10T15:50:46.914Z',
+                'ownerNames': ['John Tordoff'],
+                'owners': [{'displayName': 'John Tordoff',
+                            'emailAddress': 'john@cos.io',
+                            'isAuthenticatedUser': True,
+                            'kind': 'drive#user',
+                            'permissionId': '06821444256322263786'}],
+                'parents': [{'id': '0AFwCl2fPFhPoUk9PVA',
+                             'isRoot': True,
+                             'kind': 'drive#parentReference',
+                             'parentLink': 'https://www.googleapis.com/drive/v2/files/0AFwCl2fPFhPoUk9PVA',
+                             'selfLink': 'https://www.googleapis.com/drive/v2/files/0B1wCl2fPFhPoUHk2SzY0dnF3Nk0/parents/0AFwCl2fPFhPoUk9PVA'}],
+                'quotaBytesUsed': '0',
+                'selfLink': 'https://www.googleapis.com/drive/v2/files/0B1wCl2fPFhPoUHk2SzY0dnF3Nk0',
+                'shared': False,
+                'spaces': ['drive'],
+                'title': 'foofolder',
+                'userPermission': {'etag': '"CHXJyqSTqQN6k2cni3iCrLmxCRE/cACbf6NA-UyyjWV7IqTIe3owkFo"',
+                                   'id': 'me',
+                                   'kind': 'drive#permission',
+                                   'role': 'owner',
+                                   'selfLink': 'https://www.googleapis.com/drive/v2/files/0B1wCl2fPFhPoUHk2SzY0dnF3Nk0/permissions/me',
+                                   'type': 'user'},
+                'version': '977',
+                'writersCanShare': True}],
+     'kind': 'drive#fileList',
+     'selfLink': "https://www.googleapis.com/drive/v2/files?q=title+%3D+'Test+Folder'+and+trashed+%3D+false+and+'0AFwCl2fPFhPoUk9PVA'+in+parents"
+    }

--- a/tests/providers/googledrive/test_provider.py
+++ b/tests/providers/googledrive/test_provider.py
@@ -85,6 +85,206 @@ def actual_file_response():
         'title': 'B.txt',
     }
 
+
+@pytest.fixture()
+def file_list_response():
+    return {
+        'etag': '"bcIyJ9A3gXa8oTYmz6nzAjQd-lY/H_ibMImWHz1GTl7M1HOk-ONcBqw"',
+        'incompleteSearch': False,
+        'items': [
+            {'alternateLink': 'https://drive.google.com/a/cos.io/file/d/0B1wCl2fPFhPoQjJGSXY3dkJLU2s/view?usp=drivesdk',
+          'appDataContents': False,
+          'capabilities': {'canCopy': True, 'canEdit': True},
+          'copyable': True,
+          'createdDate': '2017-03-14T17:46:57.339Z',
+          'downloadUrl': 'https://doc-00-80-docs.googleusercontent.com/docs/securesc/ntfg9vrht378qhlmjtincrgr21dums06/3gq29qpfc1n4jvs0v1ddvtetb3ecg0tm/1490299200000/06821444256322263786/06821444256322263786/0B1wCl2fPFhPoQjJGSXY3dkJLU2s?h=02276134969107310156&e=download&gd=true',
+          'editable': True,
+          'embedLink': 'https://drive.google.com/a/cos.io/file/d/0B1wCl2fPFhPoQjJGSXY3dkJLU2s/preview?usp=drivesdk',
+          'etag': '"bcIyJ9A3gXa8oTYmz6nzAjQd-lY/MTQ4OTUxMzYxNzMzOQ"',
+          'explicitlyTrashed': False,
+          'fileExtension': '',
+          'fileSize': '20',
+          'headRevisionId': '0B1wCl2fPFhPoWklXQndYUDRQbGx0SG9ablhtZG1xOGFZNDdzPQ',
+          'iconLink': 'https://ssl.gstatic.com/docs/doclist/images/icon_10_generic_list.png',
+          'id': '0B1wCl2fPFhPoQjJGSXY3dkJLU2s',
+          'kind': 'drive#file',
+          'labels': {'hidden': False,
+                     'restricted': False,
+                     'starred': False,
+                     'trashed': False,
+                     'viewed': True},
+          'lastModifyingUser': {'displayName': 'John Tordoff',
+                                'emailAddress': 'john@cos.io',
+                                'isAuthenticatedUser': True,
+                                'kind': 'drive#user',
+                                'permissionId': '06821444256322263786'},
+          'lastModifyingUserName': 'John Tordoff',
+          'lastViewedByMeDate': '2017-03-14T17:46:57.339Z',
+          'markedViewedByMeDate': '1970-01-01T00:00:00.000Z',
+          'md5Checksum': 'c5053cbd4ceb890f0c545a60300ad1b3',
+          'mimeType': 'application/octet-stream',
+          'modifiedByMeDate': '2017-03-14T17:46:57.339Z',
+          'modifiedDate': '2017-03-14T17:46:57.339Z',
+          'originalFilename': 'shared',
+          'ownerNames': ['John Tordoff'],
+          'owners': [{'displayName': 'John Tordoff',
+                      'emailAddress': 'john@cos.io',
+                      'isAuthenticatedUser': True,
+                      'kind': 'drive#user',
+                      'permissionId': '06821444256322263786'}],
+          'parents': [{'id': '0AFwCl2fPFhPoUk9PVA',
+                       'isRoot': True,
+                       'kind': 'drive#parentReference',
+                       'parentLink': 'https://www.googleapis.com/drive/v2/files/0AFwCl2fPFhPoUk9PVA',
+                       'selfLink': 'https://www.googleapis.com/drive/v2/files/0B1wCl2fPFhPoQjJGSXY3dkJLU2s/parents/0AFwCl2fPFhPoUk9PVA'}],
+          'quotaBytesUsed': '20',
+          'selfLink': 'https://www.googleapis.com/drive/v2/files/0B1wCl2fPFhPoQjJGSXY3dkJLU2s',
+          'shared': False,
+          'spaces': ['drive'],
+          'title': 'file',
+          'userPermission': {'etag': '"bcIyJ9A3gXa8oTYmz6nzAjQd-lY/5FTbiILWwdAJODZ_YAIoRfvzAZ8"',
+                             'id': 'me',
+                             'kind': 'drive#permission',
+                             'role': 'owner',
+                             'selfLink': 'https://www.googleapis.com/drive/v2/files/0B1wCl2fPFhPoQjJGSXY3dkJLU2s/permissions/me',
+                             'type': 'user'},
+          'version': '831',
+          'webContentLink': 'https://drive.google.com/a/cos.io/uc?id=0B1wCl2fPFhPoQjJGSXY3dkJLU2s&export=download',
+          'writersCanShare': True},
+        {
+             'alternateLink': 'https://docs.google.com/a/cos.io/spreadsheets/d/11SrZojQm7HFvEi4pD9_WSLg6LAv59QIuGg-Of1Q13fw/edit?usp=drivesdk',
+             'appDataContents': False,
+             'capabilities': {'canCopy': True, 'canEdit': True},
+             'copyable': True,
+             'createdDate': '2017-02-21T20:28:00.628Z',
+             'editable': True,
+             'embedLink': 'https://docs.google.com/a/cos.io/spreadsheets/d/11SrZojQm7HFvEi4pD9_WSLg6LAv59QIuGg-Of1Q13fw/htmlembed',
+             'etag': '"bcIyJ9A3gXa8oTYmz6nzAjQd-lY/MTQ4OTQyODA2OTAxMQ"',
+             'explicitlyTrashed': False,
+             'exportLinks': {
+                 'application/pdf': 'https://docs.google.com/spreadsheets/export?id=11SrZojQm7HFvEi4pD9_WSLg6LAv59QIuGg-Of1Q13fw&exportFormat=pdf',
+                 'application/vnd.oasis.opendocument.spreadsheet': 'https://docs.google.com/spreadsheets/export?id=11SrZojQm7HFvEi4pD9_WSLg6LAv59QIuGg-Of1Q13fw&exportFormat=ods',
+                 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'https://docs.google.com/spreadsheets/export?id=11SrZojQm7HFvEi4pD9_WSLg6LAv59QIuGg-Of1Q13fw&exportFormat=xlsx',
+                 'application/x-vnd.oasis.opendocument.spreadsheet': 'https://docs.google.com/spreadsheets/export?id=11SrZojQm7HFvEi4pD9_WSLg6LAv59QIuGg-Of1Q13fw&exportFormat=ods',
+                 'application/zip': 'https://docs.google.com/spreadsheets/export?id=11SrZojQm7HFvEi4pD9_WSLg6LAv59QIuGg-Of1Q13fw&exportFormat=zip',
+                 'text/csv': 'https://docs.google.com/spreadsheets/export?id=11SrZojQm7HFvEi4pD9_WSLg6LAv59QIuGg-Of1Q13fw&exportFormat=csv',
+                 'text/tab-separated-values': 'https://docs.google.com/spreadsheets/export?id=11SrZojQm7HFvEi4pD9_WSLg6LAv59QIuGg-Of1Q13fw&exportFormat=tsv'},
+             'iconLink': 'https://ssl.gstatic.com/docs/doclist/images/icon_11_spreadsheet_list.png',
+             'id': '11SrZojQm7HFvEi4pD9_WSLg6LAv59QIuGg-Of1Q13fw',
+             'kind': 'drive#file',
+             'labels': {'hidden': False,
+                        'restricted': False,
+                        'starred': False,
+                        'trashed': False,
+                        'viewed': True},
+             'lastModifyingUser': {'displayName': 'John Tordoff',
+                                   'emailAddress': 'john@cos.io',
+                                   'isAuthenticatedUser': True,
+                                   'kind': 'drive#user',
+                                   'permissionId': '06821444256322263786'},
+             'lastModifyingUserName': 'John Tordoff',
+             'lastViewedByMeDate': '2017-03-22T15:42:54.770Z',
+             'markedViewedByMeDate': '1970-01-01T00:00:00.000Z',
+             'mimeType': 'application/vnd.google-apps.spreadsheet',
+             'modifiedByMeDate': '2017-03-13T18:01:09.011Z',
+             'modifiedDate': '2017-03-13T18:01:09.011Z',
+             'ownerNames': ['John Tordoff'],
+             'owners': [{'displayName': 'John Tordoff',
+                         'emailAddress': 'john@cos.io',
+                         'isAuthenticatedUser': True,
+                         'kind': 'drive#user',
+                         'permissionId': '06821444256322263786'}],
+             'parents': [{'id': '0AFwCl2fPFhPoUk9PVA',
+                          'isRoot': True,
+                          'kind': 'drive#parentReference',
+                          'parentLink': 'https://www.googleapis.com/drive/v2/files/0AFwCl2fPFhPoUk9PVA',
+                          'selfLink': 'https://www.googleapis.com/drive/v2/files/11SrZojQm7HFvEi4pD9_WSLg6LAv59QIuGg-Of1Q13fw/parents/0AFwCl2fPFhPoUk9PVA'}],
+             'quotaBytesUsed': '0',
+             'selfLink': 'https://www.googleapis.com/drive/v2/files/11SrZojQm7HFvEi4pD9_WSLg6LAv59QIuGg-Of1Q13fw',
+             'shared': False,
+             'spaces': ['drive'],
+             'thumbnailLink': 'https://docs.google.com/a/cos.io/feeds/vt?gd=true&id=11SrZojQm7HFvEi4pD9_WSLg6LAv59QIuGg-Of1Q13fw&v=1&s=AMedNnoAAAAAWNRbOXwThWm_gwedVtYwsPryoa3V6NP7&sz=s220',
+             'title': 'file',
+             'userPermission': {'etag': '"bcIyJ9A3gXa8oTYmz6nzAjQd-lY/lfaNhy6x0-CZLEO2zDwMkBXIq3s"',
+                                'id': 'me',
+                                'kind': 'drive#permission',
+                                'role': 'owner',
+                                'selfLink': 'https://www.googleapis.com/drive/v2/files/11SrZojQm7HFvEi4pD9_WSLg6LAv59QIuGg-Of1Q13fw/permissions/me',
+                                'type': 'user'},
+             'version': '950',
+             'writersCanShare': True},
+            {
+            'alternateLink': 'https://docs.google.com/a/cos.io/document/d/1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I/edit?usp=drivesdk',
+            'appDataContents': False,
+            'capabilities': {'canCopy': True, 'canEdit': True},
+            'copyable': True,
+            'createdDate': '2017-02-28T15:34:51.550Z',
+            'editable': True,
+            'embedLink': 'https://docs.google.com/a/cos.io/document/d/1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I/preview',
+            'etag': '"bcIyJ9A3gXa8oTYmz6nzAjQd-lY/MTQ4ODI5NjEwMDAzOQ"',
+            'explicitlyTrashed': False,
+            'exportLinks': {
+                 'application/epub+zip': 'https://docs.google.com/feeds/download/documents/export/Export?id=1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I&exportFormat=epub',
+                 'application/pdf': 'https://docs.google.com/feeds/download/documents/export/Export?id=1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I&exportFormat=pdf',
+                 'application/rtf': 'https://docs.google.com/feeds/download/documents/export/Export?id=1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I&exportFormat=rtf',
+                 'application/vnd.oasis.opendocument.text': 'https://docs.google.com/feeds/download/documents/export/Export?id=1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I&exportFormat=odt',
+                 'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'https://docs.google.com/feeds/download/documents/export/Export?id=1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I&exportFormat=docx',
+                 'application/zip': 'https://docs.google.com/feeds/download/documents/export/Export?id=1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I&exportFormat=zip',
+                 'text/html': 'https://docs.google.com/feeds/download/documents/export/Export?id=1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I&exportFormat=html',
+                 'text/plain': 'https://docs.google.com/feeds/download/documents/export/Export?id=1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I&exportFormat=txt'},
+            'iconLink': 'https://ssl.gstatic.com/docs/doclist/images/icon_11_document_list.png',
+            'id': '1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I',
+            'kind': 'drive#file',
+            'labels': {'hidden': False,
+                        'restricted': False,
+                        'starred': False,
+                        'trashed': False,
+                        'viewed': True},
+            'lastModifyingUser': {'displayName': 'John Tordoff',
+                                   'emailAddress': 'john@cos.io',
+                                   'isAuthenticatedUser': True,
+                                   'kind': 'drive#user',
+                                   'permissionId': '06821444256322263786'},
+            'lastModifyingUserName': 'John Tordoff',
+            'lastViewedByMeDate': '2017-02-28T15:52:32.739Z',
+            'markedViewedByMeDate': '1970-01-01T00:00:00.000Z',
+            'mimeType': 'application/vnd.google-apps.document',
+            'modifiedByMeDate': '2017-02-28T15:35:00.039Z',
+            'modifiedDate': '2017-02-28T15:35:00.039Z',
+            'ownerNames': ['John Tordoff'],
+            'owners': [{'displayName': 'John Tordoff',
+                         'emailAddress': 'john@cos.io',
+                         'isAuthenticatedUser': True,
+                         'kind': 'drive#user',
+                         'permissionId': '06821444256322263786'}],
+            'parents': [{'id': '0AFwCl2fPFhPoUk9PVA',
+                          'isRoot': True,
+                          'kind': 'drive#parentReference',
+                          'parentLink': 'https://www.googleapis.com/drive/v2/files/0AFwCl2fPFhPoUk9PVA',
+                          'selfLink': 'https://www.googleapis.com/drive/v2/files/1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I/parents/0AFwCl2fPFhPoUk9PVA'}],
+            'quotaBytesUsed': '0',
+            'selfLink': 'https://www.googleapis.com/drive/v2/files/1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I',
+            'shared': False,
+            'spaces': ['drive'],
+            'thumbnailLink': 'https://docs.google.com/a/cos.io/feeds/vt?gd=true&id=1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I&v=3&s=AMedNnoAAAAAWNRbOWo7pI-Lg8-K3zdqkFzj_uvT2O4d&sz=s220',
+            'title': 'file',
+            'userPermission': {'etag': '"bcIyJ9A3gXa8oTYmz6nzAjQd-lY/__QBlvnh0XFmRhQvB-zDojUpMec"',
+                                'id': 'me',
+                                'kind': 'drive#permission',
+                                'role': 'owner',
+                                'selfLink': 'https://www.googleapis.com/drive/v2/files/1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I/permissions/me',
+                                'type': 'user'},
+            'version': '596',
+            'webContentLink': 'https://drive.google.com/a/cos.io/uc?id=1LY0Wls2MeMV5ETNcvYvttlxfCBQvJ_mCalSBt3xLY3I&export=download',
+            'writersCanShare': True
+            }
+        ],
+        'kind': 'drive#fileList',
+        'selfLink': "https://www.googleapis.com/drive/v2/files?q=title+%3D+'shared'+and+trashed+%3D+false+and+'0AFwCl2fPFhPoUk9PVA'+in+parents"
+    }
+
+
+
 @pytest.fixture
 def search_for_folder_response():
     return {
@@ -126,26 +326,13 @@ class TestValidatePath:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_validate_v1_path_file(self, provider, search_for_file_response,
-                                         actual_file_response, no_folder_response):
-        file_name = 'file.txt'
-        file_id = '1234ideclarethumbwar'
+    async def test_validate_v1_path_file(self, provider, file_list_response):
+        file_name = 'file'
 
-        query_url = provider.build_url(
-            'files', provider.folder['id'], 'children',
-            q=_build_title_search_query(provider, file_name, False),
-            fields='items(id)'
-        )
-        wrong_query_url = provider.build_url(
-            'files', provider.folder['id'], 'children',
-            q=_build_title_search_query(provider, file_name, True),
-            fields='items(id)'
-        )
-        specific_url = provider.build_url('files', file_id, fields='id,title,mimeType')
+        query_url = provider.build_url('files', q="title = '{}' and trashed = false "
+                                              "and '{}' in parents".format(file_name, provider.folder['id']))
 
-        aiohttpretty.register_json_uri('GET', query_url, body=search_for_file_response)
-        aiohttpretty.register_json_uri('GET', wrong_query_url, body=no_folder_response)
-        aiohttpretty.register_json_uri('GET', specific_url, body=actual_file_response)
+        aiohttpretty.register_json_uri('GET', query_url, body=file_list_response)
 
         try:
             wb_path_v1 = await provider.validate_v1_path('/' + file_name)
@@ -163,26 +350,14 @@ class TestValidatePath:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_validate_v1_path_folder(self, provider, search_for_folder_response,
-                                           actual_folder_response, no_file_response):
+    async def test_validate_v1_path_folder(self, provider, file_list_response, no_file_response):
         folder_name = 'foofolder'
-        folder_id = 'whyis6afraidof7'
 
-        query_url = provider.build_url(
-            'files', provider.folder['id'], 'children',
-            q=_build_title_search_query(provider, folder_name, True),
-            fields='items(id)'
-        )
-        wrong_query_url = provider.build_url(
-            'files', provider.folder['id'], 'children',
-            q=_build_title_search_query(provider, folder_name, False),
-            fields='items(id)'
-        )
-        specific_url = provider.build_url('files', folder_id, fields='id,title,mimeType')
+        query_url = provider.build_url('files', q="title = '{}' "
+                                              "and trashed = false "
+                                              "and '{}' in parents".format(folder_name, provider.folder['id']))
 
-        aiohttpretty.register_json_uri('GET', query_url, body=search_for_folder_response)
-        aiohttpretty.register_json_uri('GET', wrong_query_url, body=no_file_response)
-        aiohttpretty.register_json_uri('GET', specific_url, body=actual_folder_response)
+        aiohttpretty.register_json_uri('GET', query_url, body=fixtures.folder_list)
 
         try:
             wb_path_v1 = await provider.validate_v1_path('/' + folder_name + '/')
@@ -520,6 +695,9 @@ class TestRevisions:
 
         revisions_url = provider.build_url('files', item['id'], 'revisions')
         aiohttpretty.register_json_uri('GET', revisions_url, body=fixtures.revisions_list)
+
+        metadata_url = provider.build_url('files', item['id'])
+        aiohttpretty.register_json_uri('GET', metadata_url, body=fixtures.docs_file_metadata)
 
         result = await provider.revisions(path)
 

--- a/waterbutler/providers/googledrive/metadata.py
+++ b/waterbutler/providers/googledrive/metadata.py
@@ -18,6 +18,10 @@ class BaseGoogleDriveMetadata(metadata.BaseMetadata):
     def extra(self):
         return {'revisionId': self.raw['version']}
 
+    @property
+    def has_view_only_permission(self):
+        return self.raw['userPermission']['role'] in ('commenter', 'reader')
+
 
 class GoogleDriveFolderMetadata(BaseGoogleDriveMetadata, metadata.BaseFolderMetadata):
 

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -430,7 +430,12 @@ class GoogleDriveProvider(provider.BaseProvider):
                 results = data['items']
 
             if len(results) == 0:
-                raise exceptions.NotFoundError(str(path))
+                ret += [{
+                    'title': name_with_ext,
+                    'mimeType': '',
+                    'id': None
+                }]
+                return ret
             elif len(results) == 1:
                 item = results[0]
             else:

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -58,23 +58,24 @@ class GoogleDriveProvider(provider.BaseProvider):
     BASE_URL = settings.BASE_URL
     FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder'
 
+    async def validate_v1_path(self, path, **kwargs):
+
+        parts = await self._resolve_path_to_ids(path)
+
+        is_folder = parts[-1]['mimeType'] == self.FOLDER_MIME_TYPE
+
+        if is_folder and not path.endswith('/'):
+            raise exceptions.NotFoundError(str(path))
+        elif not is_folder and path.endswith('/'):
+            raise exceptions.NotFoundError(str(path))
+
+        ids = [x['id'] for x in parts]
+        return GoogleDrivePath(path, _ids=ids, folder=self.FOLDER_MIME_TYPE in parts[-1]['mimeType'])
+
     def __init__(self, auth, credentials, settings):
         super().__init__(auth, credentials, settings)
         self.token = self.credentials['token']
         self.folder = self.settings['folder']
-
-    async def validate_v1_path(self, path, **kwargs):
-        if path == '/':
-            return GoogleDrivePath('/', _ids=[self.folder['id']], folder=True)
-
-        implicit_folder = path.endswith('/')
-        parts = await self._resolve_path_to_ids(path)
-        explicit_folder = parts[-1]['mimeType'] == self.FOLDER_MIME_TYPE
-        if parts[-1]['id'] is None or implicit_folder != explicit_folder:
-            raise exceptions.NotFoundError(str(path))
-
-        names, ids = zip(*[(parse.quote(x['title'], safe=''), x['id']) for x in parts])
-        return GoogleDrivePath('/'.join(names), _ids=ids, folder='folder' in parts[-1]['mimeType'])
 
     async def validate_path(self, path, **kwargs):
         if path == '/':
@@ -82,7 +83,7 @@ class GoogleDriveProvider(provider.BaseProvider):
 
         parts = await self._resolve_path_to_ids(path)
         names, ids = zip(*[(parse.quote(x['title'], safe=''), x['id']) for x in parts])
-        return GoogleDrivePath('/'.join(names), _ids=ids, folder='folder' in parts[-1]['mimeType'])
+        return GoogleDrivePath('/'.join(names), _ids=ids, folder=self.FOLDER_MIME_TYPE in parts[-1]['mimeType'])
 
     async def revalidate_path(self, base, name, folder=None):
         # TODO Redo the logic here folders names ending in /s
@@ -97,11 +98,11 @@ class GoogleDriveProvider(provider.BaseProvider):
 
         parts = await self._resolve_path_to_ids(name, start_at=[{
             'title': base.name,
-            'mimeType': 'folder',
+            'mimeType': self.FOLDER_MIME_TYPE,
             'id': base.identifier,
         }])
         _id, name, mime = list(map(parts[-1].__getitem__, ('id', 'title', 'mimeType')))
-        return base.child(name, _id=_id, folder='folder' in mime)
+        return base.child(name, _id=_id, folder=self.FOLDER_MIME_TYPE in mime)
 
     def can_duplicate_names(self):
         return True
@@ -168,6 +169,10 @@ class GoogleDriveProvider(provider.BaseProvider):
         else:
             metadata = await self.metadata(path)
             self.metrics.add('download.got_supported_revision', False)
+
+        if metadata.has_view_only_permission:
+            raise exceptions.AuthError('You don\'t have permission to download this file through '
+                                       'the Open Science Framework', code=403)
 
         download_resp = await self.make_request(
             'GET',
@@ -265,6 +270,13 @@ class GoogleDriveProvider(provider.BaseProvider):
         if path.identifier is None:
             raise exceptions.NotFoundError(str(path))
 
+        print(self.build_url('files', path.identifier, 'revisions'))
+        metadata = await self.metadata(path)
+
+        if metadata.has_view_only_permission:
+            raise exceptions.AuthError('You don\'t have permission to download this file through '
+                                       'the Open Science Framework', code=403)
+
         async with self.request(
             'GET',
             self.build_url('files', path.identifier, 'revisions'),
@@ -278,11 +290,9 @@ class GoogleDriveProvider(provider.BaseProvider):
                 for item in reversed(data['items'])
             ]
 
-        metadata = await self.metadata(path, raw=True)
-
         # Use dummy ID if no revisions found
         return [GoogleDriveRevision({
-            'modifiedDate': metadata['modifiedDate'],
+            'modifiedDate': metadata.raw['modifiedDate'],
             'id': data['etag'] + settings.DRIVE_IGNORE_VERSION,
         })]
 
@@ -384,70 +394,52 @@ class GoogleDriveProvider(provider.BaseProvider):
     async def _resolve_path_to_ids(self, path, start_at=None):
         """Takes a path and traverses the file tree (ha!) beginning at ``start_at``, looking for
         something that matches ``path``.  Returns a list of dicts for each part of the path, with
-        ``title``, ``mimeType``, and ``id`` keys.
+        the file metadata.
+
+        GFiles can only be called without an extension, this causes a great degree of ambiguity as
+        to which files files are being called when multiple files of the same name can exist in
+        the same directory. This function makes sure in cases where a non-GFiles and a GFile have
+        the same name the non-GFile is called by the API (because you still retrieve the GFile
+        by including the extension, but not the Non-GFile which may not even have a recognized format.)
         """
         self.metrics.incr('called_resolve_path_to_ids')
-        ret = start_at or [{
-            'title': '',
-            'mimeType': 'folder',
-            'id': self.folder['id'],
-        }]
-        item_id = ret[0]['id']
-        # parts is list of [path_part_name, is_folder]
-        parts = [[parse.unquote(x), True] for x in path.strip('/').split('/')]
 
-        if not path.endswith('/'):
-            parts[-1][1] = False
-        while parts:
-            current_part = parts.pop(0)
-            part_name, part_is_folder = current_part[0], current_part[1]
-            name, ext = os.path.splitext(part_name)
-            if not part_is_folder and ext in ('.gdoc', '.gdraw', '.gslides', '.gsheet'):
-                gd_ext = drive_utils.get_mimetype_from_ext(ext)
-                query = "title = '{}' " \
-                        "and trashed = false " \
-                        "and mimeType = '{}'".format(clean_query(name), gd_ext)
-            else:
-                query = "title = '{}' " \
-                        "and trashed = false " \
-                        "and mimeType != 'application/vnd.google-apps.form' " \
-                        "and mimeType != 'application/vnd.google-apps.map' " \
-                        "and mimeType != 'application/vnd.google-apps.document' " \
-                        "and mimeType != 'application/vnd.google-apps.drawing' " \
-                        "and mimeType != 'application/vnd.google-apps.presentation' " \
-                        "and mimeType != 'application/vnd.google-apps.spreadsheet' " \
-                        "and mimeType {} '{}'".format(
-                            clean_query(part_name),
-                            '=' if part_is_folder else '!=',
-                            self.FOLDER_MIME_TYPE
-                        )
+        item_id = self.folder['id']
+        root = [{
+            'title': '',
+            'mimeType': self.FOLDER_MIME_TYPE,
+            'id': item_id,
+        }]
+        ret = start_at or root
+
+        parts = [parse.unquote(x) for x in path.strip('/').split('/') if x != '']
+
+        for name_with_ext in parts:
+            name_without_ext, ext = os.path.splitext(name_with_ext)
+            query_name = name_without_ext if drive_utils.ext_is_gfile(ext) else name_with_ext
+
             async with self.request(
-                'GET',
-                self.build_url('files', item_id, 'children', q=query, fields='items(id)'),
-                expects=(200, ),
-                throws=exceptions.MetadataError,
+                    'GET',
+                    self.build_url('files', q="title = '{}' "
+                                              "and trashed = false "
+                                              "and '{}' in parents".format(query_name, item_id)),
+                    expects=(200, ),
+                    throws=exceptions.MetadataError,
             ) as resp:
                 data = await resp.json()
+                results = data['items']
 
-            try:
-                item_id = data['items'][0]['id']
-            except (KeyError, IndexError):
-                if parts:
-                    # if we can't find an intermediate path part, that's an error
-                    raise exceptions.MetadataError('{} not found'.format(str(path)), code=http.client.NOT_FOUND)
-                return ret + [{
-                    'id': None,
-                    'title': part_name,
-                    'mimeType': 'folder' if part_is_folder else '',
-                }]
+            if len(results) == 0:
+                raise exceptions.NotFoundError(str(path))
+            elif len(results) == 1:
+                item = results[0]
+            else:
+                item = drive_utils.disambiguate_files(ext, results, path)
 
-            async with self.request(
-                'GET',
-                self.build_url('files', item_id, fields='id,title,mimeType'),
-                expects=(200, ),
-                throws=exceptions.MetadataError,
-            ) as resp:
-                ret.append(await resp.json())
+            item_id = item['id']
+
+            ret.append(item)
+
         return ret
 
     async def _resolve_id_to_parts(self, _id, accum=None):
@@ -455,7 +447,7 @@ class GoogleDriveProvider(provider.BaseProvider):
         if _id == self.folder['id']:
             return [{
                 'title': '',
-                'mimeType': 'folder',
+                'mimeType': self.FOLDER_MIME_TYPE,
                 'id': self.folder['id'],
             }] + (accum or [])
 

--- a/waterbutler/providers/googledrive/utils.py
+++ b/waterbutler/providers/googledrive/utils.py
@@ -1,3 +1,5 @@
+from waterbutler.core import exceptions
+
 DOCS_FORMATS = [
     {
         'mime_type': 'application/vnd.google-apps.document',
@@ -54,6 +56,16 @@ def get_extension(metadata):
     return format['ext']
 
 
+def get_ext_from_mime_type(mime_type):
+    for format in DOCS_FORMATS:
+        if format['mime_type'] == mime_type:
+            return format['ext']
+
+
+def ext_is_gfile(ext):
+    return ext in [x['ext'] for x in DOCS_FORMATS]
+
+
 def get_download_extension(metadata):
     format = get_format(metadata)
     return format['download_ext']
@@ -61,4 +73,31 @@ def get_download_extension(metadata):
 
 def get_export_link(metadata):
     format = get_format(metadata)
-    return metadata['exportLinks'][format['type']]
+    if metadata.get('exportLinks'):
+        return metadata['exportLinks'].get(format['type'])
+
+
+def disambiguate_files(ext, resp_items, path):
+    """
+    When calling for an extension-less file there are two cases:
+    1. It's a random file the user uploaded without an extension
+    2. It's a GFile that's hiding it's extension
+
+    We want the random file when possible, but we also have to disambiguate between GFiles and we
+    do that using mime type.
+
+    :param ext: The extension we are given as part of the path, for GFiles it should always be given.
+    :param resp_items: The json dicts returned from a GDrive query
+    :return: The item the user was looking for.
+    """
+
+    if ext_is_gfile(ext):
+        items = [x for x in resp_items if x['mimeType'] == get_mimetype_from_ext(ext)]
+    else:
+        # GFiles never include a 'fileExtension' field, but extension-less files have them as ''
+        items = [x for x in resp_items if x.get('fileExtension') == '']
+
+    if len(items) == 1:
+        return items[0]
+    else:
+        raise exceptions.NotFoundError(path)


### PR DESCRIPTION
## Purpose

When a user tries to render a file they only have view permissions for it can't find it because the user it's allowed to download it. This fix is meant to recognize that and send a better message...

But there's a big wrinkle 'view only' files don't always have extensions accessible like other GFiles, so there's a need to rewrite the code which disambiguate files with the same title. The result is pretty much a full rewrite of the resolve_path_to_id code, which has been cleaned up quite a bit.

## Changes

resolve_parts_to_ids has fundamentally changed so it uses few requests and receives all available metadata on each file. Added some documentation and tweaked some tests as well.

## Side Effects 

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/SVCS-273  