### PR TITLE
[SVCS-281] Address issues with CTRL characters in file names

### DIFF
--- a/tests/server/api/v1/test_create_mixin.py
+++ b/tests/server/api/v1/test_create_mixin.py
@@ -53,6 +53,15 @@ class TestValidatePut(BaseCreateMixinTest):
         assert e.value.code == client.LENGTH_REQUIRED
         assert e.value.message == 'Content-Length is required for file uploads'
 
+    def test_file_name_may_not_contain_ctrl_chars(self):
+        self.mixin.get_query_argument.return_value = 'tabby\tmctabface'
+
+        with pytest.raises(exceptions.InvalidParameters) as e:
+            self.mixin.prevalidate_put()
+
+        assert e.value.code == 400
+        assert e.value.message == 'File names may not contain CTRL characters.'
+
     def test_payload_with_folder(self):
         self.mixin.path = '/'
         self.mixin.request.headers = {'Content-Length': 5000}

--- a/waterbutler/server/api/v1/provider/create.py
+++ b/waterbutler/server/api/v1/provider/create.py
@@ -1,4 +1,5 @@
 from waterbutler.core import exceptions
+from waterbutler.server import settings
 
 
 class CreateMixin:
@@ -14,6 +15,11 @@ class CreateMixin:
         3. Ensure that content length is either not present or 0 for folder creation requests
         """
         self.kind = self.get_query_argument('kind', default='file')
+        self.arg_name = self.get_query_argument('name', default=None)
+        if self.arg_name:
+            if settings.INVALID_FILE_NAME_CHAR_RE.search(self.arg_name.encode('utf-8')):
+                raise exceptions.InvalidParameters('File names may not contain CTRL characters.',
+                                                   code=400)
 
         if self.kind not in ('file', 'folder'):
             raise exceptions.InvalidParameters('Kind must be file, folder or unspecified (interpreted as file), not {}'.format(self.kind))

--- a/waterbutler/server/api/v1/provider/metadata.py
+++ b/waterbutler/server/api/v1/provider/metadata.py
@@ -8,6 +8,7 @@ from dateutil.parser import parse as datetime_parser
 
 from waterbutler.core import mime_types
 from waterbutler.server import utils
+from waterbutler.server import settings
 
 
 # TODO split this into metadata.py and data.py
@@ -91,6 +92,7 @@ class MetadataMixin:
         # Build `Content-Disposition` header from `displayName` override,
         # headers of provider response, or file path, whichever is truthy first
         name = self.get_query_argument('displayName', default=None) or getattr(stream, 'name', None) or self.path.name
+        name = settings.INVALID_FILE_NAME_CHAR_RE.sub(b'', name.encode('utf-8')).decode('utf-8')
         self.set_header('Content-Disposition', utils.make_disposition(name))
 
         _, ext = os.path.splitext(name)

--- a/waterbutler/server/settings.py
+++ b/waterbutler/server/settings.py
@@ -1,3 +1,4 @@
+import re
 import hashlib
 
 from waterbutler import settings
@@ -30,3 +31,7 @@ HMAC_SECRET = config.get('HMAC_SECRET')
 if not settings.DEBUG:
     assert HMAC_SECRET, 'HMAC_SECRET must be specified when not in debug mode'
 HMAC_SECRET = (HMAC_SECRET or 'changeme').encode('utf-8')
+
+# Matches https://github.com/tornadoweb/tornado/blob/v4.4.2/tornado/web.py#L354
+# We should consider adding "Delete" x7f
+INVALID_FILE_NAME_CHAR_RE = re.compile(br"[\x00-\x1f]")


### PR DESCRIPTION
## Purpose:

[SVCS-281](https://openscience.atlassian.net/browse/SVCS-281)
Files with \t in name are unsafe and will 500 WB (and thus MFR)
## Changes:

update waterbutler/server/settings.py Add precompiled regex for ut8 bytestring ctrl characters
update waterbutler/server/api/v1/provider/metadata.py remove ctrl chars from file name in header
update waterbutler/server/api/v1/provider/create.py catch CTRL Chars in file name during prevalidate
update tests/server/api/v1/test_create_mixin.py add test

## Side effects:

Downloaded files with ctrl characters in there name will have them removed.

[#SVCS-281]
