### PR TITLE
[proposal] Support use of coveralls.io for repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,6 @@ before_cache:
 
 notifications:
   flowdock: 9f8a6baf3feafdb62e515718698d06d0
+
+after_success:
+  coveralls

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Documentation Status](https://readthedocs.org/projects/waterbutler/badge/?version=latest)](http://waterbutler.readthedocs.org/en/latest/?badge=latest)
 [![Code Climate](https://codeclimate.com/github/CenterForOpenScience/waterbutler/badges/gpa.svg)](https://codeclimate.com/github/CenterForOpenScience/waterbutler)
+[![Coverage Status](https://coveralls.io/repos/github/CenterForOpenScience/waterbutler/badge.svg)](https://coveralls.io/github/CenterForOpenScience/waterbutler)
 
 `master` Build Status: [![Build Status](https://travis-ci.org/CenterForOpenScience/waterbutler.svg?branch=master)](https://travis-ci.org/CenterForOpenScience/waterbutler)
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,4 +10,5 @@ pyflakes
 pytest==2.8.2
 pytest-asyncio==0.3.0
 pytest-cov==2.2.0
+python-coveralls
 redis

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@
 [flake8]
 ignore = E501,E731,E127,E128
 max-line-length = 100
-exclude = .ropeproject,tests/*,src/*
+exclude = .ropeproject,tests/*,src/*,env, venv


### PR DESCRIPTION
# Purpose
Encourage higher unit test coverage by supporting a badging/reporting service to make code coverage metrics more visible to developers.

Specifically, this activates `coveralls.io`, a service that COS has also used for projects such as `ember-osf`.

Here is a sample report that was run against my own personal WB repo. It lets you see code coverage per file, including identifying untested branches of code:
https://coveralls.io/builds/11568940

# Future improvements
This does not modify the existing reporting scheme, only the way in which those reports are surfaced to developers during the review / development process. Once we have experimented with these reports we may wish to change how or what is measured.

# Deployment notes
This requires turning something on at `coveralls.io`, which must be done by someone with write access to the repo, separate from merging this code.

