### PR TITLE
[SVCS-294] Add rename validations

### DIFF
--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -78,6 +78,8 @@ class BaseProvider(metaclass=abc.ABCMeta):
     """
 
     BASE_URL = None
+    FORBIDDEN_FILENAME_CHARS = []
+    FORBIDDEN_FOLDERNAME_CHARS = ['/']
 
     def __init__(self, auth, credentials, settings, retry_on={408, 502, 503, 504}):
         """
@@ -373,6 +375,24 @@ class BaseProvider(metaclass=abc.ABCMeta):
         dest_path, _ = await self.handle_name_conflict(dest_path, conflict=conflict)
 
         return dest_path
+
+    def validate_rename(self, name, folder):
+        """Some providers don't allow files or folders to be renamed with slashes or special
+        characters this function weeds out those illegal names before we make the request
+        """
+        if not name:
+            raise exceptions.InvalidParameters('Rename parameter is required for renaming')
+
+        elif folder and any((char in self.FORBIDDEN_FOLDERNAME_CHARS) for char in name):
+            bad_chars = ', '.join([char for char in self.FORBIDDEN_FOLDERNAME_CHARS if char in name])
+            raise exceptions.InvalidParameters("New folder name contains forbidden character(s) {}".format(bad_chars))
+
+        elif not folder and any((char in self.FORBIDDEN_FILENAME_CHARS) for char in name):
+            bad_chars = ', '.join([char for char in self.FORBIDDEN_FILENAME_CHARS if char in name])
+            raise exceptions.InvalidParameters("New file name contains forbidden character(s) {}".format(bad_chars))
+
+        else:
+            return name
 
     def can_intra_copy(self, other, path=None):
         """Indicates if a quick copy can be performed between the current provider and `other`.

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -50,6 +50,7 @@ class DropboxProvider(provider.BaseProvider):
     """
     NAME = 'dropbox'
     BASE_URL = settings.BASE_URL
+    FORBIDDEN_FILENAME_CHARS = ['/']
 
     def __init__(self, auth, credentials, settings):
         super().__init__(auth, credentials, settings)


### PR DESCRIPTION
## Purpose

Currently you can rename a file or folder whatever you like, this creates a variety of error behaviors for the different providers. For Dropbox filenames with slashes create bad folders and files, for other providers the rename will just fail with no explanation, this fix alerts the user they are using an illegal character. 

## Changes

Add two static variables for the base provider FORBIDDEN_FILENAME_CHARS and FORBIDDEN_FOLDERNAME_CHARS which are used by validate_rename to bar the use of invalid characters. 

Also cleans up some superfluous code in movecopy.py

## Side Effects 

None that I know of.

## Tickets

https://openscience.atlassian.net/browse/SVCS-294