### PR TITLE
Add type annotations and mypy compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ env/
 dist/
 build/
 .cache
+.mypy_cache

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,6 +5,7 @@ colorlog==2.5.0
 flake8==3.0.4
 ipdb
 ipython
+mypy==0.511
 pydevd==0.0.6
 pyflakes
 pytest==2.8.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,11 @@
 ignore = E501,E731,E127,E128
 max-line-length = 100
 exclude = .ropeproject,tests/*,src/*
+
+[mypy]
+# These default options are aimed at a newly converted codebase. See:
+#   http://mypy.readthedocs.io/en/latest/command_line.html#ignore-missing-imports
+python_version = 3.5
+follow_imports = silent
+ignore_missing_imports = true
+incremental = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@
 [flake8]
 ignore = E501,E731,E127,E128
 max-line-length = 100
-exclude = .ropeproject,tests/*,src/*
+exclude = .ropeproject,tests/*,src/*,env/,venv/
 
 [mypy]
 # These default options are aimed at a newly converted codebase. See:

--- a/tasks.py
+++ b/tasks.py
@@ -54,7 +54,7 @@ def mypy(ctx):
     These default options are aimed at a newly converted codebase. See:
       http://mypy.readthedocs.io/en/latest/command_line.html#ignore-missing-imports
     """
-    ctx.run('mypy -i --follow-imports silent --ignore-missing-imports waterbutler/', pty=True)
+    ctx.run('mypy -i --follow-imports silent --ignore-missing-imports --python-version 3.5 waterbutler/', pty=True)
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -48,8 +48,21 @@ def flake(ctx):
 
 
 @task
-def test(ctx, verbose=False):
+def mypy(ctx):
+    """
+    Check python types using mypy (additional level of linting)
+    These default options are aimed at a newly converted codebase. See:
+      http://mypy.readthedocs.io/en/latest/command_line.html#ignore-missing-imports
+    """
+    ctx.run('mypy -i --follow-imports silent --ignore-missing-imports waterbutler/', pty=True)
+
+
+@task
+def test(ctx, verbose=False, types=False):
     flake(ctx)
+    if types:
+        mypy(ctx)
+
     cmd = 'py.test --cov-report term-missing --cov waterbutler tests'
     if verbose:
         cmd += ' -v'

--- a/tasks.py
+++ b/tasks.py
@@ -44,17 +44,18 @@ def install(ctx, develop=False, pty=True):
 
 @task
 def flake(ctx):
+    """
+    Run style and syntax checker. Follows options defined in setup.cfg
+    """
     ctx.run('flake8 .', pty=True)
 
 
 @task
 def mypy(ctx):
     """
-    Check python types using mypy (additional level of linting)
-    These default options are aimed at a newly converted codebase. See:
-      http://mypy.readthedocs.io/en/latest/command_line.html#ignore-missing-imports
+    Check python types using mypy (additional level of linting). Follows options defined in setup.cfg
     """
-    ctx.run('mypy -i --follow-imports silent --ignore-missing-imports --python-version 3.5 waterbutler/', pty=True)
+    ctx.run('mypy waterbutler/', pty=True)
 
 
 @task

--- a/waterbutler/core/metadata.py
+++ b/waterbutler/core/metadata.py
@@ -1,5 +1,6 @@
 import abc
 import hashlib
+import typing
 
 import furl
 
@@ -26,10 +27,10 @@ class BaseMetadata(metaclass=abc.ABCMeta):
         }
     """
 
-    def __init__(self, raw):
+    def __init__(self, raw: dict) -> None:
         self.raw = raw
 
-    def serialized(self):
+    def serialized(self) -> dict:
         """Returns a dict of primitives suitable for serializing into JSON.
 
         .. note::
@@ -48,7 +49,7 @@ class BaseMetadata(metaclass=abc.ABCMeta):
             'etag': hashlib.sha256('{}::{}'.format(self.provider, self.etag).encode('utf-8')).hexdigest(),
         }
 
-    def json_api_serialized(self, resource):
+    def json_api_serialized(self, resource: str) -> dict:
         """Returns a dict of primitives suitable for serializing into a JSON-API -compliant
         response.  Sets the `id` and `type` attributes required by JSON-API, and stores the
         metadata under the `attributes` key.  A `links` object provides a dict of actions and the
@@ -66,10 +67,11 @@ class BaseMetadata(metaclass=abc.ABCMeta):
             'attributes': self.serialized(),
             'links': self._json_api_links(resource),
         }
-        json_api['attributes']['resource'] = resource
+        # Typing: skip "unsupported target for indexed assignment" errors for nested dict from method
+        json_api['attributes']['resource'] = resource  # type: ignore
         return json_api
 
-    def _json_api_links(self, resource):
+    def _json_api_links(self, resource: str) -> dict:
         """ Returns a dict of action names and the endpoints where those actions are performed.
 
         :rtype: dict
@@ -83,7 +85,7 @@ class BaseMetadata(metaclass=abc.ABCMeta):
 
         return actions
 
-    def _entity_url(self, resource):
+    def _entity_url(self, resource: str) -> str:
         """ Utility method for constructing the base url for actions. """
         url = furl.furl(settings.DOMAIN)
         segments = ['v1', 'resources', resource, 'providers', self.provider]
@@ -96,7 +98,7 @@ class BaseMetadata(metaclass=abc.ABCMeta):
 
         return url.url
 
-    def build_path(self, path):
+    def build_path(self, path) -> str:
         if not path.startswith('/'):
             path = '/' + path
         if self.kind == 'folder' and not path.endswith('/'):
@@ -104,7 +106,7 @@ class BaseMetadata(metaclass=abc.ABCMeta):
         return path
 
     @property
-    def is_folder(self):
+    def is_folder(self) -> bool:
         """ Does this object describe a folder?
 
         :rtype: bool
@@ -112,25 +114,28 @@ class BaseMetadata(metaclass=abc.ABCMeta):
         return self.kind == 'folder'
 
     @property
-    def is_file(self):
+    def is_file(self) -> bool:
         """ Does this object describe a file?
 
         :rtype: bool
         """
         return self.kind == 'file'
 
-    @abc.abstractproperty
-    def provider(self):
+    @property
+    @abc.abstractmethod
+    def provider(self) -> str:
         """ The provider from which this resource originated. """
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def kind(self):
+    @property
+    @abc.abstractmethod
+    def kind(self) -> str:
         """ `file` or `folder` """
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def name(self):
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
         """ The user-facing name of the entity, excluding parent folder(s).
         ::
 
@@ -139,8 +144,9 @@ class BaseMetadata(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def path(self):
+    @property
+    @abc.abstractmethod
+    def path(self) -> str:
         """ The canonical string representation of a waterbutler file or folder.  For providers
         that track entities with unique IDs, this will be the ID.  For providers that do not, this
         will usually be the full unix-style path of the file or folder.
@@ -154,7 +160,11 @@ class BaseMetadata(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @property
-    def materialized_path(self):
+    def etag(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def materialized_path(self) -> str:
         """ The unix-style path of the file relative the the root of the provider.  Encoded
         entities should be decoded.
 
@@ -177,7 +187,7 @@ class BaseMetadata(metaclass=abc.ABCMeta):
         return self.path
 
     @property
-    def extra(self):
+    def extra(self) -> dict:
         """A dict of optional metdata from the provider.  Non-mandatory metadata should be stored
         in this property.
 
@@ -187,17 +197,17 @@ class BaseMetadata(metaclass=abc.ABCMeta):
         """
         return {}
 
-    def __eq__(self, other):
+    def __eq__(self, other: 'BaseMetadata') -> bool:  # type: ignore
         return isinstance(other, self.__class__) and self.serialized() == other.serialized()
 
 
 class BaseFileMetadata(BaseMetadata):
     """ The base class for WaterButler metadata objects for files.  In addition to the properties
     required by `BaseMetadata`, `BaseFileMetadata` requires the consumer to implement the
-    `content_type`, `modified`, and `size` properties.  The `etag` may be added, but defaults to `None`.
+    `content_type`, `modified`, and `size` properties.  The `etag` may be added in a subclass.
     """
 
-    def serialized(self):
+    def serialized(self) -> dict:
         """ Returns a dict representing the file's metadata suitable to be serialized into JSON.
 
         :rtype: dict
@@ -210,7 +220,7 @@ class BaseFileMetadata(BaseMetadata):
             'size': self.size,
         })
 
-    def _json_api_links(self, resource):
+    def _json_api_links(self, resource: str) -> dict:
         """ Adds the `download` link to the JSON-API repsonse `links` field.
 
         :rtype: dict
@@ -220,50 +230,48 @@ class BaseFileMetadata(BaseMetadata):
         return ret
 
     @property
-    def kind(self):
+    def kind(self) -> str:
         """ File objects have `kind == 'file'` """
         return 'file'
 
-    @abc.abstractproperty
-    def content_type(self):
+    @property
+    @abc.abstractmethod
+    def content_type(self) -> str:
         """ MIME-type of the file (if available) """
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def modified(self):
+    @property
+    @abc.abstractmethod
+    def modified(self) -> str:
         """ Date the file was last modified, as reported by the provider, in
         the format used by the provider. """
         raise NotImplementedError
 
     @property
-    def modified_utc(self):
+    def modified_utc(self) -> str:
         """ Date the file was last modified, as reported by the provider,
         converted to UTC, in format (YYYY-MM-DDTHH:MM:SS+00:00). """
         return utils.normalize_datetime(self.modified)
 
     @property
-    def created_utc(self):
+    def created_utc(self) -> str:
         """ Date the file was created, as reported by the provider,
         converted to UTC, in format (YYYY-MM-DDTHH:MM:SS+00:00). """
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def size(self):
-        """ Size of the file in bytes. """
-        raise NotImplementedError
-
     @property
-    def etag(self):
-        """ FIXME: An etag? """
+    @abc.abstractmethod
+    def size(self) -> int:
+        """ Size of the file in bytes. """
         raise NotImplementedError
 
 
 class BaseFileRevisionMetadata(metaclass=abc.ABCMeta):
 
-    def __init__(self, raw):
+    def __init__(self, raw: dict) -> None:
         self.raw = raw
 
-    def serialized(self):
+    def serialized(self) -> dict:
         return {
             'extra': self.extra,
             'version': self.version,
@@ -272,7 +280,7 @@ class BaseFileRevisionMetadata(metaclass=abc.ABCMeta):
             'versionIdentifier': self.version_identifier,
         }
 
-    def json_api_serialized(self):
+    def json_api_serialized(self) -> dict:
         """The JSON API serialization of revision metadata from WaterButler.
 
         .. note::
@@ -285,29 +293,32 @@ class BaseFileRevisionMetadata(metaclass=abc.ABCMeta):
             'attributes': self.serialized(),
         }
 
-    @abc.abstractproperty
-    def modified(self):
+    @property
+    @abc.abstractmethod
+    def modified(self) -> str:
         raise NotImplementedError
 
     @property
-    def modified_utc(self):
+    def modified_utc(self) -> str:
         """ Date the revision was last modified, as reported by the provider,
         converted to UTC, in format (YYYY-MM-DDTHH:MM:SS+00:00). """
         return utils.normalize_datetime(self.modified)
 
-    @abc.abstractproperty
-    def version(self):
-        raise NotImplementedError
-
-    @abc.abstractproperty
-    def version_identifier(self):
+    @property
+    @abc.abstractmethod
+    def version(self) -> str:
         raise NotImplementedError
 
     @property
-    def extra(self):
+    @abc.abstractmethod
+    def version_identifier(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def extra(self) -> dict:
         return {}
 
-    def __eq__(self, other):
+    def __eq__(self, other: 'BaseFileRevisionMetadata') -> bool:  # type: ignore
         return isinstance(other, self.__class__) and self.serialized() == other.serialized()
 
 
@@ -319,11 +330,11 @@ class BaseFolderMetadata(BaseMetadata):
     children, which should be a list of file metadata objects that inherit from `BaseFileMetadata`.
     """
 
-    def __init__(self, raw):
+    def __init__(self, raw: dict) -> None:
         super().__init__(raw)
-        self._children = None
+        self._children = None  # type: list
 
-    def serialized(self):
+    def serialized(self) -> dict:
         """ Returns a dict representing the folder's metadata suitable to be serialized
         into JSON. If the `children` property has not been set, it will be excluded from
         the dict.
@@ -335,7 +346,7 @@ class BaseFolderMetadata(BaseMetadata):
             ret['children'] = [c.serialized() for c in self.children]
         return ret
 
-    def json_api_serialized(self, resource):
+    def json_api_serialized(self, resource: str) -> dict:
         """ Return a JSON-API compliant serializable dict, suitable for the WB v1 API.  Sets the
         `size` attribute to `None`, as folders do no have a size.
 
@@ -345,7 +356,7 @@ class BaseFolderMetadata(BaseMetadata):
         ret['attributes']['size'] = None
         return ret
 
-    def _json_api_links(self, resource):
+    def _json_api_links(self, resource: str) -> dict:
         """ Adds the `new_folder` link to the JSON-API repsonse `links` field.
 
         :rtype: dict
@@ -355,16 +366,16 @@ class BaseFolderMetadata(BaseMetadata):
         return ret
 
     @property
-    def children(self):
+    def children(self) -> typing.List[BaseMetadata]:
         """ (Optional) A list of child entities of the folder.  Each entity should be either a
         file or folder metadata object.  Will be `None` if the presence of children is unknown.
 
-        :rtype: None or list of Metdata objects
+        :rtype: None or list of Metadata objects
         """
         return self._children
 
     @children.setter
-    def children(self, kids):
+    def children(self, kids: typing.List[BaseMetadata]):
         """ Assigns the given list to the children property.  The affirmative absence of child
         entities should be indicated by passing an empty list.
 
@@ -373,11 +384,11 @@ class BaseFolderMetadata(BaseMetadata):
         self._children = kids
 
     @property
-    def kind(self):
+    def kind(self) -> str:
         """ Folder metadata objects have `kind == 'folder'` """
         return 'folder'
 
     @property
-    def etag(self):
+    def etag(self) -> typing.Union[str, None]:
         """ FIXME: An etag? """
         return None

--- a/waterbutler/core/path.py
+++ b/waterbutler/core/path.py
@@ -1,6 +1,8 @@
-import os
 import itertools
-from waterbutler.core import exceptions
+import os
+import typing  # noqa
+
+from waterbutler.core import exceptions, metadata
 
 
 class WaterButlerPathPart:
@@ -14,10 +16,10 @@ class WaterButlerPathPart:
     path.
     """
 
-    DECODE = lambda x: x
-    ENCODE = lambda x: x
+    DECODE = lambda x: x  # type: typing.Callable[str]
+    ENCODE = lambda x: x  # type: typing.Callable[str]
 
-    def __init__(self, part, _id=None):
+    def __init__(self, part: str, *, _id=None):
         self._id = _id
         self._count = 0
         self._orig_id = _id
@@ -29,7 +31,7 @@ class WaterButlerPathPart:
         return self._id
 
     @property
-    def value(self):
+    def value(self) -> str:
         if self._count:
             return'{} ({}){}'.format(self._name, self._count, self._ext)
         return'{}{}'.format(self._name, self._ext)
@@ -67,7 +69,7 @@ class WaterButlerPath:
     """ A standardized and validated immutable WaterButler path.  This is our abstraction around
     file paths in storage providers.  A WaterButlerPath is an array of WaterButlerPathPart objects.
     Each PathPart has two important attributes, `value` and `_id`.  `value` is always the
-    human-readble component of the path. If the provider assigns ids to entities (see: Box, Google
+    human-readable component of the path. If the provider assigns ids to entities (see: Box, Google
     Drive, OSFStorage), that id belongs in the `_id` attribute. If `/Foo/Bar/baz.txt` is stored on
     Box, its path parts will be approximately::
 
@@ -101,7 +103,7 @@ class WaterButlerPath:
     PART_CLASS = WaterButlerPathPart
 
     @classmethod
-    def generic_path_validation(cls, path):
+    def generic_path_validation(cls, path: str):
         """Validates a WaterButler specific path, e.g. /folder/file.txt, /folder/
         :param str path: WaterButler path
         """
@@ -127,7 +129,10 @@ class WaterButlerPath:
             raise exceptions.CreateFolderError('Path can not be root', code=400)
 
     @classmethod
-    def from_parts(cls, parts, folder=False, **kwargs):
+    def from_parts(cls,
+                   parts: list,
+                   folder: bool=False,
+                   **kwargs):
         _ids, _parts = [], []
         for part in parts:
             _ids.append(part.identifier)
@@ -140,11 +145,17 @@ class WaterButlerPath:
         return cls(path, _ids=_ids, folder=folder, **kwargs)
 
     @classmethod
-    def from_metadata(cls, metadata, **kwargs):
-        _ids = metadata.path.rstrip('/').split('/') or []
-        return cls(metadata.materialized_path, _ids=_ids, folder=metadata.is_folder, **kwargs)
+    def from_metadata(cls,
+                      path_metadata: metadata.BaseMetadata,
+                      **kwargs):
+        _ids = path_metadata.path.rstrip('/').split('/') or []
+        return cls(path_metadata.materialized_path, _ids=_ids, folder=path_metadata.is_folder, **kwargs)
 
-    def __init__(self, path, _ids=(), prepend=None, folder=None):
+    def __init__(self,
+                 path: str,
+                 _ids: tuple=(),
+                 prepend: str=None,
+                 folder: bool=None):
         self.__class__.generic_path_validation(path)
 
         self._orig_path = path
@@ -152,12 +163,12 @@ class WaterButlerPath:
         self._prepend = prepend
 
         if prepend:
-            self._prepend_parts = [self.PART_CLASS(part, None) for part in prepend.rstrip('/').split('/')]
+            self._prepend_parts = [self.PART_CLASS(part) for part in prepend.rstrip('/').split('/')]
         else:
-            self._prepend_parts = []
+            self._prepend_parts = []  # type: typing.List[WaterButlerPathPart]
 
         self._parts = [
-            self.PART_CLASS(part, _id)
+            self.PART_CLASS(part, _id=_id)
             for _id, part in
             itertools.zip_longest(_ids, path.rstrip('/').split('/'))
         ]
@@ -171,21 +182,21 @@ class WaterButlerPath:
             self._orig_path += '/'
 
     @property
-    def is_root(self):
+    def is_root(self) -> bool:
         """ Returns `True` if the path is the root directory. """
         return len(self._parts) == 1
 
     @property
-    def is_dir(self):
+    def is_dir(self) -> bool:
         """ Returns `True` if the path represents a folder. """
         return self._is_folder
 
     @property
-    def is_folder(self):
+    def is_folder(self) -> bool:
         return self._is_folder
 
     @property
-    def is_file(self):
+    def is_file(self) -> bool:
         """ Returns `True` if the path represents a file. """
         return not self._is_folder
 
@@ -195,7 +206,7 @@ class WaterButlerPath:
         return 'folder' if self._is_folder else 'file'
 
     @property
-    def parts(self):
+    def parts(self) -> list:
         """ Returns the list of WaterButlerPathParts that comprise this WaterButlerPath. """
         return self._parts
 
@@ -210,21 +221,21 @@ class WaterButlerPath:
         return self._parts[-1].identifier
 
     @property
-    def identifier_path(self):
+    def identifier_path(self) -> str:
         """ Returns the ID formatted as a path for providers that use unique ids
 
         Quirk:
-            If identifier is not set raises TypeError
+            If identifier is not set, raises TypeError
         """
         return '/' + self._parts[-1].identifier + ('/' if self.is_dir else '')
 
     @property
-    def ext(self):
+    def ext(self) -> str:
         """ Return the extension of the file """
         return self._parts[-1].ext
 
     @property
-    def path(self):
+    def path(self) -> str:
         """ Returns a unix-style human readable path, relative to the provider storage root.
         Does NOT include a leading slash.  Calling `.path()` on the storage root returns the
         empty string.
@@ -247,7 +258,7 @@ class WaterButlerPath:
         return '/'.join([x.value for x in self._prepend_parts + self.parts[1:]]) + ('/' if self.is_dir else '')
 
     @property
-    def materialized_path(self):
+    def materialized_path(self) -> str:
         """ Returns the user-readable unix-style path without the storage root prepended. """
         return '/'.join([x.value for x in self.parts]) + ('/' if self.is_dir else '')
 
@@ -262,11 +273,11 @@ class WaterButlerPath:
         return self.__class__.from_parts(self.parts[:-1], folder=True, prepend=self._prepend)
 
     @property
-    def extra(self):
+    def extra(self) -> dict:
         """ Any extra provider-specific properties of the path. """
         return {}
 
-    def child(self, name, _id=None, folder=False):
+    def child(self, name: str, _id=None, folder: bool=False):
         """ Create a child of the current WaterButlerPath, propagating prepend and id information to it.
 
         :param str name: the name of the child entity

--- a/waterbutler/core/path.py
+++ b/waterbutler/core/path.py
@@ -130,7 +130,7 @@ class WaterButlerPath:
 
     @classmethod
     def from_parts(cls,
-                   parts: list,
+                   parts: typing.Iterable[WaterButlerPathPart],
                    folder: bool=False,
                    **kwargs):
         _ids, _parts = [], []
@@ -153,7 +153,7 @@ class WaterButlerPath:
 
     def __init__(self,
                  path: str,
-                 _ids: tuple=(),
+                 _ids: typing.Sequence=(),
                  prepend: str=None,
                  folder: bool=None):
         self.__class__.generic_path_validation(path)
@@ -201,7 +201,7 @@ class WaterButlerPath:
         return not self._is_folder
 
     @property
-    def kind(self):
+    def kind(self) -> str:
         """ Returns `folder` if the path represents a folder, otherwise returns `file`. """
         return 'folder' if self._is_folder else 'file'
 
@@ -211,7 +211,7 @@ class WaterButlerPath:
         return self._parts
 
     @property
-    def name(self):
+    def name(self) -> str:
         """ Returns the name of the file or folder. """
         return self._parts[-1].value
 
@@ -245,7 +245,7 @@ class WaterButlerPath:
         return '/'.join([x.value for x in self.parts[1:]]) + ('/' if self.is_dir else '')
 
     @property
-    def raw_path(self):
+    def raw_path(self) -> str:
         """ Like `.path()`, but passes each path segment through the PathPart's ENCODE function.
         """
         if len(self.parts) == 1:

--- a/waterbutler/core/path.py
+++ b/waterbutler/core/path.py
@@ -1,8 +1,9 @@
-import itertools
 import os
+import itertools
 import typing  # noqa
 
-from waterbutler.core import exceptions, metadata
+from waterbutler.core import metadata
+from waterbutler.core import exceptions
 
 
 class WaterButlerPathPart:

--- a/waterbutler/core/path.py
+++ b/waterbutler/core/path.py
@@ -16,10 +16,10 @@ class WaterButlerPathPart:
     path.
     """
 
-    DECODE = lambda x: x  # type: typing.Callable[str]
-    ENCODE = lambda x: x  # type: typing.Callable[str]
+    DECODE = lambda x: x  # type: typing.Callable[[str], str]
+    ENCODE = lambda x: x  # type: typing.Callable[[str], str]
 
-    def __init__(self, part: str, *, _id=None):
+    def __init__(self, part: str, *, _id=None) -> None:
         self._id = _id
         self._count = 0
         self._orig_id = _id
@@ -132,7 +132,7 @@ class WaterButlerPath:
     def from_parts(cls,
                    parts: typing.Iterable[WaterButlerPathPart],
                    folder: bool=False,
-                   **kwargs):
+                   **kwargs) -> 'WaterButlerPath':
         _ids, _parts = [], []
         for part in parts:
             _ids.append(part.identifier)
@@ -142,21 +142,22 @@ class WaterButlerPath:
         if parts and not path:
             path = '/'
 
-        return cls(path, _ids=_ids, folder=folder, **kwargs)
+        return cls(path, _ids=_ids, folder=folder, **kwargs)  # type: ignore
 
     @classmethod
     def from_metadata(cls,
                       path_metadata: metadata.BaseMetadata,
                       **kwargs):
         _ids = path_metadata.path.rstrip('/').split('/') or []
-        return cls(path_metadata.materialized_path, _ids=_ids, folder=path_metadata.is_folder, **kwargs)
+        return cls(path_metadata.materialized_path, _ids=_ids, folder=path_metadata.is_folder, **kwargs)  # type: ignore
 
     def __init__(self,
                  path: str,
                  _ids: typing.Sequence=(),
                  prepend: str=None,
-                 folder: bool=None):
-        self.__class__.generic_path_validation(path)
+                 folder: bool=None, **kwargs) -> None:
+        # TODO: Should probably be a static method
+        self.__class__.generic_path_validation(path)  # type: ignore
 
         self._orig_path = path
 
@@ -284,7 +285,7 @@ class WaterButlerPath:
         :param _id: the id of the child entity (defaults to None)
         :param bool folder: whether or not the child is a folder (defaults to False)
         """
-        return self.__class__.from_parts(
+        return self.__class__.from_parts(  # type: ignore
             self.parts + [self.PART_CLASS(name, _id=_id)],
             folder=folder, prepend=self._prepend
         )

--- a/waterbutler/core/path.py
+++ b/waterbutler/core/path.py
@@ -19,15 +19,15 @@ class WaterButlerPathPart:
     DECODE = lambda x: x  # type: typing.Callable[[str], str]
     ENCODE = lambda x: x  # type: typing.Callable[[str], str]
 
-    def __init__(self, part: str, *, _id=None) -> None:
+    def __init__(self, part: str, *, _id: str=None) -> None:
         self._id = _id
-        self._count = 0
+        self._count = 0  # type: int
         self._orig_id = _id
         self._orig_part = part
         self._name, self._ext = os.path.splitext(self.original_value)
 
     @property
-    def identifier(self):
+    def identifier(self) -> str:
         return self._id
 
     @property
@@ -37,29 +37,29 @@ class WaterButlerPathPart:
         return'{}{}'.format(self._name, self._ext)
 
     @property
-    def raw(self):
+    def raw(self) -> str:
         """ The `value` as passed through the `ENCODE` function"""
-        return self.__class__.ENCODE(self.value)
+        return self.__class__.ENCODE(self.value)  # type: ignore
 
     @property
-    def original_value(self):
-        return self.__class__.DECODE(self._orig_part)
+    def original_value(self) -> str:
+        return self.__class__.DECODE(self._orig_part)  # type: ignore
 
     @property
-    def original_raw(self):
+    def original_raw(self) -> str:
         return self._orig_part
 
     @property
-    def ext(self):
+    def ext(self) -> str:
         return self._ext
 
-    def increment_name(self, _id=None):
+    def increment_name(self, _id=None) -> 'WaterButlerPathPart':
         self._id = _id
         self._count += 1
         return self
 
-    def renamed(self, name):
-        return self.__class__(self.__class__.ENCODE(name), _id=self._id)
+    def renamed(self, name: str) -> 'WaterButlerPathPart':
+        return self.__class__(self.__class__.ENCODE(name), _id=self._id)  # type: ignore
 
     def __repr__(self):
         return '{}({!r}, count={})'.format(self.__class__.__name__, self._orig_part, self._count)
@@ -103,7 +103,7 @@ class WaterButlerPath:
     PART_CLASS = WaterButlerPathPart
 
     @classmethod
-    def generic_path_validation(cls, path: str):
+    def generic_path_validation(cls, path: str) -> None:
         """Validates a WaterButler specific path, e.g. /folder/file.txt, /folder/
         :param str path: WaterButler path
         """
@@ -121,7 +121,7 @@ class WaterButlerPath:
             raise exceptions.InvalidPathError('Invalid path \'{}\' specified'.format(absolute_path))
 
     @classmethod
-    def validate_folder(cls, path):
+    def validate_folder(cls, path: 'WaterButlerPath') -> None:
         if not path.is_dir:
             raise exceptions.CreateFolderError('Path must be a directory', code=400)
 
@@ -290,11 +290,11 @@ class WaterButlerPath:
             folder=folder, prepend=self._prepend
         )
 
-    def increment_name(self):
+    def increment_name(self) -> 'WaterButlerPath':
         self._parts[-1].increment_name()
         return self
 
-    def rename(self, name):
+    def rename(self, name) -> 'WaterButlerPath':
         self._parts[-1] = self._parts[-1].renamed(name)
         return self
 

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -15,7 +15,7 @@ import furl
 from waterbutler import settings as wb_settings
 
 from waterbutler.core import exceptions
-from waterbutler.core import metadata
+from waterbutler.core import metadata as wb_metadata
 from waterbutler.core import path as wb_path
 from waterbutler.core import streams
 from waterbutler.core.metrics import MetricsRecord
@@ -203,7 +203,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
                    dest_path: wb_path.WaterButlerPath,
                    rename: str=None,
                    conflict: str='replace',
-                   handle_naming: bool=True) -> typing.Tuple[metadata.BaseMetadata, bool]:
+                   handle_naming: bool=True) -> typing.Tuple[wb_metadata.BaseMetadata, bool]:
         """Moves a file or folder from the current provider to the specified one
         Performs a copy and then a delete.
         Calls :func:`BaseProvider.intra_move` if possible.
@@ -261,7 +261,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
                    dest_path: wb_path.WaterButlerPath,
                    rename: str=None, conflict: str='replace',
                    handle_naming: bool=True) \
-            -> typing.Tuple[metadata.BaseMetadata, bool]:
+            -> typing.Tuple[wb_metadata.BaseMetadata, bool]:
         args = (dest_provider, src_path, dest_path)
         kwargs = {'rename': rename, 'conflict': conflict, 'handle_naming': handle_naming}
 
@@ -307,7 +307,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
                               dest_provider: 'BaseProvider',
                               src_path: wb_path.WaterButlerPath,
                               dest_path: wb_path.WaterButlerPath,
-                              **kwargs) -> typing.Tuple[metadata.BaseFolderMetadata, bool]:
+                              **kwargs) -> typing.Tuple[wb_metadata.BaseFolderMetadata, bool]:
         """Recursively apply func to src/dest path.
 
         Called from: func: copy and move if src_path.is_dir.
@@ -437,7 +437,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
     async def intra_copy(self,
                          dest_provider: 'BaseProvider',
                          source_path: wb_path.WaterButlerPath,
-                         dest_path: wb_path.WaterButlerPath) -> typing.Tuple[metadata.BaseFileMetadata, bool]:
+                         dest_path: wb_path.WaterButlerPath) -> typing.Tuple[wb_metadata.BaseFileMetadata, bool]:
         """If the provider supports copying files and/or folders within itself by some means other
         than download/upload, then ``can_intra_copy`` should return ``True``.  This method will
         implement the copy.  It accepts the destination provider, a source path, and the
@@ -455,7 +455,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
     async def intra_move(self,
                          dest_provider: 'BaseProvider',
                          src_path: wb_path.WaterButlerPath,
-                         dest_path: wb_path.WaterButlerPath) -> typing.Tuple[metadata.BaseFileMetadata, bool]:
+                         dest_path: wb_path.WaterButlerPath) -> typing.Tuple[wb_metadata.BaseFileMetadata, bool]:
         """If the provider supports moving files and/or folders within itself by some means other
         than download/upload/delete, then ``can_intra_move`` should return ``True``.  This method
         will implement the move.  It accepts the destination provider, a source path, and the
@@ -473,7 +473,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
         return data, created
 
     async def exists(self, path: wb_path.WaterButlerPath, **kwargs) \
-            -> typing.Union[bool, metadata.BaseMetadata, typing.List[metadata.BaseMetadata]]:
+            -> typing.Union[bool, wb_metadata.BaseMetadata, typing.List[wb_metadata.BaseMetadata]]:
         """Check for existence of WaterButlerPath
 
         Attempt to retrieve provider metadata to determine existence of a WaterButlerPath.  If
@@ -581,7 +581,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def upload(self, stream: streams.BaseStream, *args, **kwargs) \
-            -> typing.Tuple[metadata.BaseFileMetadata, bool]:
+            -> typing.Tuple[wb_metadata.BaseFileMetadata, bool]:
         """Uploads the given stream to the provider.  Returns the metadata for the newly created
         file and a boolean indicating whether the file is completely new (``True``) or overwrote
         a previously-existing file (``False``)
@@ -605,7 +605,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     async def metadata(self, **kwargs) \
-            -> typing.Union[metadata.BaseMetadata, typing.List[metadata.BaseMetadata]]:
+            -> typing.Union[wb_metadata.BaseMetadata, typing.List[wb_metadata.BaseMetadata]]:
         """Get metadata about the specified resource from this provider. Will be a :class:`list`
         if the resource is a directory otherwise an instance of
         :class:`waterbutler.core.metadata.BaseFileMetadata`
@@ -661,13 +661,13 @@ class BaseProvider(metaclass=abc.ABCMeta):
 
     def path_from_metadata(self,
                            parent_path: wb_path.WaterButlerPath,
-                           meta_data: metadata.BaseMetadata) -> wb_path.WaterButlerPath:
+                           meta_data: wb_metadata.BaseMetadata) -> wb_path.WaterButlerPath:
         return parent_path.child(meta_data.name, _id=meta_data.path.strip('/'), folder=meta_data.is_folder)
 
     def revisions(self, **kwargs):
         return []  # TODO Raise 405 by default h/t @rliebz
 
-    def create_folder(self, path: wb_path.WaterButlerPath, **kwargs) -> metadata.BaseFolderMetadata:
+    def create_folder(self, path: wb_path.WaterButlerPath, **kwargs) -> wb_metadata.BaseFolderMetadata:
         """Create a folder in the current provider at `path`. Returns a `BaseFolderMetadata` object
         if successful.  May throw a 409 Conflict if a directory with the same name already exists.
 

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -153,7 +153,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
         }
 
     @throttle()
-    async def make_request(self, method: str, url: str, *args, **kwargs) -> aiohttp.Response:
+    async def make_request(self, method: str, url: str, *args, **kwargs) -> aiohttp.client.ClientResponse:
         """A wrapper around :func:`aiohttp.request`. Inserts default headers.
 
         :param str method: The HTTP method
@@ -580,11 +580,13 @@ class BaseProvider(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def upload(self, stream, **kwargs) -> typing.Tuple[metadata.BaseFileMetadata, bool]:
+    def upload(self, stream: streams.BaseStream, *args, **kwargs) \
+            -> typing.Tuple[metadata.BaseFileMetadata, bool]:
         """Uploads the given stream to the provider.  Returns the metadata for the newly created
         file and a boolean indicating whether the file is completely new (``True``) or overwrote
         a previously-existing file (``False``)
 
+        :param :class:`waterbutler.core.streams.BaseStream` stream: The content to be uploaded
         :param dict \*\*kwargs: Arguments to be parsed by child classes
         :rtype: (:class:`waterbutler.core.metadata.BaseFileMetadata`, :class:`bool`)
         :raises: :class:`waterbutler.core.exceptions.DeleteError`
@@ -616,7 +618,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def validate_v1_path(self, path: wb_path.WaterButlerPath, **kwargs) -> wb_path.WaterButlerPath:
+    def validate_v1_path(self, path: str, **kwargs) -> wb_path.WaterButlerPath:
         """API v1 requires that requests against folder endpoints always end with a slash, and
         requests against files never end with a slash.  This method checks the provider's metadata
         for the given id and throws a 404 Not Found if the implicit and explicit types don't

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -1,26 +1,24 @@
 import abc
-import asyncio
-import functools
-import itertools
-import logging
 import time
 import typing
+import asyncio
+import logging
 import weakref
-
+import functools
+import itertools
 from urllib import parse
 
-import aiohttp
 import furl
+import aiohttp
 
-from waterbutler import settings as wb_settings
-
-from waterbutler.core import exceptions
-from waterbutler.core import metadata as wb_metadata
-from waterbutler.core import path as wb_path
 from waterbutler.core import streams
+from waterbutler.core import exceptions
+from waterbutler.core import path as wb_path
+from waterbutler import settings as wb_settings
 from waterbutler.core.metrics import MetricsRecord
-from waterbutler.core.utils import RequestHandlerContext
+from waterbutler.core import metadata as wb_metadata
 from waterbutler.core.utils import ZipStreamGenerator
+from waterbutler.core.utils import RequestHandlerContext
 
 
 logger = logging.getLogger(__name__)

--- a/waterbutler/core/streams/file.py
+++ b/waterbutler/core/streams/file.py
@@ -3,7 +3,7 @@ import asyncio
 
 import agent
 
-from waterbutler.core.streams import BaseStream
+from waterbutler.core.streams.base import BaseStream
 
 
 class FileStreamReader(BaseStream):

--- a/waterbutler/core/streams/http.py
+++ b/waterbutler/core/streams/http.py
@@ -1,9 +1,9 @@
 import asyncio
 import uuid
 
-from waterbutler.core.streams import BaseStream
-from waterbutler.core.streams import MultiStream
-from waterbutler.core.streams import StringStream
+from waterbutler.core.streams.base import BaseStream
+from waterbutler.core.streams.base import MultiStream
+from waterbutler.core.streams.base import StringStream
 
 
 class FormDataStream(MultiStream):

--- a/waterbutler/core/streams/json.py
+++ b/waterbutler/core/streams/json.py
@@ -1,7 +1,7 @@
 import asyncio
 
-from waterbutler.core.streams import StringStream
-from waterbutler.core.streams import MultiStream
+from waterbutler.core.streams.base import StringStream
+from waterbutler.core.streams.base import MultiStream
 
 
 class JSONStream(MultiStream):

--- a/waterbutler/core/streams/zip.py
+++ b/waterbutler/core/streams/zip.py
@@ -5,9 +5,9 @@ import time
 import zipfile
 import zlib
 
-from waterbutler.core.streams import BaseStream
-from waterbutler.core.streams import MultiStream
-from waterbutler.core.streams import StringStream
+from waterbutler.core.streams.base import BaseStream
+from waterbutler.core.streams.base import MultiStream
+from waterbutler.core.streams.base import StringStream
 
 # for some reason python3.5 has this as (1 << 31) - 1, which is 0x7fffffff
 ZIP64_LIMIT = 0xffffffff - 1

--- a/waterbutler/core/utils.py
+++ b/waterbutler/core/utils.py
@@ -25,7 +25,7 @@ sentry_dsn = config.get_nullable('SENTRY_DSN', None)
 client = Client(sentry_dsn) if sentry_dsn else None
 
 
-def make_provider(name, auth, credentials, settings, **kwargs):
+def make_provider(name: str, auth: dict, credentials: dict, settings: dict, **kwargs):
     """Returns an instance of :class:`waterbutler.core.provider.BaseProvider`
 
     :param str name: The name of the provider to instantiate. (s3, box, etc)

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -1,16 +1,13 @@
+import os
+import json
+import typing
 import aiohttp
 from http import HTTPStatus
-import json
-import os
-import typing
 
-
-from waterbutler.core import exceptions
-from waterbutler.core import provider
 from waterbutler.core import streams
-
+from waterbutler.core import provider
+from waterbutler.core import exceptions
 from waterbutler.core import path as wb_path
-
 from waterbutler.providers.box import settings
 from waterbutler.providers.box.metadata import (BaseBoxMetadata,
                                                 BoxFileMetadata,

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -1,11 +1,10 @@
-from http import HTTPStatus
 import json
 import typing
+from http import HTTPStatus
 
-from waterbutler.core import exceptions
-from waterbutler.core import provider
 from waterbutler.core import streams
-
+from waterbutler.core import provider
+from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
 
 from waterbutler.providers.dropbox import settings

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -1,17 +1,19 @@
-import json
 import http
+import json
+import typing
 
-from waterbutler.core import streams
-from waterbutler.core import provider
 from waterbutler.core import exceptions
+from waterbutler.core import provider
+from waterbutler.core import streams
+
 from waterbutler.core.path import WaterButlerPath
 
 from waterbutler.providers.dropbox import settings
-from waterbutler.providers.dropbox.metadata import DropboxRevision
-from waterbutler.providers.dropbox.metadata import DropboxFileMetadata
-from waterbutler.providers.dropbox.metadata import DropboxFolderMetadata
-from waterbutler.providers.dropbox.exceptions import DropboxNamingConflictError
-from waterbutler.providers.dropbox.exceptions import DropboxUnhandledConflictError
+from waterbutler.providers.dropbox.metadata import (BaseDropboxMetadata,
+                                                    DropboxFileMetadata,
+                                                    DropboxFolderMetadata,
+                                                    DropboxRevision)
+from waterbutler.providers.dropbox.exceptions import DropboxNamingConflictError, DropboxUnhandledConflictError
 
 
 class DropboxProvider(provider.BaseProvider):
@@ -57,7 +59,12 @@ class DropboxProvider(provider.BaseProvider):
         self.folder = self.settings['folder']
         self.metrics.add('folder_is_root', self.folder == '/')
 
-    async def dropbox_request(self, url, body, expects=(200, 409,), *args, **kwargs):
+    async def dropbox_request(self,
+                              url: str,
+                              body: dict,
+                              expects: typing.Tuple=(200, 409,),
+                              *args,
+                              **kwargs) -> dict:
         """Convenience wrapper around ``BaseProvider.request`` for simple Dropbox API calls. Sets
         the method to ``POST``, jsonifies the ``body`` param, and provides default error handling
         for Dropbox's standard 409 error response structure.
@@ -81,7 +88,7 @@ class DropboxProvider(provider.BaseProvider):
                 self.dropbox_conflict_error_handler(data, body.get('path', ''))
             return data
 
-    def dropbox_conflict_error_handler(self, data, error_path=''):
+    def dropbox_conflict_error_handler(self, data: dict, error_path: str='') -> None:
         """Takes a standard Dropbox error response and an optional path and tries to throw a
         meaningful error based on it.
 
@@ -107,7 +114,7 @@ class DropboxProvider(provider.BaseProvider):
                                                                          error_path))
         raise DropboxUnhandledConflictError(str(data))
 
-    async def validate_v1_path(self, path, **kwargs):
+    async def validate_v1_path(self, path: str, **kwargs) -> WaterButlerPath:
         if path == '/':
             return WaterButlerPath(path, prepend=self.folder)
         implicit_folder = path.endswith('/')
@@ -121,13 +128,13 @@ class DropboxProvider(provider.BaseProvider):
             raise exceptions.NotFoundError(str(path))
         return WaterButlerPath(path, prepend=self.folder)
 
-    async def validate_path(self, path, **kwargs):
+    async def validate_path(self, path: str, **kwargs) -> WaterButlerPath:
         return WaterButlerPath(path, prepend=self.folder)
 
-    def can_duplicate_names(self):
+    def can_duplicate_names(self) -> bool:
         return False
 
-    def shares_storage_root(self, other):
+    def shares_storage_root(self, other: provider.BaseProvider) -> bool:
         """Dropbox settings only include the root folder. If a cross-resource move occurs
         between two dropbox providers that are on different accounts but have the same folder
         base name, the parent method could incorrectly think the action is a self-overwrite.
@@ -135,11 +142,15 @@ class DropboxProvider(provider.BaseProvider):
         return super().shares_storage_root(other) and self.credentials == other.credentials
 
     @property
-    def default_headers(self):
+    def default_headers(self) -> dict:
         return {'Authorization': 'Bearer {}'.format(self.token),
                 'Content-Type': 'application/json'}
 
-    async def intra_copy(self, dest_provider, src_path, dest_path):
+    async def intra_copy(self,
+                         dest_provider: 'DropboxProvider',
+                         src_path: WaterButlerPath,
+                         dest_path: WaterButlerPath) \
+            -> typing.Tuple[typing.Union[DropboxFileMetadata, DropboxFolderMetadata], bool]:
         dest_folder = dest_provider.folder
         try:
             if self == dest_provider:
@@ -178,7 +189,10 @@ class DropboxProvider(provider.BaseProvider):
         folder.children = [item for item in await dest_provider.metadata(dest_path)]
         return folder, True
 
-    async def intra_move(self, dest_provider, src_path, dest_path):
+    async def intra_move(self,
+                         dest_provider: 'DropboxProvider',
+                         src_path: WaterButlerPath,
+                         dest_path: WaterButlerPath) -> typing.Tuple[BaseDropboxMetadata, bool]:
         if dest_path.full_path.lower() == src_path.full_path.lower():
             # Dropbox does not support changing the casing in a file name
             raise exceptions.InvalidPathError('In Dropbox to change case, add or subtract other characters.')
@@ -205,7 +219,11 @@ class DropboxProvider(provider.BaseProvider):
         folder.children = [item for item in await dest_provider.metadata(dest_path)]
         return folder, True
 
-    async def download(self, path, revision=None, range=None, **kwargs):
+    async def download(self,
+                       path: WaterButlerPath,
+                       revision: str=None,
+                       range: typing.Tuple[int, int]=None,
+                       **kwargs) -> streams.ResponseStreamReader:
         path_arg = {"path": ("rev:" + revision if revision else path.full_path)}
         resp = await self.make_request(
             'POST',
@@ -224,7 +242,11 @@ class DropboxProvider(provider.BaseProvider):
             size = None
         return streams.ResponseStreamReader(resp, size=size)
 
-    async def upload(self, stream, path, conflict='replace', **kwargs):
+    async def upload(self,
+                     stream: streams.BaseStream,
+                     path: WaterButlerPath,
+                     conflict: str='replace',
+                     **kwargs) -> typing.Tuple[DropboxFileMetadata, bool]:
         path, exists = await self.handle_name_conflict(path, conflict=conflict)
         path_arg = {"path": path.full_path}
         if conflict == 'replace':
@@ -247,7 +269,7 @@ class DropboxProvider(provider.BaseProvider):
             self.dropbox_conflict_error_handler(data, path.path)
         return DropboxFileMetadata(data, self.folder), not exists
 
-    async def delete(self, path, confirm_delete=0, **kwargs):
+    async def delete(self, path: WaterButlerPath, confirm_delete: int=0, **kwargs) -> None:
         """Delete file, folder, or provider root contents
 
         :param WaterButlerPath path: WaterButlerPath path object for folder
@@ -267,7 +289,8 @@ class DropboxProvider(provider.BaseProvider):
             throws=exceptions.DeleteError,
         )
 
-    async def metadata(self, path, revision=None, **kwargs):
+    async def metadata(self, path: WaterButlerPath, revision: str=None, **kwargs) \
+            -> typing.Union[BaseDropboxMetadata, typing.List[BaseDropboxMetadata]]:
         full_path = path.full_path.rstrip('/')
         url = self.build_url('files', 'get_metadata')
         body = {'path': full_path}
@@ -313,7 +336,7 @@ class DropboxProvider(provider.BaseProvider):
 
         return DropboxFileMetadata(data, self.folder)
 
-    async def revisions(self, path, **kwargs):
+    async def revisions(self, path: WaterButlerPath, **kwargs) -> typing.List[DropboxRevision]:
         # Dropbox v2 API limits the number of revisions returned to a maximum
         # of 100, default 10. Previously we had set the limit to 250.
 
@@ -331,7 +354,7 @@ class DropboxProvider(provider.BaseProvider):
             return []
         return [DropboxRevision(item) for item in data['entries']]
 
-    async def create_folder(self, path, **kwargs):
+    async def create_folder(self, path: WaterButlerPath, **kwargs) -> DropboxFolderMetadata:
         """
         :param str path: The path to create a folder at
         """
@@ -343,16 +366,16 @@ class DropboxProvider(provider.BaseProvider):
         )
         return DropboxFolderMetadata(data, self.folder)
 
-    def can_intra_copy(self, dest_provider, path=None):
+    def can_intra_copy(self, dest_provider: provider.BaseProvider, path: WaterButlerPath=None) -> bool:
         return type(self) == type(dest_provider)
 
-    def can_intra_move(self, dest_provider, path=None):
+    def can_intra_move(self, dest_provider: provider.BaseProvider, path: WaterButlerPath=None) -> bool:
         return self == dest_provider
 
     def _build_content_url(self, *segments, **query):
         return provider.build_url(settings.BASE_CONTENT_URL, *segments, **query)
 
-    async def _delete_folder_contents(self, path, **kwargs):
+    async def _delete_folder_contents(self, path: WaterButlerPath, **kwargs) -> None:
         """Delete the contents of a folder. For use against provider root.
 
         :param WaterButlerPath path: WaterButlerPath path object for folder

--- a/waterbutler/providers/figshare/path.py
+++ b/waterbutler/providers/figshare/path.py
@@ -3,8 +3,12 @@ from waterbutler.core.path import WaterButlerPath
 
 class FigsharePath(WaterButlerPath):
 
-    def __init__(self, path, folder: bool, is_public=False, parent_is_folder=True, _ids=(),
-                 prepend=None):
+    def __init__(self, path,
+                 folder: bool,
+                 is_public=False,
+                 parent_is_folder=True,
+                 _ids=(),
+                 prepend=None) -> None:
         super().__init__(path, _ids=_ids, prepend=prepend, folder=folder)
         self.is_public = is_public
         self.parent_is_folder = parent_is_folder

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -117,7 +117,7 @@ class BaseFigshareProvider(provider.BaseProvider):
             'Authorization': 'token {}'.format(self.token),
         }
 
-    def build_url(self, is_public: bool, *segments, **query):
+    def build_url(self, is_public: bool, *segments, **query) -> str:  # type: ignore
         """A nice wrapper around furl, builds urls based on self.BASE_URL
 
         :param bool is_public: ``True`` if addressing public resource
@@ -835,7 +835,7 @@ class FigshareArticleProvider(BaseFigshareProvider):
         await resp.release()
         return FigsharePath('/' + file_id, _ids=('', ''), folder=False, is_public=False)
 
-    async def revalidate_path(self, parent_path, child_name, folder: bool):
+    async def revalidate_path(self, parent_path, child_name, folder: bool=False):
         """Attempt to get child's id and return FigsharePath of child.
 
         ``revalidate_path`` is used to check for the existance of a child_name/folder

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -278,7 +278,7 @@ class GoogleDriveProvider(provider.BaseProvider):
                        path: wb_path.WaterButlerPath,
                        raw: bool = False,
                        revision=None,
-                       **kwargs) -> typing.Union[list, dict, BaseGoogleDriveMetadata]:
+                       **kwargs) -> typing.Union[dict, BaseGoogleDriveMetadata, typing.List[BaseGoogleDriveMetadata]]:
         # TODO: Work out correct return type (may be file vs folder discrepancy)
         if path.identifier is None:
             raise exceptions.MetadataError('{} not found'.format(str(path)), code=404)
@@ -313,7 +313,10 @@ class GoogleDriveProvider(provider.BaseProvider):
             'id': data['etag'] + settings.DRIVE_IGNORE_VERSION,
         })]
 
-    async def create_folder(self, path, folder_precheck=True, **kwargs):
+    async def create_folder(self,
+                            path: wb_path.WaterButlerPath,
+                            folder_precheck: bool=True,
+                            **kwargs) -> GoogleDriveFolderMetadata:
         GoogleDrivePath.validate_folder(path)
 
         if folder_precheck:
@@ -549,7 +552,8 @@ class GoogleDriveProvider(provider.BaseProvider):
 
         return self._serialize_item(path, item, raw=raw)
 
-    async def _folder_metadata(self, path: wb_path.WaterButlerPath, raw: bool=False):
+    async def _folder_metadata(self, path: wb_path.WaterButlerPath, raw: bool=False) \
+            -> typing.List[BaseGoogleDriveMetadata]:
         query = self._build_query(path.identifier)
         built_url = self.build_url('files', q=query, alt='json', maxResults=1000)
         full_resp = []
@@ -595,7 +599,7 @@ class GoogleDriveProvider(provider.BaseProvider):
     async def _delete_folder_contents(self, path: wb_path.WaterButlerPath) -> None:
         """Given a WaterButlerPath, delete all contents of folder
 
-        :param WaterButlerPath: Folder to be emptied
+        :param WaterButlerPath path: Folder to be emptied
         :rtype: None
         :raises: :class:`waterbutler.core.exceptions.NotFoundError`
         :raises: :class:`waterbutler.core.exceptions.MetadataError`

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -1,16 +1,16 @@
-import functools
-from http import HTTPStatus
-import json
 import os
+import json
 import typing
+import functools
 from urllib import parse
+from http import HTTPStatus
 
 import furl
 
+from waterbutler.core import streams
+from waterbutler.core import provider
 from waterbutler.core import exceptions
 from waterbutler.core import path as wb_path
-from waterbutler.core import provider
-from waterbutler.core import streams
 
 from waterbutler.providers.googledrive import settings
 from waterbutler.providers.googledrive import utils as drive_utils

--- a/waterbutler/providers/owncloud/settings.py
+++ b/waterbutler/providers/owncloud/settings.py
@@ -1,6 +1,6 @@
 try:
     from waterbutler import settings
 except ImportError:
-    settings = {}
+    settings = {}  # type: ignore
 
-config = settings.get('OWNCLOUD_PROVIDER_CONFIG', {})
+config = settings.get('OWNCLOUD_PROVIDER_CONFIG', {})  # type: ignore

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -8,7 +8,7 @@ import xmltodict
 import xml.sax.saxutils
 
 from boto import config as boto_config
-from boto.compat import BytesIO
+from boto.compat import BytesIO  # type: ignore
 from boto.utils import compute_md5
 from boto.auth import get_auth_handler
 from boto.s3.connection import S3Connection

--- a/waterbutler/server/api/v0/core.py
+++ b/waterbutler/server/api/v0/core.py
@@ -42,7 +42,7 @@ class BaseHandler(server_utils.CORsMixin, server_utils.UtilMixin, tornado.web.Re
         actual method, to be interpreted as the specified method.
     """
 
-    ACTION_MAP = {}
+    ACTION_MAP = {}  # type: dict
 
     def write_error(self, status_code, exc_info):
         self.captureException(exc_info)

--- a/waterbutler/tasks/move.py
+++ b/waterbutler/tasks/move.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 @core.celery_task
-async def move(src_bundle, dest_bundle, request={}, start_time=None, **kwargs):
+async def move(src_bundle, dest_bundle, request: dict=None, start_time=None, **kwargs):
+    request = request or {}
     start_time = start_time or time.time()
 
     src_path, src_provider = src_bundle.pop('path'), utils.make_provider(**src_bundle.pop('provider'))

--- a/waterbutler/tasks/move.py
+++ b/waterbutler/tasks/move.py
@@ -22,7 +22,7 @@ async def move(src_bundle, dest_bundle, request: dict=None, start_time=None, **k
     logger.info('Starting moving {!r}, {!r} to {!r}, {!r}'
                 .format(src_path, src_provider, dest_path, dest_provider))
 
-    metadata, errors = None, []
+    metadata, errors = None, []  # type: ignore
     try:
         metadata, created = await src_provider.move(dest_provider, src_path, dest_path, **kwargs)
     except Exception as e:


### PR DESCRIPTION
:squid: Ready for review, but watch for sea monsters (my first WB PR)

# Ticket 
https://openscience.atlassian.net/browse/SVCS-351

# Purpose
- Add type annotations to assist with debugging (core classes and some, but not all, providers)
- Provide an option (currently not on by default) to use mypy, a linter for gradual type hinting- catches weird usages of methods

# Notes for reviewers
To try this out, run `inv mypy`. 

In the future this can be used in Travis CI, but is currently hidden behind a flag by default:
`inv test --types`

Many of these types are a "best guess" and subject to evolve in the future. Python types are informational only and do not affect runtime, but tools such as mypy (and pycharm!) support automatic linting to catch errors during development.

I am new to waterbutler. If there is a better type to use, let me know. The ignore settings in mypy may be too aggressive and are worth revisiting in the future.

## Specific rules that we ignore
Mypy does not appear to support selective ignoring of certain rules. Therefore, ignore statements are scattered throughout the code more than I would wish. See notes and rationale:

- Mypy doesn't seem to do very well with functions that can return more than one type of thing. (so basically every call to metadata gets ignored) See:
`https://github.com/python/mypy/issues/1693`
  - This could be resolved using dependent types / `@overload`, if we some day refactor so that files and folders are represented via different classes.
- Method call signatures or return types are not consistent with parent classes. We routinely violate the Liskov substitution principle, of necessity as there is no uniform abstraction for all providers. See: `https://github.com/python/mypy/issues/1237`
  - There are a lot of ignores for this. It's terrible; I'm sorry.

# Summary of changes
- Add type annotations to code
- Update docstrings
- Update method signatures that did not reflect the common usages across all subclasses

# Testing notes
In theory this is a pure developer facing change. One or two minor changes were made to method call signatures.

Recommend watching for any new errors during common operations. I have done light manual testing consisting of uploads/downloads/renames/cross provider moves (osf storage to google drive).