### PR TITLE
[SVCS-236] Fix broken revision handling for Github

### DIFF
--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -156,6 +156,94 @@ def create_folder_response():
         }
     }
 
+@pytest.fixture
+def comparision_metadata():
+    return {'ahead_by': 0,
+            'base_commit': {'author': {'avatar_url': 'https://avatars0.githubusercontent.com/u/9688518?v=3',
+                                'events_url': 'https://api.github.com/users/Johnetordoff/events{/privacy}',
+                                'followers_url': 'https://api.github.com/users/Johnetordoff/followers',
+                                'following_url': 'https://api.github.com/users/Johnetordoff/following{/other_user}',
+                                'gists_url': 'https://api.github.com/users/Johnetordoff/gists{/gist_id}',
+                                'gravatar_id': '',
+                                'html_url': 'https://github.com/Johnetordoff',
+                                'id': 9688518,
+                                'login': 'Johnetordoff',
+                                'organizations_url': 'https://api.github.com/users/Johnetordoff/orgs',
+                                'received_events_url': 'https://api.github.com/users/Johnetordoff/received_events',
+                                'repos_url': 'https://api.github.com/users/Johnetordoff/repos',
+                                'site_admin': False,
+                                'starred_url': 'https://api.github.com/users/Johnetordoff/starred{/owner}{/repo}',
+                                'subscriptions_url': 'https://api.github.com/users/Johnetordoff/subscriptions',
+                                'type': 'User',
+                                'url': 'https://api.github.com/users/Johnetordoff'},
+                     'comments_url': 'https://api.github.com/repos/Johnetordoff/git-hub-api-test/commits/b13aadfbe32408eea7d4e0eb0ffe7c6da78e3578/comments',
+                     'commit': {'author': {'date': '2017-05-02T19:00:19Z',
+                                           'email': 'Johnetordoff@users.noreply.github.com',
+                                           'name': 'John Tordoff'},
+                                'comment_count': 0,
+                                'committer': {'date': '2017-05-02T19:00:19Z',
+                                              'email': 'vscxw@osf.io',
+                                              'name': 'fake'},
+                                'message': 'File updated on behalf of WaterButler',
+                                'tree': {'sha': '48a98cf824b1ae6d64dc1216d6a3793ae6daf8a8',
+                                         'url': 'https://api.github.com/repos/Johnetordoff/git-hub-api-test/git/trees/48a98cf824b1ae6d64dc1216d6a3793ae6daf8a8'},
+                                'url': 'https://api.github.com/repos/Johnetordoff/git-hub-api-test/git/commits/b13aadfbe32408eea7d4e0eb0ffe7c6da78e3578'},
+                     'committer': None,
+                     'html_url': 'https://github.com/Johnetordoff/git-hub-api-test/commit/b13aadfbe32408eea7d4e0eb0ffe7c6da78e3578',
+                     'parents': [{
+                                     'html_url': 'https://github.com/Johnetordoff/git-hub-api-test/commit/a0f1708eef358227cb0bc1dbd29b604086e71a4e',
+                                     'sha': 'a0f1708eef358227cb0bc1dbd29b604086e71a4e',
+                                     'url': 'https://api.github.com/repos/Johnetordoff/git-hub-api-test/commits/a0f1708eef358227cb0bc1dbd29b604086e71a4e'}],
+                     'sha': 'b13aadfbe32408eea7d4e0eb0ffe7c6da78e3578',
+                     'url': 'https://api.github.com/repos/Johnetordoff/git-hub-api-test/commits/b13aadfbe32408eea7d4e0eb0ffe7c6da78e3578'},
+     'behind_by': 1,
+     'diff_url': 'https://github.com/Johnetordoff/git-hub-api-test/compare/master...a0f1708eef358227cb0bc1dbd29b604086e71a4e.diff',
+     'files': [],
+     'html_url': 'https://github.com/Johnetordoff/git-hub-api-test/compare/master...a0f1708eef358227cb0bc1dbd29b604086e71a4e',
+     'merge_base_commit': {'author': {'avatar_url': 'https://avatars0.githubusercontent.com/u/9688518?v=3',
+                                      'events_url': 'https://api.github.com/users/Johnetordoff/events{/privacy}',
+                                      'followers_url': 'https://api.github.com/users/Johnetordoff/followers',
+                                      'following_url': 'https://api.github.com/users/Johnetordoff/following{/other_user}',
+                                      'gists_url': 'https://api.github.com/users/Johnetordoff/gists{/gist_id}',
+                                      'gravatar_id': '',
+                                      'html_url': 'https://github.com/Johnetordoff',
+                                      'id': 9688518,
+                                      'login': 'Johnetordoff',
+                                      'organizations_url': 'https://api.github.com/users/Johnetordoff/orgs',
+                                      'received_events_url': 'https://api.github.com/users/Johnetordoff/received_events',
+                                      'repos_url': 'https://api.github.com/users/Johnetordoff/repos',
+                                      'site_admin': False,
+                                      'starred_url': 'https://api.github.com/users/Johnetordoff/starred{/owner}{/repo}',
+                                      'subscriptions_url': 'https://api.github.com/users/Johnetordoff/subscriptions',
+                                      'type': 'User',
+                                      'url': 'https://api.github.com/users/Johnetordoff'},
+                           'comments_url': 'https://api.github.com/repos/Johnetordoff/git-hub-api-test/commits/a0f1708eef358227cb0bc1dbd29b604086e71a4e/comments',
+                           'commit': {'author': {'date': '2017-05-02T18:44:45Z',
+                                                 'email': 'Johnetordoff@users.noreply.github.com',
+                                                 'name': 'John Tordoff'},
+                                      'comment_count': 0,
+                                      'committer': {'date': '2017-05-02T18:44:45Z',
+                                                    'email': 'vscxw@osf.io',
+                                                    'name': 'fake'},
+                                      'message': 'Moved on behalf of WaterButler',
+                                      'tree': {'sha': 'ed792c2c6dfc1947e19b2b5f3059385cd674b86f',
+                                               'url': 'https://api.github.com/repos/Johnetordoff/git-hub-api-test/git/trees/ed792c2c6dfc1947e19b2b5f3059385cd674b86f'},
+                                      'url': 'https://api.github.com/repos/Johnetordoff/git-hub-api-test/git/commits/a0f1708eef358227cb0bc1dbd29b604086e71a4e'},
+                           'committer': None,
+                           'html_url': 'https://github.com/Johnetordoff/git-hub-api-test/commit/a0f1708eef358227cb0bc1dbd29b604086e71a4e',
+                           'parents': [{
+                                           'html_url': 'https://github.com/Johnetordoff/git-hub-api-test/commit/e5e79a120fd6baa78289df7a3528216088d5a3db',
+                                           'sha': 'e5e79a120fd6baa78289df7a3528216088d5a3db',
+                                           'url': 'https://api.github.com/repos/Johnetordoff/git-hub-api-test/commits/e5e79a120fd6baa78289df7a3528216088d5a3db'}],
+                           'sha': 'a0f1708eef358227cb0bc1dbd29b604086e71a4e',
+                           'url': 'https://api.github.com/repos/Johnetordoff/git-hub-api-test/commits/a0f1708eef358227cb0bc1dbd29b604086e71a4e'},
+     'patch_url': 'https://github.com/Johnetordoff/git-hub-api-test/compare/master...a0f1708eef358227cb0bc1dbd29b604086e71a4e.patch',
+     'permalink_url': 'https://github.com/Johnetordoff/git-hub-api-test/compare/Johnetordoff:b13aadf...Johnetordoff:a0f1708',
+     'status': 'behind',
+     'total_commits': 0,
+     'url': 'https://api.github.com/repos/Johnetordoff/git-hub-api-test/compare/master...a0f1708eef358227cb0bc1dbd29b604086e71a4e'}
+
+
 
 @pytest.fixture
 def repo_metadata():
@@ -336,6 +424,16 @@ def branch_metadata():
         },
         'name': 'master'
     }
+
+@pytest.fixture
+def branch_list_metadata():
+    return [
+            {'commit': {
+                'sha': 'b13aadfbe32408eea7d4e0eb0ffe7c6da78e3578',
+                'url': 'https://api.github.com/repos/Johnetordoff/git-hub-api-test/commits/b13aadfbe32408eea7d4e0eb0ffe7c6da78e3578'},
+                'name': 'master'
+            }
+            ]
 
 @pytest.fixture
 def content_repo_metadata_root():
@@ -545,6 +643,39 @@ class TestValidatePath:
         assert exc.value.code == client.NOT_FOUND
 
         wb_path_v0 = await provider.validate_path('/' + tree_path + '/')
+
+        assert wb_path_v1 == wb_path_v0
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_validate_v1_path_revision(self, provider, branch_metadata, comparision_metadata, branch_list_metadata, repo_tree_metadata_root):
+
+        params = {'ref' : 'a0f1708eef358227cb0bc1dbd29b604086e71a4e'}
+
+        branch_url = provider.build_repo_url('branches', 'master')
+        branches_url = provider.build_repo_url('branches')
+        compare_url = provider.build_repo_url('compare', '{}...{}'.format('master', params['ref']))
+        tree_url = provider.build_repo_url('git', 'trees',
+                                       branch_metadata['commit']['commit']['tree']['sha'], recursive=1)
+
+        aiohttpretty.register_json_uri('GET', branches_url, body=branch_list_metadata)
+        aiohttpretty.register_json_uri('GET', branch_url, body=branch_metadata)
+        aiohttpretty.register_json_uri('GET', compare_url, body=comparision_metadata)
+        aiohttpretty.register_json_uri('GET', tree_url, body=repo_tree_metadata_root)
+
+        blob_path = 'file.txt'
+
+        try:
+            wb_path_v1 = await provider.validate_v1_path('/' + blob_path, **params)
+        except Exception as exc:
+            pytest.fail(str(exc))
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            await provider.validate_v1_path('/' + blob_path + '/')
+
+        assert exc.value.code == client.NOT_FOUND
+
+        wb_path_v0 = await provider.validate_path('/' + blob_path)
 
         assert wb_path_v1 == wb_path_v0
 

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -72,14 +72,61 @@ class GitHubProvider(provider.BaseProvider):
         self.repo = self.settings['repo']
         self.metrics.add('repo', {'repo': self.repo, 'owner': self.owner})
 
+    async def get_comparison(self, ref, ref2):
+        """
+        Compares two 'refs' (branch names or commits shas) and gives you lots of potentially useful
+        metadata about there relationship.
+
+        :param ref: a branch name or commit sha
+        :param ref2: a branch name or commit sha
+        :return dict: json metadata of the comparison.
+        """
+
+        resp = await self.make_request('GET', self.build_repo_url('compare', '{}...{}'.format(ref, ref2)))
+        return await resp.json()
+
+    async def _fetch_branch_from_commit_sha(self, commit_sha):
+        """
+        This will give you the metadata for the branch a particular commit is/was on.
+
+        :param commit_sha:
+        :return dict: this the json metadata for the branch the commit is/was on.
+        """
+
+        resp = await self.make_request('GET', self.build_repo_url('branches'))
+        branches = await resp.json()
+        for branch in branches:
+            comparison = await self.get_comparison(branch['name'], commit_sha)
+            if comparison['status'] in ('behind', 'identical'):
+                return branch
+
+        raise exceptions.NotFoundError(str(commit_sha))
+
     async def validate_v1_path(self, path, **kwargs):
+        """
+        There are two methods of path validation used here, one for paths with query params that
+        give branch name and one for commit shas or 'refs'. This is necessary because revisions
+        cannot be validated strictly by branch once a revision is made the old tree is unstuck from
+        the branch and cannot be found by iterating through every tree in the current branch
+        because the old data isn't connected to the branch anymore, it only exsists in some prior
+        commit. So to validate revisions we compare the commit sha to all the branches in the repo,
+        if it's status is 'behind' on a branch that's where it's a revision, we then make sure the path
+        still exists in the current tree and which gives us all the infomation we need for a fully
+        validated path.
+
+        :param path: The path given to be validated
+        :param kwargs: query params give in the url
+        :return:
+        """
         if not getattr(self, '_repo', None):
             self._repo = await self._fetch_repo()
             self.default_branch = self._repo['default_branch']
 
-        branch_ref, ref_from = None, None
+        if isinstance(kwargs.get('ref'), list) or isinstance(kwargs.get('branch'), list):
+            raise exceptions.InvalidParameters('Only one ref or branch may be given.')
+
         if kwargs.get('ref'):
-            branch_ref = kwargs.get('ref')
+            branch_ref = (await self._fetch_branch_from_commit_sha(kwargs.get('ref')))['name']
             ref_from = 'query_ref'
         elif kwargs.get('branch'):
             branch_ref = kwargs.get('branch')
@@ -87,8 +134,6 @@ class GitHubProvider(provider.BaseProvider):
         else:
             branch_ref = self.default_branch
             ref_from = 'default_branch'
-        if isinstance(branch_ref, list):
-            raise exceptions.InvalidParameters('Only one ref or branch may be given.')
         self.metrics.add('branch_ref_from', ref_from)
 
         if path == '/':

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -72,7 +72,7 @@ class GitHubProvider(provider.BaseProvider):
         self.repo = self.settings['repo']
         self.metrics.add('repo', {'repo': self.repo, 'owner': self.owner})
 
-    async def get_comparison(self, ref, ref2):
+    async def _get_comparison(self, ref, ref2):
         """
         Compares two 'refs' (branch names or commits shas) and gives you lots of potentially useful
         metadata about there relationship.
@@ -96,7 +96,7 @@ class GitHubProvider(provider.BaseProvider):
         resp = await self.make_request('GET', self.build_repo_url('branches'))
         branches = await resp.json()
         for branch in branches:
-            comparison = await self.get_comparison(branch['name'], commit_sha)
+            comparison = await self._get_comparison(branch['name'], commit_sha)
             if comparison['status'] in ('behind', 'identical'):
                 return branch
 


### PR DESCRIPTION
# Purpose 

Stop the 404s that occur when attempting to view Github revisions.

# Changes

Uses Github's comparison API endpoint to tell on what branch a commit sha originated that gives us enough data to validation that path of the revision still exists in the branch's tree. 

# Side Effects

None that I know of.

# Ticket / Related PRs

https://openscience.atlassian.net/browse/SVCS-236
#193 
#190 
