### PR TITLE
[SVCS-273] support read-only files on GDrive / improve revision handling

### DIFF
--- a/tests/providers/googledrive/fixtures.py
+++ b/tests/providers/googledrive/fixtures.py
@@ -1,3 +1,6 @@
+import os
+import json
+
 list_file = {
     'etag': '"zWM2D6PBtLRQKuDNbaQNSNEy5BE/MrSD7Al_zGPN4CKisJpWLDC3cyY"',
     'kind': 'drive#fileList',
@@ -321,3 +324,46 @@ revisions_list_empty = {
     'selfLink': 'https://www.googleapis.com/drive/v2/files/1GwpK7IozbO01RiyC5aPd66v7ShEViqggvT6ur5_pZMFo-ZzQHOgkyoU3ztjf0ytKt0HSdvUg6O2nmoYR/revisions',
     'items': []
 }
+
+
+# fixtures for testing files under unusual sharing regimes
+with open(os.path.join(os.path.dirname(__file__), 'fixtures/sharing.json'), 'r') as fp:
+    sharing = json.load(fp)
+
+
+def make_no_such_revision_error(revision_id):
+    message = 'Revision not found: {}'.format(revision_id)
+    return json.dumps({
+        "error": {
+            "errors": [
+                {
+                    "reason": "notFound",
+                    "locationType": "other",
+                    "message": message,
+                    "location": "revision",
+                    "domain": "global"
+                }
+            ],
+            "message": message,
+            "code": 404
+        }
+    })
+
+def make_unauthorized_file_access_error(file_id):
+    message = ('The authenticated user does not have the required access '
+               'to the file {}'.format(file_id))
+    return json.dumps({
+        "error": {
+            "errors": [
+                {
+                    "reason": "userAccess",
+                    "locationType": "header",
+                    "message": message,
+                    "location": "Authorization",
+                    "domain": "global"
+                }
+            ],
+            "message": message,
+            "code": 403
+        }
+    })

--- a/tests/providers/googledrive/fixtures/sharing.json
+++ b/tests/providers/googledrive/fixtures/sharing.json
@@ -1,0 +1,492 @@
+{
+    "editable_gdoc": {
+        "metadata": {
+            "iconLink" : "https://drive-thirdparty.googleusercontent.com/16/type/application/vnd.google-apps.document",
+            "version" : "43684",
+            "createdDate" : "2017-02-24T18:36:58.044Z",
+            "selfLink" : "https://www.googleapis.com/drive/v2/files/1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ",
+            "lastModifyingUserName" : "Fitz Elliott",
+            "appDataCqontents" : false,
+            "explicitlyTrashed" : false,
+            "exportLinks" : {
+                "application/vnd.oasis.opendocument.text" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&exportFormat=odt",
+                "application/zip" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&exportFormat=zip",
+                "text/html" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&exportFormat=html",
+                "application/pdf" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&exportFormat=pdf",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&exportFormat=docx",
+                "text/plain" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&exportFormat=txt",
+                "application/rtf" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&exportFormat=rtf",
+                "application/epub+zip" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&exportFormat=epub"
+            },
+            "alternateLink" : "https://docs.google.com/a/cos.io/document/d/1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ/edit?usp=drivesdk",
+            "modifiedDate" : "2017-02-24T18:37:28.569Z",
+            "thumbnailLink" : "https://docs.google.com/a/cos.io/feeds/vt?gd=true&id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&v=1&s=AMedNnoAAAAAWRo2ctWxLS7eQmcAhSbHbBAhdQmkSbVa&sz=s220",
+            "id" : "1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ",
+            "spaces" : [
+                "drive"
+            ],
+            "mimeType" : "application/vnd.google-apps.document",
+            "userPermission" : {
+                "etag" : "\"_Iwf20PbJS7QPBy9REF76uRLkQo/Q8v9eUEXTjEPR7_OHywQXTXv8d0\"",
+                "selfLink" : "https://www.googleapis.com/drive/v2/files/1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ/permissions/me",
+                "role" : "owner",
+                "id" : "me",
+                "type" : "user",
+                "kind" : "drive#permission"
+            },
+            "title" : "editable_gdoc",
+            "capabilities" : {
+                "canEdit" : true,
+                "canCopy" : true
+            },
+            "lastModifyingUser" : {
+                "kind" : "drive#user",
+                "isAuthenticatedUser" : true,
+                "emailAddress" : "fitz@cos.io",
+                "displayName" : "Fitz Elliott",
+                "permissionId" : "17667957036718347700"
+            },
+            "kind" : "drive#file",
+            "editable" : true,
+            "shared" : false,
+            "copyable" : true,
+            "markedViewedByMeDate" : "1970-01-01T00:00:00.000Z",
+            "writersCanShare" : true,
+            "etag" : "\"_Iwf20PbJS7QPBy9REF76uRLkQo/MTQ4Nzk2MTQ0ODU2OQ\"",
+            "modifiedByMeDate" : "2017-02-24T18:37:28.569Z",
+            "labels" : {
+                "restricted" : false,
+                "hidden" : false,
+                "starred" : false,
+                "trashed" : false,
+                "viewed" : true
+            },
+            "owners" : [
+                {
+                    "emailAddress" : "fitz@cos.io",
+                    "displayName" : "Fitz Elliott",
+                    "permissionId" : "17667957036718347700",
+                    "isAuthenticatedUser" : true,
+                    "kind" : "drive#user"
+                }
+            ],
+            "parents" : [
+                {
+                    "selfLink" : "https://www.googleapis.com/drive/v2/files/1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ/parents/0B74RCNS4TbRVNGJwLWFacnlKdGM",
+                    "parentLink" : "https://www.googleapis.com/drive/v2/files/0B74RCNS4TbRVNGJwLWFacnlKdGM",
+                    "isRoot" : false,
+                    "id" : "0B74RCNS4TbRVNGJwLWFacnlKdGM",
+                    "kind" : "drive#parentReference"
+                }
+            ],
+            "quotaBytesUsed" : "0",
+            "lastViewedByMeDate" : "2017-02-24T18:37:28.569Z",
+            "embedLink" : "https://docs.google.com/a/cos.io/document/d/1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ/preview",
+            "ownerNames" : [
+                "Fitz Elliott"
+            ]
+        },
+        "revisions":  {
+            "items" : [
+                {
+                    "exportLinks" : {
+                        "application/rtf" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=rtf",
+                        "application/epub+zip" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=epub",
+                        "application/zip" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=zip",
+                        "application/pdf" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=pdf",
+                        "text/plain" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=txt",
+                        "application/vnd.oasis.opendocument.text" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=odt",
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=docx",
+                        "text/html" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=html"
+                    },
+                    "selfLink" : "https://www.googleapis.com/drive/v2/files/1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ/revisions/1",
+                    "id" : "1",
+                    "kind" : "drive#revision",
+                    "etag" : "\"LUxk1DXE_0fd4yeJDIgpecr5uPA/lHudfDwfTEz0RxswkJ6vUFpP4z8\"",
+                    "modifiedDate" : "2017-02-24T18:36:58.041Z",
+                    "lastModifyingUser" : {
+                        "emailAddress" : "fitz@cos.io",
+                        "kind" : "drive#user",
+                        "permissionId" : "17667957036718347700",
+                        "isAuthenticatedUser" : true,
+                        "displayName" : "Fitz Elliott"
+                    },
+                    "lastModifyingUserName" : "Fitz Elliott",
+                    "mimeType" : "application/vnd.google-apps.document",
+                    "published" : false
+                },
+                {
+                    "exportLinks" : {
+                        "application/vnd.oasis.opendocument.text" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=11&exportFormat=odt",
+                        "text/html" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=11&exportFormat=html",
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=11&exportFormat=docx",
+                        "application/pdf" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=11&exportFormat=pdf",
+                        "text/plain" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=11&exportFormat=txt",
+                        "application/zip" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=11&exportFormat=zip",
+                        "application/epub+zip" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=11&exportFormat=epub",
+                        "application/rtf" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=11&exportFormat=rtf"
+                    },
+                    "id" : "11",
+                    "selfLink" : "https://www.googleapis.com/drive/v2/files/1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ/revisions/11",
+                    "kind" : "drive#revision",
+                    "etag" : "\"LUxk1DXE_0fd4yeJDIgpecr5uPA/EYC91bmPetPKWKMdh9HrqjoYm7A\"",
+                    "modifiedDate" : "2017-02-24T18:37:28.552Z",
+                    "lastModifyingUser" : {
+                        "kind" : "drive#user",
+                        "emailAddress" : "fitz@cos.io",
+                        "displayName" : "Fitz Elliott",
+                        "isAuthenticatedUser" : true,
+                        "permissionId" : "17667957036718347700"
+                    },
+                    "lastModifyingUserName" : "Fitz Elliott",
+                    "published" : false,
+                    "mimeType" : "application/vnd.google-apps.document"
+                }
+            ],
+            "kind" : "drive#revisionList",
+            "etag" : "\"LUxk1DXE_0fd4yeJDIgpecr5uPA/U3foOOt7M1OyjEO9G9omVQ4w4G4\"",
+            "selfLink" : "https://www.googleapis.com/drive/v2/files/1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ/revisions"
+        },
+        "revision": {
+            "lastModifyingUser" : {
+                "displayName" : "Fitz Elliott",
+                "kind" : "drive#user",
+                "permissionId" : "17667957036718347700",
+                "isAuthenticatedUser" : true,
+                "emailAddress" : "fitz@cos.io"
+            },
+            "exportLinks" : {
+                "application/pdf" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=pdf",
+                "text/plain" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=txt",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=docx",
+                "application/epub+zip" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=epub",
+                "application/rtf" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=rtf",
+                "application/vnd.oasis.opendocument.text" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=odt",
+                "text/html" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=html",
+                "application/zip" : "https://docs.google.com/feeds/download/documents/export/Export?id=1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ&revision=1&exportFormat=zip"
+            },
+            "etag" : "\"LUxk1DXE_0fd4yeJDIgpecr5uPA/lHudfDwfTEz0RxswkJ6vUFpP4z8\"",
+            "mimeType" : "application/vnd.google-apps.document",
+            "selfLink" : "https://www.googleapis.com/drive/v2/files/1XeE-iK-SolhmYntE5gq9fVT_icHrJ2hTIEISZ6t4COQ/revisions/1",
+            "lastModifyingUserName" : "Fitz Elliott",
+            "kind" : "drive#revision",
+            "published" : false,
+            "modifiedDate" : "2017-02-24T18:36:58.041Z",
+            "id" : "1"
+        }
+    },
+    "viewable_gdoc": {
+        "metadata": {
+            "createdDate" : "2017-05-15T17:45:45.246Z",
+            "ownerNames" : [
+                "Fitz Elliott"
+            ],
+            "appDataContents" : false,
+            "alternateLink" : "https://docs.google.com/a/cos.io/document/d/1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8/edit?usp=drivesdk",
+            "mimeType" : "application/vnd.google-apps.document",
+            "explicitlyTrashed" : false,
+            "iconLink" : "https://drive-thirdparty.googleusercontent.com/16/type/application/vnd.google-apps.document",
+            "title" : "viewable_gdoc",
+            "sharingUser" : {
+                "isAuthenticatedUser" : false,
+                "emailAddress" : "fitz.elliott@gmail.com",
+                "kind" : "drive#user",
+                "permissionId" : "14130805958117813174",
+                "displayName" : "Fitz Elliott"
+            },
+            "labels" : {
+                "trashed" : false,
+                "hidden" : false,
+                "viewed" : true,
+                "restricted" : false,
+                "starred" : false
+            },
+            "userPermission" : {
+                "id" : "me",
+                "role" : "reader",
+                "kind" : "drive#permission",
+                "type" : "user",
+                "etag" : "\"_Iwf20PbJS7QPBy9REF76uRLkQo/sFn5tJwi_oV7gdwOzjpuBu5Ib28\"",
+                "selfLink" : "https://www.googleapis.com/drive/v2/files/1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8/permissions/me"
+            },
+            "exportLinks" : {
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document" : "https://docs.google.com/feeds/download/documents/export/Export?id=1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8&exportFormat=docx",
+                "text/html" : "https://docs.google.com/feeds/download/documents/export/Export?id=1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8&exportFormat=html",
+                "application/pdf" : "https://docs.google.com/feeds/download/documents/export/Export?id=1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8&exportFormat=pdf",
+                "application/zip" : "https://docs.google.com/feeds/download/documents/export/Export?id=1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8&exportFormat=zip",
+                "application/vnd.oasis.opendocument.text" : "https://docs.google.com/feeds/download/documents/export/Export?id=1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8&exportFormat=odt",
+                "application/rtf" : "https://docs.google.com/feeds/download/documents/export/Export?id=1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8&exportFormat=rtf",
+                "application/epub+zip" : "https://docs.google.com/feeds/download/documents/export/Export?id=1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8&exportFormat=epub",
+                "text/plain" : "https://docs.google.com/feeds/download/documents/export/Export?id=1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8&exportFormat=txt"
+            },
+            "shared" : true,
+            "lastModifyingUser" : {
+                "isAuthenticatedUser" : false,
+                "emailAddress" : "fitz.elliott@gmail.com",
+                "kind" : "drive#user",
+                "permissionId" : "14130805958117813174",
+                "displayName" : "Fitz Elliott"
+            },
+            "etag" : "\"_Iwf20PbJS7QPBy9REF76uRLkQo/MTQ5NDg3MDM2NTYyOQ\"",
+            "selfLink" : "https://www.googleapis.com/drive/v2/files/1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8",
+            "spaces" : [
+                "drive"
+            ],
+            "parents" : [
+                {
+                    "parentLink" : "https://www.googleapis.com/drive/v2/files/0B74RCNS4TbRVNGJwLWFacnlKdGM",
+                    "kind" : "drive#parentReference",
+                    "id" : "0B74RCNS4TbRVNGJwLWFacnlKdGM",
+                    "isRoot" : false,
+                    "selfLink" : "https://www.googleapis.com/drive/v2/files/1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8/parents/0B74RCNS4TbRVNGJwLWFacnlKdGM"
+                }
+            ],
+            "writersCanShare" : true,
+            "copyable" : true,
+            "owners" : [
+                {
+                    "emailAddress" : "fitz.elliott@gmail.com",
+                    "kind" : "drive#user",
+                    "isAuthenticatedUser" : false,
+                    "displayName" : "Fitz Elliott",
+                    "permissionId" : "14130805958117813174"
+                }
+            ],
+            "modifiedDate" : "2017-05-15T17:46:05.629Z",
+            "lastModifyingUserName" : "Fitz Elliott",
+            "embedLink" : "https://docs.google.com/a/cos.io/document/d/1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8/preview",
+            "editable" : false,
+            "id" : "1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8",
+            "kind" : "drive#file",
+            "markedViewedByMeDate" : "1970-01-01T00:00:00.000Z",
+            "capabilities" : {
+                "canCopy" : true,
+                "canEdit" : false
+            },
+            "thumbnailLink" : "https://docs.google.com/a/cos.io/feeds/vt?gd=true&id=1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8&v=1&s=AMedNnoAAAAAWRo0v0XudaVK3uVkQeUG8-VYyFN49Zne&sz=s220",
+            "version" : "58109",
+            "lastViewedByMeDate" : "2017-05-15T17:50:17.249Z",
+            "sharedWithMeDate" : "2017-05-15T17:46:34.835Z",
+            "quotaBytesUsed" : "0"
+        },
+        "revisions_error": {
+            "error": {
+                "errors": [
+                    {
+                        "reason": "userAccess",
+                        "locationType": "header",
+                        "message": "The authenticated user does not have the required access to the file 1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8",
+                        "location": "Authorization",
+                        "domain": "global"
+                    }
+                ],
+                "message": "The authenticated user does not have the required access to the file 1k05-O-4a79X4ysubQSxHow6ZhgVVEE1oM-f3hXAWvj8",
+                "code": 403
+            }
+        }
+    },
+    "commentable_gdoc": {
+        "metadata": {}
+    },
+    "editable_jpeg": {
+        "metadata": {
+            "shared" : false,
+            "capabilities" : {
+                "canCopy" : true,
+                "canEdit" : true
+            },
+            "alternateLink" : "https://drive.google.com/a/cos.io/file/d/0B74RCNS4TbRVTGs4OTNock9ma0k/view?usp=drivesdk",
+            "lastModifyingUser" : {
+                "displayName" : "Fitz Elliott",
+                "permissionId" : "17667957036718347700",
+                "isAuthenticatedUser" : true,
+                "kind" : "drive#user",
+                "emailAddress" : "fitz@cos.io"
+            },
+            "fileExtension" : "jpeg",
+            "headRevisionId" : "0B74RCNS4TbRVTitFais4VzVmQlQ4S0docGlhelk5MXE3OFJnPQ",
+            "explicitlyTrashed" : false,
+            "fileSize" : "24",
+            "modifiedByMeDate" : "2017-05-15T20:01:21.364Z",
+            "iconLink" : "https://drive-thirdparty.googleusercontent.com/16/type/application/octet-stream",
+            "webContentLink" : "https://drive.google.com/a/cos.io/uc?id=0B74RCNS4TbRVTGs4OTNock9ma0k&export=download",
+            "userPermission" : {
+                "type" : "user",
+                "role" : "owner",
+                "id" : "me",
+                "etag" : "\"_Iwf20PbJS7QPBy9REF76uRLkQo/JhOaef_gJgidSRJMOjo1GIFUDpU\"",
+                "selfLink" : "https://www.googleapis.com/drive/v2/files/0B74RCNS4TbRVTGs4OTNock9ma0k/permissions/me",
+                "kind" : "drive#permission"
+            },
+            "lastModifyingUserName" : "Fitz Elliott",
+            "ownerNames" : [
+                "Fitz Elliott"
+            ],
+            "version" : "48259",
+            "writersCanShare" : true,
+            "lastViewedByMeDate" : "2017-05-15T20:00:30.278Z",
+            "copyable" : true,
+            "title" : "editable_jpeg.jpeg",
+            "embedLink" : "https://drive.google.com/a/cos.io/file/d/0B74RCNS4TbRVTGs4OTNock9ma0k/preview?usp=drivesdk",
+            "owners" : [
+                {
+                    "kind" : "drive#user",
+                    "emailAddress" : "fitz@cos.io",
+                    "isAuthenticatedUser" : true,
+                    "permissionId" : "17667957036718347700",
+                    "displayName" : "Fitz Elliott"
+                }
+            ],
+            "markedViewedByMeDate" : "1970-01-01T00:00:00.000Z",
+            "selfLink" : "https://www.googleapis.com/drive/v2/files/0B74RCNS4TbRVTGs4OTNock9ma0k",
+            "labels" : {
+                "starred" : false,
+                "hidden" : false,
+                "restricted" : false,
+                "trashed" : false,
+                "viewed" : true
+            },
+            "id" : "0B74RCNS4TbRVTGs4OTNock9ma0k",
+            "md5Checksum" : "b7705327bf8ca279454028343d45f3ce",
+            "parents" : [
+                {
+                    "selfLink" : "https://www.googleapis.com/drive/v2/files/0B74RCNS4TbRVTGs4OTNock9ma0k/parents/0B74RCNS4TbRVNGJwLWFacnlKdGM",
+                    "parentLink" : "https://www.googleapis.com/drive/v2/files/0B74RCNS4TbRVNGJwLWFacnlKdGM",
+                    "kind" : "drive#parentReference",
+                    "isRoot" : false,
+                    "id" : "0B74RCNS4TbRVNGJwLWFacnlKdGM"
+                }
+            ],
+            "spaces" : [
+                "drive"
+            ],
+            "kind" : "drive#file",
+            "downloadUrl" : "https://doc-0k-bs-docs.googleusercontent.com/docs/securesc/l7i1tlu42rp555c40740almu52k58sf3/8p50odb9i4jucb432pvfm7lfuug7tj21/1494878400000/17667957036718347700/17667957036718347700/0B74RCNS4TbRVTGs4OTNock9ma0k?h=02276134969107310156&e=download&gd=true",
+            "modifiedDate" : "2017-05-15T20:01:21.364Z",
+            "quotaBytesUsed" : "24",
+            "originalFilename" : "editable_jpeg.jpeg",
+            "editable" : true,
+            "mimeType" : "application/octet-stream",
+            "etag" : "\"_Iwf20PbJS7QPBy9REF76uRLkQo/MTQ5NDg3ODQ4MTM2NA\"",
+            "createdDate" : "2017-03-13T16:22:39.007Z",
+            "appDataContents" : false
+        },
+        "revision": {
+            "published" : false,
+            "etag" : "\"LUxk1DXE_0fd4yeJDIgpecr5uPA/178AcdJuH_nwqx-A-gtOqBTgFk8\"",
+            "kind" : "drive#revision",
+            "originalFilename" : "woof",
+            "lastModifyingUser" : {
+                "emailAddress" : "fitz@cos.io",
+                "isAuthenticatedUser" : true,
+                "displayName" : "Fitz Elliott",
+                "permissionId" : "17667957036718347700",
+                "kind" : "drive#user"
+            },
+            "id" : "0B74RCNS4TbRVTitFais4VzVmQlQ4S0docGlhelk5MXE3OFJnPQ",
+            "fileSize" : "24",
+            "modifiedDate" : "2017-05-15T20:00:30.278Z",
+            "mimeType" : "application/octet-stream",
+            "lastModifyingUserName" : "Fitz Elliott",
+            "md5Checksum" : "b7705327bf8ca279454028343d45f3ce",
+            "downloadUrl" : "https://doc-0k-bs-docs.googleusercontent.com/docs/securesc/l7i1tlu42rp555c40740almu52k58sf3/2o2i1vilnakajd9fsh4d3lq8d1ant01g/1495483200000/17667957036718347700/17667957036718347700/0B74RCNS4TbRVTGs4OTNock9ma0k?rid=0B74RCNS4TbRVTitFais4VzVmQlQ4S0docGlhelk5MXE3OFJnPQ&h=02276134969107310156&e=download&gd=true",
+            "pinned" : true,
+            "selfLink" : "https://www.googleapis.com/drive/v2/files/0B74RCNS4TbRVTGs4OTNock9ma0k/revisions/0B74RCNS4TbRVTitFais4VzVmQlQ4S0docGlhelk5MXE3OFJnPQ"
+        }
+    },
+    "viewable_jpeg": {
+        "metadata": {
+            "lastModifyingUser" : {
+                "isAuthenticatedUser" : false,
+                "displayName" : "Fitz Elliott",
+                "emailAddress" : "fitz.elliott@gmail.com",
+                "permissionId" : "14130805958117813174",
+                "kind" : "drive#user"
+            },
+            "labels" : {
+                "viewed" : true,
+                "hidden" : false,
+                "starred" : false,
+                "trashed" : false,
+                "restricted" : false
+            },
+            "alternateLink" : "https://drive.google.com/a/cos.io/file/d/0B5RhExds5_WHYnp6Um9fOGpwVVU/view?usp=drivesdk",
+            "version" : "58119",
+            "mimeType" : "text/plain",
+            "thumbnailLink" : "https://lh5.googleusercontent.com/w8fu-Im3cwup-k_B3lz5yVsxM6SSISeiVR0h6vochLOQiFKuixc_vvWRr46iCTkHXb-Bpg=s220",
+            "kind" : "drive#file",
+            "owners" : [
+                {
+                    "kind" : "drive#user",
+                    "permissionId" : "14130805958117813174",
+                    "emailAddress" : "fitz.elliott@gmail.com",
+                    "displayName" : "Fitz Elliott",
+                    "isAuthenticatedUser" : false
+                }
+            ],
+            "writersCanShare" : true,
+            "webContentLink" : "https://drive.google.com/a/cos.io/uc?id=0B5RhExds5_WHYnp6Um9fOGpwVVU&export=download",
+            "copyable" : true,
+            "spaces" : [
+                "drive"
+            ],
+            "sharedWithMeDate" : "2017-05-15T17:50:43.573Z",
+            "etag" : "\"_Iwf20PbJS7QPBy9REF76uRLkQo/MTQ5NDg3MDY0MzU3MQ\"",
+            "lastModifyingUserName" : "Fitz Elliott",
+            "createdDate" : "2017-05-15T17:50:23.253Z",
+            "headRevisionId" : "0B5RhExds5_WHdkJWc0dZS2pZVk1SOTd1bVlydktHbVBJSEd3PQ",
+            "iconLink" : "https://drive-thirdparty.googleusercontent.com/16/type/text/plain",
+            "lastViewedByMeDate" : "2017-05-15T17:50:53.135Z",
+            "markedViewedByMeDate" : "1970-01-01T00:00:00.000Z",
+            "id" : "0B5RhExds5_WHYnp6Um9fOGpwVVU",
+            "explicitlyTrashed" : false,
+            "downloadUrl" : "https://doc-00-78-docs.googleusercontent.com/docs/securesc/l7i1tlu42rp555c40740almu52k58sf3/sso0ksodpgkj6uka1v2of0ms11dtguv7/1494878400000/14130805958117813174/17667957036718347700/0B5RhExds5_WHYnp6Um9fOGpwVVU?h=02276134969107310156&e=download&gd=true",
+            "capabilities" : {
+                "canCopy" : true,
+                "canEdit" : false
+            },
+            "md5Checksum" : "8219a2180f96d8e85092a4fea17445d4",
+            "appDataContents" : false,
+            "quotaBytesUsed" : "0",
+            "fileSize" : "30",
+            "modifiedDate" : "2017-05-15T17:50:43.571Z",
+            "originalFilename" : "viewable_jpeg.jpeg",
+            "selfLink" : "https://www.googleapis.com/drive/v2/files/0B5RhExds5_WHYnp6Um9fOGpwVVU",
+            "userPermission" : {
+                "type" : "user",
+                "selfLink" : "https://www.googleapis.com/drive/v2/files/0B5RhExds5_WHYnp6Um9fOGpwVVU/permissions/me",
+                "role" : "reader",
+                "kind" : "drive#permission",
+                "id" : "me",
+                "etag" : "\"_Iwf20PbJS7QPBy9REF76uRLkQo/eimdML0wdpTxibfYHooVAmGWumk\""
+            },
+            "editable" : false,
+            "ownerNames" : [
+                "Fitz Elliott"
+            ],
+            "fileExtension" : "jpeg",
+            "shared" : true,
+            "sharingUser" : {
+                "permissionId" : "14130805958117813174",
+                "emailAddress" : "fitz.elliott@gmail.com",
+                "kind" : "drive#user",
+                "displayName" : "Fitz Elliott",
+                "isAuthenticatedUser" : false
+            },
+            "parents" : [
+                {
+                    "selfLink" : "https://www.googleapis.com/drive/v2/files/0B5RhExds5_WHYnp6Um9fOGpwVVU/parents/0B74RCNS4TbRVNGJwLWFacnlKdGM",
+                    "isRoot" : false,
+                    "kind" : "drive#parentReference",
+                    "parentLink" : "https://www.googleapis.com/drive/v2/files/0B74RCNS4TbRVNGJwLWFacnlKdGM",
+                    "id" : "0B74RCNS4TbRVNGJwLWFacnlKdGM"
+                }
+            ],
+            "embedLink" : "https://drive.google.com/a/cos.io/file/d/0B5RhExds5_WHYnp6Um9fOGpwVVU/preview?usp=drivesdk",
+            "title" : "viewable_jpeg.jpeg"
+        }
+    },
+    "commentable_jpeg": {
+        "metadata": {}
+    }
+}

--- a/tests/providers/googledrive/test_provider.py
+++ b/tests/providers/googledrive/test_provider.py
@@ -199,67 +199,7 @@ class TestValidatePath:
         assert wb_path_v1 == wb_path_v0
 
 
-class TestCRUD:
-
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_download_drive(self, provider):
-        body = b'we love you conrad'
-        item = fixtures.list_file['items'][0]
-        path = WaterButlerPath('/birdie.jpg', _ids=(provider.folder['id'], item['id']))
-
-        download_file_url = item['downloadUrl']
-        metadata_url = provider.build_url('files', path.identifier)
-
-        aiohttpretty.register_json_uri('GET', metadata_url, body=item)
-        aiohttpretty.register_uri('GET', download_file_url, body=body, auto_length=True)
-
-        result = await provider.download(path)
-
-        content = await result.read()
-        assert content == body
-
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_download_drive_revision(self, provider):
-        revision = 'oldest'
-        body = b'we love you conrad'
-        item = fixtures.list_file['items'][0]
-        path = WaterButlerPath('/birdie.jpg', _ids=(provider.folder['id'], item['id']))
-
-        download_file_url = item['downloadUrl']
-        metadata_url = provider.build_url('files', path.identifier)
-        revision_url = provider.build_url('files', item['id'], 'revisions', revision)
-
-        aiohttpretty.register_json_uri('GET', revision_url, body=item)
-        aiohttpretty.register_json_uri('GET', metadata_url, body=item)
-        aiohttpretty.register_uri('GET', download_file_url, body=body, auto_length=True)
-
-        result = await provider.download(path, revision=revision)
-        content = await result.read()
-
-        assert content == body
-
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_download_docs(self, provider):
-        body = b'we love you conrad'
-        item = fixtures.docs_file_metadata
-        path = WaterButlerPath('/birdie.jpg', _ids=(provider.folder['id'], item['id']))
-
-        metadata_url = provider.build_url('files', path.identifier)
-        revisions_url = provider.build_url('files', item['id'], 'revisions')
-        download_file_url = item['exportLinks']['application/vnd.openxmlformats-officedocument.wordprocessingml.document']
-
-        aiohttpretty.register_json_uri('GET', metadata_url, body=item)
-        aiohttpretty.register_uri('GET', download_file_url, body=body, auto_length=True)
-        aiohttpretty.register_json_uri('GET', revisions_url, body={'items': [{'id': 'foo'}]})
-
-        result = await provider.download(path)
-        assert result.name == 'version-test.docx'
-
-        content = await result.read()
-        assert content == body
+class TestUpload:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -347,6 +287,9 @@ class TestCRUD:
         expected = GoogleDriveFileMetadata(item, path)
         assert result == expected
 
+
+class TestDelete:
+
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_delete(self, provider):
@@ -387,6 +330,69 @@ class TestCRUD:
     async def test_delete_not_existing(self, provider):
         with pytest.raises(exceptions.NotFoundError):
             await provider.delete(WaterButlerPath('/foobar/'))
+
+
+class TestDownload:
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_drive(self, provider):
+        body = b'we love you conrad'
+        item = fixtures.list_file['items'][0]
+        path = WaterButlerPath('/birdie.jpg', _ids=(provider.folder['id'], item['id']))
+
+        download_file_url = item['downloadUrl']
+        metadata_url = provider.build_url('files', path.identifier)
+
+        aiohttpretty.register_json_uri('GET', metadata_url, body=item)
+        aiohttpretty.register_uri('GET', download_file_url, body=body, auto_length=True)
+
+        result = await provider.download(path)
+
+        content = await result.read()
+        assert content == body
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_drive_revision(self, provider):
+        revision = 'oldest'
+        body = b'we love you conrad'
+        item = fixtures.list_file['items'][0]
+        path = WaterButlerPath('/birdie.jpg', _ids=(provider.folder['id'], item['id']))
+
+        download_file_url = item['downloadUrl']
+        metadata_url = provider.build_url('files', path.identifier)
+        revision_url = provider.build_url('files', item['id'], 'revisions', revision)
+
+        aiohttpretty.register_json_uri('GET', revision_url, body=item)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=item)
+        aiohttpretty.register_uri('GET', download_file_url, body=body, auto_length=True)
+
+        result = await provider.download(path, revision=revision)
+        content = await result.read()
+
+        assert content == body
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_docs(self, provider):
+        body = b'we love you conrad'
+        item = fixtures.docs_file_metadata
+        path = WaterButlerPath('/birdie.jpg', _ids=(provider.folder['id'], item['id']))
+
+        metadata_url = provider.build_url('files', path.identifier)
+        revisions_url = provider.build_url('files', item['id'], 'revisions')
+        download_file_url = item['exportLinks']['application/vnd.openxmlformats-officedocument.wordprocessingml.document']
+
+        aiohttpretty.register_json_uri('GET', metadata_url, body=item)
+        aiohttpretty.register_uri('GET', download_file_url, body=body, auto_length=True)
+        aiohttpretty.register_json_uri('GET', revisions_url, body={'items': [{'id': 'foo'}]})
+
+        result = await provider.download(path)
+        assert result.name == 'version-test.docx'
+
+        content = await result.read()
+        assert content == body
 
 
 class TestMetadata:

--- a/tests/providers/googledrive/test_provider.py
+++ b/tests/providers/googledrive/test_provider.py
@@ -1,3 +1,4 @@
+import copy
 import pytest
 
 import io
@@ -16,6 +17,7 @@ from waterbutler.providers.googledrive.provider import GoogleDrivePath
 from waterbutler.providers.googledrive.metadata import GoogleDriveRevision
 from waterbutler.providers.googledrive.metadata import GoogleDriveFileMetadata
 from waterbutler.providers.googledrive.metadata import GoogleDriveFolderMetadata
+from waterbutler.providers.googledrive.metadata import GoogleDriveFileRevisionMetadata
 
 from tests.providers.googledrive import fixtures
 
@@ -333,69 +335,394 @@ class TestDelete:
 
 
 class TestDownload:
+    """Google Docs (incl. Google Sheets, Google Slides, etc.) require extra API calls and use a
+    different branch for downloading/exporting files than non-GDoc files.  For brevity's sake
+    our non-gdoc test files are called jpegs, though it could stand for any type of file.
+
+    We want to test all the permutations of:
+
+    * editability: editable vs. viewable files
+    * file type: Google doc vs. non-Google Doc (e.g. jpeg)
+    * revision parameter: non, valid, invalid, and magic
+
+    Non-editable (viewable) GDocs do not support revisions, so the good and bad revisions tests
+    are the same.  Both should 404.
+
+    The notion of a GDOC_GOOD_REVISION being the same as a JPEG_BAD_REVISION and vice-versa is an
+    unnecessary flourish for testing purposes.  I'm only including it to remind developers that
+    GDoc revisions look very different from non-GDoc revisions in production.
+    """
+
+    GDOC_GOOD_REVISION = '1'
+    GDOC_BAD_REVISION = '0B74RCNS4TbRVTitFais4VzVmQlQ4S0docGlhelk5MXE3OFJnPQ'
+    JPEG_GOOD_REVISION = GDOC_BAD_REVISION
+    JPEG_BAD_REVISION = GDOC_GOOD_REVISION
+    MAGIC_REVISION = '"LUxk1DXE_0fd4yeJDIgpecr5uPA/MTQ5NTExOTgxMzgzOQ"{}'.format(
+        ds.DRIVE_IGNORE_VERSION)
+
+    GDOC_EXPORT_MIME_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_download_drive(self, provider):
-        body = b'we love you conrad'
-        item = fixtures.list_file['items'][0]
-        path = WaterButlerPath('/birdie.jpg', _ids=(provider.folder['id'], item['id']))
+    async def test_download_editable_gdoc_no_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_gdoc']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_gdoc',
+            _ids=['1', '2', metadata_body['id']]
+        )
 
-        download_file_url = item['downloadUrl']
+        metadata_query = provider._build_query(path.identifier)
         metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
 
-        aiohttpretty.register_json_uri('GET', metadata_url, body=item)
-        aiohttpretty.register_uri('GET', download_file_url, body=body, auto_length=True)
+        revisions_body = fixtures.sharing['editable_gdoc']['revisions']
+        revisions_url = provider.build_url('files', metadata_body['id'], 'revisions')
+        aiohttpretty.register_json_uri('GET', revisions_url, body=revisions_body)
+
+        file_content = b'we love you conrad'
+        download_file_url = metadata_body['exportLinks'][self.GDOC_EXPORT_MIME_TYPE]
+        aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
+
+        result = await provider.download(path)
+        assert result.name == 'editable_gdoc.docx'
+
+        content = await result.read()
+        assert content == file_content
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+        assert aiohttpretty.has_call(method='GET', uri=revisions_url)
+        assert aiohttpretty.has_call(method='GET', uri=download_file_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_editable_gdoc_good_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_gdoc']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_gdoc',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        revision_body = fixtures.sharing['editable_gdoc']['revision']
+        revision_url = provider.build_url('files', metadata_body['id'],
+                                          'revisions', self.GDOC_GOOD_REVISION)
+        aiohttpretty.register_json_uri('GET', revision_url, body=revision_body)
+
+        file_content = b'we love you conrad'
+        download_file_url = revision_body['exportLinks'][self.GDOC_EXPORT_MIME_TYPE]
+        aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
+
+        result = await provider.download(path, revision=self.GDOC_GOOD_REVISION)
+        assert result.name == 'editable_gdoc.docx'
+
+        content = await result.read()
+        assert content == file_content
+        assert aiohttpretty.has_call(method='GET', uri=revision_url)
+        assert aiohttpretty.has_call(method='GET', uri=download_file_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_editable_gdoc_bad_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_gdoc']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_gdoc',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        no_such_revision_error = fixtures.make_no_such_revision_error(self.GDOC_BAD_REVISION)
+        revision_url = provider.build_url('files', metadata_body['id'],
+                                          'revisions', self.GDOC_BAD_REVISION)
+        aiohttpretty.register_json_uri('GET', revision_url, status=404, body=no_such_revision_error)
+
+        with pytest.raises(exceptions.NotFoundError) as e:
+            await provider.download(path, revision=self.GDOC_BAD_REVISION)
+
+        assert e.value.code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_editable_gdoc_magic_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_gdoc']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_gdoc',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
+        metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
+
+        revisions_body = fixtures.sharing['editable_gdoc']['revisions']
+        revisions_url = provider.build_url('files', metadata_body['id'], 'revisions')
+        aiohttpretty.register_json_uri('GET', revisions_url, body=revisions_body)
+
+        file_content = b'we love you conrad'
+        download_file_url = metadata_body['exportLinks'][self.GDOC_EXPORT_MIME_TYPE]
+        aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
+
+        result = await provider.download(path, revision=self.MAGIC_REVISION)
+        assert result.name == 'editable_gdoc.docx'
+
+        content = await result.read()
+        assert content == file_content
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+        assert aiohttpretty.has_call(method='GET', uri=revisions_url)
+        assert aiohttpretty.has_call(method='GET', uri=download_file_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_viewable_gdoc_no_revision(self, provider):
+        metadata_body = fixtures.sharing['viewable_gdoc']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/viewaable_gdoc',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
+        metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
+
+        file_content = b'we love you conrad'
+        download_file_url = metadata_body['exportLinks'][self.GDOC_EXPORT_MIME_TYPE]
+        aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
+
+        result = await provider.download(path)
+        assert result.name == 'viewable_gdoc.docx'
+
+        content = await result.read()
+        assert content == file_content
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+        assert aiohttpretty.has_call(method='GET', uri=download_file_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_viewable_gdoc_bad_revision(self, provider):
+        metadata_body = fixtures.sharing['viewable_gdoc']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/viewable_gdoc',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        unauthorized_error = fixtures.make_unauthorized_file_access_error(metadata_body['id'])
+        revision_url = provider.build_url('files', metadata_body['id'],
+                                          'revisions', self.GDOC_BAD_REVISION)
+        aiohttpretty.register_json_uri('GET', revision_url, status=404, body=unauthorized_error)
+
+        with pytest.raises(exceptions.NotFoundError) as e:
+            await provider.download(path, revision=self.GDOC_BAD_REVISION)
+
+        assert e.value.code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_viewable_gdoc_magic_revision(self, provider):
+        metadata_body = fixtures.sharing['viewable_gdoc']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/viewable_gdoc',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
+        metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
+
+        file_content = b'we love you conrad'
+        download_file_url = metadata_body['exportLinks'][self.GDOC_EXPORT_MIME_TYPE]
+        aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
+
+        result = await provider.download(path, revision=self.MAGIC_REVISION)
+        assert result.name == 'viewable_gdoc.docx'
+
+        content = await result.read()
+        assert content == file_content
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+        assert aiohttpretty.has_call(method='GET', uri=download_file_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_editable_jpeg_no_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_jpeg']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_jpeg.jpeg',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
+        metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
+
+        file_content = b'we love you conrad'
+        download_file_url = metadata_body['downloadUrl']
+        aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
 
         result = await provider.download(path)
 
         content = await result.read()
-        assert content == body
+        assert content == file_content
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+        assert aiohttpretty.has_call(method='GET', uri=download_file_url)
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_download_drive_revision(self, provider):
-        revision = 'oldest'
-        body = b'we love you conrad'
-        item = fixtures.list_file['items'][0]
-        path = WaterButlerPath('/birdie.jpg', _ids=(provider.folder['id'], item['id']))
+    async def test_download_editable_jpeg_good_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_jpeg']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_jpeg.jpeg',
+            _ids=['1', '2', metadata_body['id']]
+        )
 
-        download_file_url = item['downloadUrl']
-        metadata_url = provider.build_url('files', path.identifier)
-        revision_url = provider.build_url('files', item['id'], 'revisions', revision)
+        revision_body = fixtures.sharing['editable_jpeg']['revision']
+        revision_url = provider.build_url('files', metadata_body['id'],
+                                          'revisions', self.JPEG_GOOD_REVISION)
+        aiohttpretty.register_json_uri('GET', revision_url, body=revision_body)
 
-        aiohttpretty.register_json_uri('GET', revision_url, body=item)
-        aiohttpretty.register_json_uri('GET', metadata_url, body=item)
-        aiohttpretty.register_uri('GET', download_file_url, body=body, auto_length=True)
+        file_content = b'we love you conrad'
+        download_file_url = revision_body['downloadUrl']
+        aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
 
-        result = await provider.download(path, revision=revision)
+        result = await provider.download(path, revision=self.JPEG_GOOD_REVISION)
+
         content = await result.read()
-
-        assert content == body
+        assert content == file_content
+        assert aiohttpretty.has_call(method='GET', uri=revision_url)
+        assert aiohttpretty.has_call(method='GET', uri=download_file_url)
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_download_docs(self, provider):
-        body = b'we love you conrad'
-        item = fixtures.docs_file_metadata
-        path = WaterButlerPath('/birdie.jpg', _ids=(provider.folder['id'], item['id']))
+    async def test_download_editable_jpeg_bad_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_jpeg']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_jpeg.jpeg',
+            _ids=['1', '2', metadata_body['id']]
+        )
 
+        no_such_revision_error = fixtures.make_no_such_revision_error(self.JPEG_BAD_REVISION)
+        revision_url = provider.build_url('files', metadata_body['id'],
+                                          'revisions', self.JPEG_BAD_REVISION)
+        aiohttpretty.register_json_uri('GET', revision_url, status=404, body=no_such_revision_error)
+
+        with pytest.raises(exceptions.NotFoundError) as e:
+            await provider.download(path, revision=self.JPEG_BAD_REVISION)
+
+        assert e.value.code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_editable_jpeg_magic_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_jpeg']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_jpeg.jpeg',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
         metadata_url = provider.build_url('files', path.identifier)
-        revisions_url = provider.build_url('files', item['id'], 'revisions')
-        download_file_url = item['exportLinks']['application/vnd.openxmlformats-officedocument.wordprocessingml.document']
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
 
-        aiohttpretty.register_json_uri('GET', metadata_url, body=item)
-        aiohttpretty.register_uri('GET', download_file_url, body=body, auto_length=True)
-        aiohttpretty.register_json_uri('GET', revisions_url, body={'items': [{'id': 'foo'}]})
+        file_content = b'we love you conrad'
+        download_file_url = metadata_body['downloadUrl']
+        aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
+
+        result = await provider.download(path, revision=self.MAGIC_REVISION)
+
+        content = await result.read()
+        assert content == file_content
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+        assert aiohttpretty.has_call(method='GET', uri=download_file_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_viewable_jpeg_no_revision(self, provider):
+        metadata_body = fixtures.sharing['viewable_jpeg']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/viewaable_jpeg.jpeg',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
+        metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
+
+        file_content = b'we love you conrad'
+        download_file_url = metadata_body['downloadUrl']
+        aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
 
         result = await provider.download(path)
-        assert result.name == 'version-test.docx'
 
         content = await result.read()
-        assert content == body
+        assert content == file_content
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+        assert aiohttpretty.has_call(method='GET', uri=download_file_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_viewable_jpeg_bad_revision(self, provider):
+        metadata_body = fixtures.sharing['viewable_jpeg']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/viewable_jpeg.jpeg',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        unauthorized_error = fixtures.make_unauthorized_file_access_error(metadata_body['id'])
+        revision_url = provider.build_url('files', metadata_body['id'],
+                                          'revisions', self.JPEG_BAD_REVISION)
+        aiohttpretty.register_json_uri('GET', revision_url, status=404, body=unauthorized_error)
+
+        with pytest.raises(exceptions.NotFoundError) as e:
+            await provider.download(path, revision=self.JPEG_BAD_REVISION)
+
+        assert e.value.code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_viewable_jpeg_magic_revision(self, provider):
+        metadata_body = fixtures.sharing['viewable_jpeg']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/viewable_jpeg.jpeg',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
+        metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
+
+        file_content = b'we love you conrad'
+        download_file_url = metadata_body['downloadUrl']
+        aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
+
+        result = await provider.download(path, revision=self.MAGIC_REVISION)
+
+        content = await result.read()
+        assert content == file_content
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+        assert aiohttpretty.has_call(method='GET', uri=download_file_url)
 
 
 class TestMetadata:
+    """Google Docs (incl. Google Sheets, Google Slides, etc.) require extra API calls and use a
+    different branch for fetching metadata about files than non-GDoc files.  For brevity's sake
+    our non-gdoc test files are called jpegs, though it could stand for any type of file.
+
+    We want to test all the permutations of:
+
+    * editability: editable vs. viewable files
+    * file type: Google doc vs. non-Google Doc (e.g. jpeg)
+    * revision parameter: non, valid, invalid, and magic
+
+    Non-editable (viewable) GDocs do not support revisions, so the good and bad revisions tests
+    are the same.  Both should 404.
+
+    The notion of a GDOC_GOOD_REVISION being the same as a JPEG_BAD_REVISION and vice-versa is an
+    unnecessary flourish for testing purposes.  I'm only including it to remind developers that
+    GDoc revisions look very different from non-GDoc revisions in production.
+    """
+
+    GDOC_GOOD_REVISION = '1'
+    GDOC_BAD_REVISION = '0B74RCNS4TbRVTitFais4VzVmQlQ4S0docGlhelk5MXE3OFJnPQ'
+    JPEG_GOOD_REVISION = GDOC_BAD_REVISION
+    JPEG_BAD_REVISION = GDOC_GOOD_REVISION
+    MAGIC_REVISION = '"LUxk1DXE_0fd4yeJDIgpecr5uPA/MTQ5NTExOTgxMzgzOQ"{}'.format(
+        ds.DRIVE_IGNORE_VERSION)
+
+    GDOC_EXPORT_MIME_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -413,7 +740,6 @@ class TestMetadata:
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_metadata_file_root_not_found(self, provider):
-        path = '/birdie.jpg'
         path = WaterButlerPath('/birdie.jpg', _ids=(provider.folder['id'], None))
 
         with pytest.raises(exceptions.MetadataError) as exc_info:
@@ -439,19 +765,6 @@ class TestMetadata:
         expected = GoogleDriveFileMetadata(item, path)
         assert result == expected
         assert aiohttpretty.has_call(method='GET', uri=url)
-
-    # @pytest.mark.asyncio
-    # @pytest.mark.aiohttpretty
-    # async def test_metadata_file_nested_not_child(self, provider):
-    #     path = '/ed/sullivan/show.mp3'
-    #     query = provider._build_query(provider.folder['id'], title='ed')
-    #     url = provider.build_url('files', q=query, alt='json')
-    #     aiohttpretty.register_json_uri('GET', url, body={'items': []})
-
-    #     with pytest.raises(exceptions.MetadataError) as exc_info:
-    #         await provider.metadata(path)
-
-    #     assert exc_info.value.code == 404
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -515,6 +828,292 @@ class TestMetadata:
         assert result == [expected]
         assert aiohttpretty.has_call(method='GET', uri=url)
 
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_editable_gdoc_no_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_gdoc']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_gdoc',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
+        metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
+
+        revisions_body = fixtures.sharing['editable_gdoc']['revisions']
+        revisions_url = provider.build_url('files', metadata_body['id'], 'revisions')
+        aiohttpretty.register_json_uri('GET', revisions_url, body=revisions_body)
+
+        result = await provider.metadata(path)
+
+        local_metadata = copy.deepcopy(metadata_body)
+        local_metadata['version'] = revisions_body['items'][-1]['id']
+        expected = GoogleDriveFileMetadata(local_metadata, path)
+        assert result == expected
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+        assert aiohttpretty.has_call(method='GET', uri=revisions_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_editable_gdoc_good_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_gdoc']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_gdoc',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        revision_body = fixtures.sharing['editable_gdoc']['revision']
+        revision_url = provider.build_url('files', metadata_body['id'],
+                                          'revisions', self.GDOC_GOOD_REVISION)
+        aiohttpretty.register_json_uri('GET', revision_url, body=revision_body)
+
+        result = await provider.metadata(path, revision=self.GDOC_GOOD_REVISION)
+
+        expected = GoogleDriveFileRevisionMetadata(revision_body, path)
+        assert result == expected
+        assert aiohttpretty.has_call(method='GET', uri=revision_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_editable_gdoc_bad_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_gdoc']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_gdoc',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        no_such_revision_error = fixtures.make_no_such_revision_error(self.GDOC_BAD_REVISION)
+        revision_url = provider.build_url('files', metadata_body['id'],
+                                          'revisions', self.GDOC_BAD_REVISION)
+        aiohttpretty.register_json_uri('GET', revision_url, status=404, body=no_such_revision_error)
+
+        with pytest.raises(exceptions.NotFoundError) as e:
+            await provider.metadata(path, revision=self.GDOC_BAD_REVISION)
+
+        assert e.value.code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_editable_gdoc_magic_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_gdoc']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_gdoc',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
+        metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
+
+        revisions_body = fixtures.sharing['editable_gdoc']['revisions']
+        revisions_url = provider.build_url('files', metadata_body['id'], 'revisions')
+        aiohttpretty.register_json_uri('GET', revisions_url, body=revisions_body)
+
+        result = await provider.metadata(path, revision=self.MAGIC_REVISION)
+
+        local_metadata = copy.deepcopy(metadata_body)
+        local_metadata['version'] = revisions_body['items'][-1]['id']
+        expected = GoogleDriveFileMetadata(local_metadata, path)
+        assert result == expected
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+        assert aiohttpretty.has_call(method='GET', uri=revisions_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_viewable_gdoc_no_revision(self, provider):
+        metadata_body = fixtures.sharing['viewable_gdoc']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/viewable_gdoc',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
+        metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
+
+        result = await provider.metadata(path)
+
+        local_metadata = copy.deepcopy(metadata_body)
+        local_metadata['version'] = local_metadata['etag'] + ds.DRIVE_IGNORE_VERSION
+        expected = GoogleDriveFileMetadata(local_metadata, path)
+        assert result == expected
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_viewable_gdoc_bad_revision(self, provider):
+        metadata_body = fixtures.sharing['viewable_gdoc']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/viewable_gdoc',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        unauthorized_error = fixtures.make_unauthorized_file_access_error(metadata_body['id'])
+        revision_url = provider.build_url('files', metadata_body['id'],
+                                          'revisions', self.GDOC_BAD_REVISION)
+        aiohttpretty.register_json_uri('GET', revision_url, status=404, body=unauthorized_error)
+
+        with pytest.raises(exceptions.NotFoundError) as e:
+            await provider.metadata(path, revision=self.GDOC_BAD_REVISION)
+
+        assert e.value.code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_viewable_gdoc_magic_revision(self, provider):
+        metadata_body = fixtures.sharing['viewable_gdoc']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/viewable_gdoc',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
+        metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
+
+        result = await provider.metadata(path, revision=self.MAGIC_REVISION)
+
+        local_metadata = copy.deepcopy(metadata_body)
+        local_metadata['version'] = local_metadata['etag'] + ds.DRIVE_IGNORE_VERSION
+        expected = GoogleDriveFileMetadata(local_metadata, path)
+        assert result == expected
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_editable_jpeg_no_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_jpeg']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_jpeg.jpeg',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
+        metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
+
+        result = await provider.metadata(path)
+
+        expected = GoogleDriveFileMetadata(metadata_body, path)
+        assert result == expected
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_editable_jpeg_good_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_jpeg']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_jpeg.jpeg',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        revision_body = fixtures.sharing['editable_jpeg']['revision']
+        revision_url = provider.build_url('files', metadata_body['id'],
+                                          'revisions', self.JPEG_GOOD_REVISION)
+        aiohttpretty.register_json_uri('GET', revision_url, body=revision_body)
+
+        result = await provider.metadata(path, revision=self.JPEG_GOOD_REVISION)
+
+        expected = GoogleDriveFileRevisionMetadata(revision_body, path)
+        assert result == expected
+        assert aiohttpretty.has_call(method='GET', uri=revision_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_editable_jpeg_bad_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_jpeg']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_jpeg.jpeg',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        no_such_revision_error = fixtures.make_no_such_revision_error(self.JPEG_BAD_REVISION)
+        revision_url = provider.build_url('files', metadata_body['id'],
+                                          'revisions', self.JPEG_BAD_REVISION)
+        aiohttpretty.register_json_uri('GET', revision_url, status=404, body=no_such_revision_error)
+
+        with pytest.raises(exceptions.NotFoundError) as e:
+            await provider.metadata(path, revision=self.JPEG_BAD_REVISION)
+
+        assert e.value.code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_editable_jpeg_magic_revision(self, provider):
+        metadata_body = fixtures.sharing['editable_jpeg']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/editable_jpeg.jpeg',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
+        metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
+
+        result = await provider.metadata(path, revision=self.MAGIC_REVISION)
+
+        expected = GoogleDriveFileMetadata(metadata_body, path)
+        assert result == expected
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_viewable_jpeg_no_revision(self, provider):
+        metadata_body = fixtures.sharing['viewable_jpeg']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/viewaable_jpeg.jpeg',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
+        metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
+
+        result = await provider.metadata(path)
+
+        expected = GoogleDriveFileMetadata(metadata_body, path)
+        assert result == expected
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_viewable_jpeg_bad_revision(self, provider):
+        metadata_body = fixtures.sharing['viewable_jpeg']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/viewable_jpeg.jpeg',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        unauthorized_error = fixtures.make_unauthorized_file_access_error(metadata_body['id'])
+        revision_url = provider.build_url('files', metadata_body['id'],
+                                          'revisions', self.JPEG_BAD_REVISION)
+        aiohttpretty.register_json_uri('GET', revision_url, status=404, body=unauthorized_error)
+
+        with pytest.raises(exceptions.NotFoundError) as e:
+            await provider.metadata(path, revision=self.JPEG_BAD_REVISION)
+
+        assert e.value.code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_viewable_jpeg_magic_revision(self, provider):
+        metadata_body = fixtures.sharing['viewable_jpeg']['metadata']
+        path = GoogleDrivePath(
+            '/sharing/viewable_jpeg.jpeg',
+            _ids=['1', '2', metadata_body['id']]
+        )
+
+        metadata_query = provider._build_query(path.identifier)
+        metadata_url = provider.build_url('files', path.identifier)
+        aiohttpretty.register_json_uri('GET', metadata_url, body=metadata_body)
+
+        result = await provider.metadata(path, revision=self.MAGIC_REVISION)
+
+        expected = GoogleDriveFileMetadata(metadata_body, path)
+        assert result == expected
+        assert aiohttpretty.has_call(method='GET', uri=metadata_url)
+
 
 class TestRevisions:
 
@@ -528,7 +1127,6 @@ class TestRevisions:
         aiohttpretty.register_json_uri('GET', revisions_url, body=fixtures.revisions_list)
 
         result = await provider.revisions(path)
-
         expected = [
             GoogleDriveRevision(each)
             for each in fixtures.revisions_list['items']
@@ -547,11 +1145,32 @@ class TestRevisions:
         aiohttpretty.register_json_uri('GET', revisions_url, body=fixtures.revisions_list_empty)
 
         result = await provider.revisions(path)
-
         expected = [
             GoogleDriveRevision({
                 'modifiedDate': item['modifiedDate'],
-                'id': fixtures.revisions_list_empty['etag'] + ds.DRIVE_IGNORE_VERSION,
+                'id': item['etag'] + ds.DRIVE_IGNORE_VERSION,
+            })
+        ]
+        assert result == expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_get_revisions_for_uneditable(self, provider):
+        file_fixtures = fixtures.sharing['viewable_gdoc']
+        item = file_fixtures['metadata']
+        metadata_url = provider.build_url('files', item['id'])
+        revisions_url = provider.build_url('files', item['id'], 'revisions')
+        path = WaterButlerPath('/birdie.jpg', _ids=('doesntmatter', item['id']))
+
+        aiohttpretty.register_json_uri('GET', metadata_url, body=item)
+        aiohttpretty.register_json_uri(
+            'GET', revisions_url, body=file_fixtures['revisions_error'], status=403)
+
+        result = await provider.revisions(path)
+        expected = [
+            GoogleDriveRevision({
+                'modifiedDate': item['modifiedDate'],
+                'id': item['etag'] + ds.DRIVE_IGNORE_VERSION,
             })
         ]
         assert result == expected

--- a/waterbutler/providers/googledrive/metadata.py
+++ b/waterbutler/providers/googledrive/metadata.py
@@ -16,6 +16,13 @@ class BaseGoogleDriveMetadata(metadata.BaseMetadata):
 
     @property
     def extra(self):
+        """NB: The Google Drive provider frequently fudges this value in the raw data before passing
+        it to the GoogleDrive*Metadata constructor.  The ``version`` field provided by the GDrive
+        API does not actually identify any previous versions, so we must look it up another way.
+        GDrive does not support revisions for read-only files, so those are assigned artificial
+        values to help the provider to recognize them.  See the **Revisions** section of the
+        GoogleDriveProvider docstring."""
+
         return {'revisionId': self.raw['version']}
 
 
@@ -47,6 +54,12 @@ class GoogleDriveFolderMetadata(BaseGoogleDriveMetadata, metadata.BaseFolderMeta
 
 
 class GoogleDriveFileMetadata(BaseGoogleDriveMetadata, metadata.BaseFileMetadata):
+    """The metadata for a single file on Google Drive.  This class expects a the ``raw``
+    property to be the response[1] from the GDrive v2 file metadata endpoint[2].
+
+    [1] https://developers.google.com/drive/v2/reference/files
+    [2] https://developers.google.com/drive/v2/reference/files/get
+    """
 
     @property
     def id(self):
@@ -54,7 +67,7 @@ class GoogleDriveFileMetadata(BaseGoogleDriveMetadata, metadata.BaseFileMetadata
 
     @property
     def name(self):
-        title = self.raw['title']
+        title = self._file_title
         if self.is_google_doc:
             ext = utils.get_extension(self.raw)
             title += ext
@@ -111,58 +124,32 @@ class GoogleDriveFileMetadata(BaseGoogleDriveMetadata, metadata.BaseFileMetadata
 
     @property
     def export_name(self):
-        title = self.raw['title']
+        title = self._file_title
         if self.is_google_doc:
             ext = utils.get_download_extension(self.raw)
             title += ext
         return title
 
+    @property
+    def _file_title(self):
+        return self.raw['title']
+
 
 class GoogleDriveFileRevisionMetadata(GoogleDriveFileMetadata):
-    @property
-    def id(self):
-        return self.raw['id']
+    """The metadata for a single file at a particular revision on Google Drive.  This class expects
+    the ``raw`` property to be the response[1] from the GDrive v2 revision metadata endpoint[2].
+    This response is similar to the one from the file metadata endpoint, but lacks a created date
+    and version field.  It also stores the file name of non-GDoc files in the ``originalFilename``
+    field instead of the ``title`` field.  GDocs do not include the file name at all, and must
+    derive it from the `GoogleDrivePath` object.
 
-    @property
-    def name(self):
-        title = self.raw.get('originalFilename', self._path.name)
-        if self.is_google_doc:
-            ext = utils.get_extension(self.raw)
-            title += ext
-        return title
-
-    @property
-    def path(self):
-        path = '/' + self._path.raw_path
-        if self.is_google_doc:
-            ext = utils.get_extension(self.raw)
-            path += ext
-        return path
-
-    @property
-    def materialized_path(self):
-        materialized = str(self._path)
-        if self.is_google_doc:
-            ext = utils.get_extension(self.raw)
-            materialized += ext
-        return materialized
-
-    @property
-    def size(self):
-        # Google docs(Docs,sheets, slides, etc)  don't have file size before they are exported
-        return self.raw.get('fileSize')
-
-    @property
-    def modified(self):
-        return self.raw['modifiedDate']
+    [1] https://developers.google.com/drive/v2/reference/revisions
+    [2] https://developers.google.com/drive/v2/reference/revisions/get
+    """
 
     @property
     def created_utc(self):
         return None
-
-    @property
-    def content_type(self):
-        return self.raw['mimeType']
 
     @property
     def etag(self):
@@ -170,17 +157,16 @@ class GoogleDriveFileRevisionMetadata(GoogleDriveFileMetadata):
 
     @property
     def extra(self):
+        """The metadata for a file revision doesn't contain a webView link, and a revisionId isn't
+        appropriate.  GDocs don't have an md5, non-GDocs don't need a downloadExt.
+        """
         if self.is_google_doc:
             return {'downloadExt': utils.get_download_extension(self.raw)}
         return {'md5': self.raw['md5Checksum']}
 
     @property
-    def export_name(self):
-        title = self.raw.get('originalFilename', self._path.name)
-        if self.is_google_doc:
-            ext = utils.get_download_extension(self.raw)
-            title += ext
-        return title
+    def _file_title(self):
+        return self.raw.get('originalFilename', self._path.name)
 
 
 class GoogleDriveRevision(metadata.BaseFileRevisionMetadata):

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -627,6 +627,9 @@ class GoogleDriveProvider(provider.BaseProvider):
         ``_file_metadata.revision_is_valid``: if a revision was given, was it valid? A revision is
         "valid" if it doesn't end with our sentinal string (`settings.DRIVE_IGNORE_VERSION`).
 
+        ``_file_metadata.user_role``: What role did the user possess? Helps identify other roles
+        for which revision information isn't available.
+
         :param GoogleDrivePath path: the path of the file whose metadata is being requested
         :param str revision: a string representing the ID of the revision (default: `None`)
         :param bool raw: should we return the raw response object from the GDrive API?
@@ -662,6 +665,7 @@ class GoogleDriveProvider(provider.BaseProvider):
         if revision and valid_revision:
             return GoogleDriveFileRevisionMetadata(data, path)
 
+        self.metrics.add('_file_metadata.user_role', data['userPermission']['role'])
         can_access_revisions = data['userPermission']['role'] not in ('reader', 'commenter')
         if drive_utils.is_docs_file(data):
             if can_access_revisions:

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -1,6 +1,7 @@
 import os
 import http
 import json
+import typing
 import functools
 from urllib import parse
 
@@ -53,6 +54,20 @@ class GoogleDriveProvider(provider.BaseProvider):
     * Google Drive is not really a filesystem.  Folders are actually labels, meaning a file ``foo``
       could be in two folders (ex. ``A``, ``B``) at the same time.  Deleting ``/A/foo`` will
       cause ``/B/foo`` to be deleted as well.
+
+    Revisions:
+
+    Both Google Drive and WaterButler have weird behaviors wrt file revisions.  Google docs use a
+    simple integer versioning system.  Non-Google doc files, like jpegs or text files, use strings
+    that resemble the standard Google Drive file ID format (ex.
+    ``0B74RCNS4TbRVTitFais4VzVmQlQ4S0docGlhelk5MXE3OFJnPQ``).  In addition, revision history is not
+    available for any file that the user only has view or commenting permissions for.  In the past
+    WB forged revision ids for these files by taking the etag of the file and appending a sentinel
+    value (set in `googledrive.settings.DRIVE_IGNORE_VERSION`) to the end.  If WB receives a request
+    to download a file with a revision ending with the sentinel string, we ignore the revision and
+    return the latest version instead.  The file metadata endpoint will behave the same.  A metadata
+    or download request for a readonly file with a revision value that doesn't end with the sentinel
+    value will always return a 404 Not Found.
     """
     NAME = 'googledrive'
     BASE_URL = settings.BASE_URL
@@ -161,13 +176,29 @@ class GoogleDriveProvider(provider.BaseProvider):
             data = await resp.json()
         return GoogleDriveFileMetadata(data, dest_path), dest_path.identifier is None
 
-    async def download(self, path, revision=None, range=None, **kwargs):
-        if revision and not revision.endswith(settings.DRIVE_IGNORE_VERSION):
-            metadata = await self.metadata(path, revision=revision)
-            self.metrics.add('download.got_supported_revision', True)
-        else:
-            metadata = await self.metadata(path)
-            self.metrics.add('download.got_supported_revision', False)
+    async def download(self,
+                       path: GoogleDrivePath,
+                       revision: str=None,
+                       range: typing.Tuple[int, int]=None,
+                       **kwargs):
+        """Download the file at `path`.  If `revision` is present, attempt to download that revision
+        of the file.  See **Revisions** in the class doctring for an explanation of this provider's
+        revision handling.   The actual revision handling is done in `_file_metadata()`.
+
+        Quirks::
+
+        Google docs don't have a size until they're exported, so WB must download them, then
+        re-stream them as a StringStream.
+
+        :param GoogleDrivePath path: the file to download
+        :param str revision: the id of a particular version to download
+        :param tuple(int, int) range: range of bytes to download in this request
+        :rtype: streams.ResponseStreamReader
+        :rtype: streams.StringStream
+        :returns: For GDocs, a StringStream.  All others, a ResponseStreamReader.
+        """
+
+        metadata = await self.metadata(path, revision=revision)
 
         download_resp = await self.make_request(
             'GET',
@@ -205,7 +236,7 @@ class GoogleDriveProvider(provider.BaseProvider):
     async def delete(self, path, confirm_delete=0, **kwargs):
         """Given a WaterButlerPath, delete that path
 
-        :param WaterButlerPath: Path to be deleted
+        :param GoogleDrivePath: Path to be deleted
         :param int confirm_delete: Must be 1 to confirm root folder delete
         :rtype: None
         :raises: :class:`waterbutler.core.exceptions.NotFoundError`
@@ -261,29 +292,44 @@ class GoogleDriveProvider(provider.BaseProvider):
 
         return await self._file_metadata(path, revision=revision, raw=raw)
 
-    async def revisions(self, path, **kwargs):
+    async def revisions(self, path: GoogleDrivePath, **kwargs):
+        """Returns list of revisions for the file at ``path``.
+
+        Google Drive will not allow a user to view the revision list of a file if they only have
+        view or commenting permissions.  It will return a 403 Unathorized.  If that happens, then
+        we construct a recognizable dummy revision based off of the metadata of the current file
+        version.
+
+        Note: though we explicitly support the case where the revision list is empty, I have yet to
+        see it in practice.  The current handling is based on historical behavior.
+
+        :param GoogleDrivePath path: the path of the file to fetch revisions for
+        :rtype: `list(GoogleDriveRevision)`
+        :return: list of `GoogleDriveRevision` objects representing revisions of the file
+        """
         if path.identifier is None:
             raise exceptions.NotFoundError(str(path))
 
         async with self.request(
             'GET',
             self.build_url('files', path.identifier, 'revisions'),
-            expects=(200, ),
+            expects=(200, 403, ),
             throws=exceptions.RevisionsError,
         ) as resp:
             data = await resp.json()
-        if data['items']:
+            has_revisions = resp.status == 200
+
+        if has_revisions and data['items']:
             return [
                 GoogleDriveRevision(item)
                 for item in reversed(data['items'])
             ]
 
-        metadata = await self.metadata(path, raw=True)
-
         # Use dummy ID if no revisions found
+        metadata = await self.metadata(path, raw=True)
         return [GoogleDriveRevision({
             'modifiedDate': metadata['modifiedDate'],
-            'id': data['etag'] + settings.DRIVE_IGNORE_VERSION,
+            'id': metadata['etag'] + settings.DRIVE_IGNORE_VERSION,
         })]
 
     async def create_folder(self, path, folder_precheck=True, **kwargs):
@@ -502,7 +548,26 @@ class GoogleDriveProvider(provider.BaseProvider):
                 parents.append(await p_resp.json())
         return parents
 
-    async def _handle_docs_versioning(self, path, item, raw=True):
+    async def _handle_docs_versioning(self, path: GoogleDrivePath, item: dict, raw: bool=True):
+        """Sends an extra request to GDrive to fetch revision information for Google Docs. Needed
+        because Google Docs use a different versioning system from regular files.
+
+        I've been unable to replicate the case where revisions_data['items'] is None.  I'm leaving
+        it in for now and adding a metric to see if we ever actually encounter this case.  If not,
+        we should probably remove it to simplify this method.
+
+        This method does not handle the case of read-only google docs, which will return a 403.
+        Other methods should check the ``userPermission.role`` field of the file metadata before
+        calling this.  If the value of that field is ``"reader"`` or ``"commenter"``, this method
+        will error.
+
+        :param GoogleDrivePath path: the path of the google doc to get version information for
+        :param dict item: a raw response object from the GDrive file metadata endpoint
+        :param bool raw: should we return the raw response object from the GDrive API?
+        :rtype: GoogleDriveFileMetadata
+        :rtype: dict
+        :return: a metadata for the googledoc or the raw response object from the GDrive API
+        """
         async with self.request(
             'GET',
             self.build_url('files', item['id'], 'revisions'),
@@ -510,16 +575,16 @@ class GoogleDriveProvider(provider.BaseProvider):
             throws=exceptions.RevisionsError,
         ) as resp:
             revisions_data = await resp.json()
+            has_revisions = revisions_data['items'] is not None
 
-        # Revisions are not available for some sharing configurations. If
-        # revisions list is empty, use the etag of the file plus a sentinel
-        # string as a dummy revision ID.
-        self.metrics.add('handle_docs_versioning.revisions_not_supported', not revisions_data['items'])
-        if not revisions_data['items']:
-            # If there are no revisions use etag as vid
-            item['version'] = revisions_data['etag'] + settings.DRIVE_IGNORE_VERSION
-        else:
+        # Revisions are not available for some sharing configurations. If revisions list is empty,
+        # use the etag of the file plus a sentinel string as a dummy revision ID.
+        self.metrics.add('handle_docs_versioning.empty_revision_list', not has_revisions)
+        if has_revisions:
             item['version'] = revisions_data['items'][-1]['id']
+        else:
+            # If there are no revisions use etag as vid
+            item['version'] = item['etag'] + settings.DRIVE_IGNORE_VERSION
 
         return self._serialize_item(path, item, raw=raw)
 
@@ -542,26 +607,71 @@ class GoogleDriveProvider(provider.BaseProvider):
                 built_url = resp_json.get('nextLink', None)
         return full_resp
 
-    async def _file_metadata(self, path, revision=None, raw=False):
+    async def _file_metadata(self, path: GoogleDrivePath, revision: str=None, raw: bool=False):
+        """ Returns metadata for the file identified by `path`.  If the `revision` arg is set,
+        will attempt to return metadata for the given revision of the file.  If the revision does
+        not exist, ``_file_metadata`` will throw a 404.
+
+        This method used to error with a 500 when metadata was requested for a file that the
+        authorizing user only had view or commenting permissions for.  The GDrive revisions
+        endpoint returns a 403, which was not being handled.  WB postpends a sentinel value to the
+        revisions for these files.  If a revision ending with this sentinel value is detected, this
+        method will return metadata for the latest revision of the file.  If a revision NOT ending
+        in the sentinel value is requested for a read-only file, this method will return a 404 Not
+        Found instead.
+
+        Metrics:
+
+        ``_file_metadata.got_revision``: did this request include a revision parameter?
+
+        ``_file_metadata.revision_is_valid``: if a revision was given, was it valid? A revision is
+        "valid" if it doesn't end with our sentinal string (`settings.DRIVE_IGNORE_VERSION`).
+
+        :param GoogleDrivePath path: the path of the file whose metadata is being requested
+        :param str revision: a string representing the ID of the revision (default: `None`)
+        :param bool raw: should we return the raw response object from the GDrive API?
+        :rtype: GoogleDriveFileMetadata
+        :rtype: dict
+        :return: a metadata for the googledoc or the raw response object from the GDrive API
+        """
+
+        self.metrics.add('_file_metadata.got_revision', revision is not None)
+
+        valid_revision = revision and not revision.endswith(settings.DRIVE_IGNORE_VERSION)
         if revision:
+            self.metrics.add('_file_metadata.revision_is_valid', valid_revision)
+
+        if revision and valid_revision:
             url = self.build_url('files', path.identifier, 'revisions', revision)
         else:
             url = self.build_url('files', path.identifier)
 
         async with self.request(
             'GET', url,
-            expects=(200, ),
-            throws=exceptions.MetadataError,
+            expects=(200, 403, 404, ),
+            throws=exceptions.NotFoundError,
         ) as resp:
-            data = await resp.json()
+            try:
+                data = await resp.json()
+            except:  # some 404s return a string instead of json
+                data = await resp.read()
 
-        if revision:
+        if resp.status != 200:
+            raise exceptions.NotFoundError(path)
+
+        if revision and valid_revision:
             return GoogleDriveFileRevisionMetadata(data, path)
 
+        can_access_revisions = data['userPermission']['role'] not in ('reader', 'commenter')
         if drive_utils.is_docs_file(data):
-            return await self._handle_docs_versioning(path, data, raw=raw)
+            if can_access_revisions:
+                return await self._handle_docs_versioning(path, data, raw=raw)
+            else:
+                # Revisions are not available for some sharing configurations. If revisions list is
+                # empty, use the etag of the file plus a sentinel string as a dummy revision ID.
+                data['version'] = data['etag'] + settings.DRIVE_IGNORE_VERSION
 
-        return self._serialize_item(path, data, raw=raw)
+        return data if raw else GoogleDriveFileMetadata(data, path)
 
     async def _delete_folder_contents(self, path):
         """Given a WaterButlerPath, delete all contents of folder


### PR DESCRIPTION
# Ticket 

https://openscience.atlassian.net/browse/SVCS-273

# Purpose

From the ticket:

> A user reported (see attached pdf) that she has a Google Drive file that shows up in the file browser, but when she clicks on it she gets a "File not found at Google Drive.". The problem is that when getting file metadata for GDocs, we also ask for revision metadata about the file to help construct our metadata response. Under certain permission/sharing conditions, GDrive will return a 403 Not Authorized, which we don't currently handle.

This ticket fixes this issue and cleans up a bunch of issues around Google Drive revision handling.  See the commit messages and docstrings for more details, but the new behaviors are summarized as:

* If a download or metadata request is made without a revision parameter for a file of any type or editability, WB will download or provide metadata for the latest version.

* If a download or metadata request is made and the revision ends with the sentinel value, WB will download or provide metadata  for the latest version.  This is true for all files.

* If a file is read-only (user has view or commenting permissions) and a revision is given that DOES NOT end with the sentinel value, WB will respond with a 404 Not Found. Read-only files do not have revisions.

* If a file is editable and a revision is given that DOES NOT end with the sentinel value, WB will respond with a 404 if the requested revision does not exist on Google Drive.  Otherwise, it will return the content or metadata for the file at that revision.

# Testing

See the JIRA ticket.