### PR TITLE
[SVCS-259] Sends correct UTC date modified in to fangorn after upload 

### DIFF
--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -390,6 +390,7 @@ class OSFStorageProvider(provider.BaseProvider):
             'downloads': data['data']['downloads'],
             'checkout': data['data']['checkout'],
             'modified': data['data']['modified'],
+            'modified_utc': utils.normalize_datetime(data['data']['modified']),
         })
 
         path._parts[-1]._id = metadata['path'].strip('/')


### PR DESCRIPTION
## Purpose 

Currently metadata sent back in a response to fangorn after an upload reflects the date modified coming from the file system, not the actual revision metadata from osfstorage.

## Changes 

Updates metadata to return correct info in the response.

## Side Effects 

None that I know of.

## Tickets/ Related PRs
https://openscience.atlassian.net/browse/SVCS-259
https://github.com/CenterForOpenScience/osf.io/pull/7155
https://github.com/CenterForOpenScience/waterbutler/pull/215