### PR TITLE
[SVCS-327][SVCS-292] Make Box give folder children’s metadata on moves and copies

### DIFF
--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -446,10 +446,13 @@ class BoxProvider(provider.BaseProvider):
 
     def _serialize_item(self, item, path):
         if item['type'] == 'folder':
-            serializer = BoxFolderMetadata
+            serialized_folder = BoxFolderMetadata(item, path)
+            if item.get('item_collection'):
+                serialized_folder._children = [self._serialize_item(item, path.child(item['name']))
+                                               for item in item['item_collection']['entries']]
+            return serialized_folder
         else:
-            serializer = BoxFileMetadata
-        return serializer(item, path)
+            return BoxFileMetadata(item, path)
 
     def _build_upload_url(self, *segments, **query):
         return provider.build_url(settings.BASE_UPLOAD_URL, *segments, **query)


### PR DESCRIPTION
# Purpose

On inter/intra moves/copies Box doesn't return the folder's children, this fixes that.

# Changes

Changes item serializer to include children to metadata.

# Side Effects

None that I know of.

# Ticket

https://openscience.atlassian.net/browse/SVCS-292