### PR TITLE
[SVCS-137] stop passing query params as kwargs

### DIFF
--- a/waterbutler/server/api/v0/core.py
+++ b/waterbutler/server/api/v0/core.py
@@ -89,8 +89,8 @@ class BaseProviderHandler(BaseHandler):
             self.payload['settings'],
         )
 
-        self.path = await self.provider.validate_path(**self.arguments)
-        self.arguments['path'] = self.path  # TODO Not this
+        path = self.arguments['path']
+        self.path = await self.provider.validate_path(path, params=self.arguments)
 
     def _send_hook(self, action, metadata=None, path=None):
         source = LogPayload(self.arguments['nid'], self.provider, metadata=metadata, path=path)
@@ -112,8 +112,8 @@ class BaseCrossProviderHandler(BaseHandler):
         self.source_provider = await self.make_provider(prefix='from', **self.json['source'])
         self.destination_provider = await self.make_provider(prefix='to', **self.json['destination'])
 
-        self.json['source']['path'] = await self.source_provider.validate_path(**self.json['source'])
-        self.json['destination']['path'] = await self.destination_provider.validate_path(**self.json['destination'])
+        self.json['source']['path'] = await self.source_provider.validate_path(self.json['source']['path'])
+        self.json['destination']['path'] = await self.destination_provider.validate_path(self.json['destination']['path'])
 
     async def make_provider(self, provider, prefix='', **kwargs):
         payload = await auth_handler.fetch(

--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -62,7 +62,7 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
 
         self.auth = await auth_handler.get(self.resource, provider, self.request)
         self.provider = utils.make_provider(provider, self.auth['auth'], self.auth['credentials'], self.auth['settings'])
-        self.path = await self.provider.validate_v1_path(self.path, **self.arguments)
+        self.path = await self.provider.validate_v1_path(self.path, params=self.arguments)
 
         self.target_path = None
 


### PR DESCRIPTION
## Purpose

Stops Waterbutler from passing query params as kwargs, this prevents 500 when params (like 'path') overwrite real params.

## Changes 

Minor refactoring

## Side Effects 

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/SVCS-137

