### PR TITLE
[SVCS-146] In GDrive, a .gdoc and a .docx with the same name don't fully register

### DIFF
--- a/tests/providers/googledrive/test_metadata.py
+++ b/tests/providers/googledrive/test_metadata.py
@@ -63,7 +63,7 @@ def test_file_metadata_docs(basepath):
     assert parsed.name == item['title'] + '.gdoc'
     assert parsed.extra == {'revisionId': item['version'], 'downloadExt': '.docx', 'webView': item['alternateLink']}
     assert parsed.is_google_doc == True
-    assert parsed.export_name == item['title'] + '.docx'
+    assert parsed.export_name == parsed.name + '.docx'
 
 
 def test_folder_metadata():

--- a/tests/providers/googledrive/test_provider.py
+++ b/tests/providers/googledrive/test_provider.py
@@ -384,7 +384,7 @@ class TestDownload:
         aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
 
         result = await provider.download(path)
-        assert result.name == 'editable_gdoc.docx'
+        assert result.name == 'editable_gdoc.gdoc.docx'
 
         content = await result.read()
         assert content == file_content
@@ -411,7 +411,7 @@ class TestDownload:
         aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
 
         result = await provider.download(path, revision=self.GDOC_GOOD_REVISION)
-        assert result.name == 'editable_gdoc.docx'
+        assert result.name == 'editable_gdoc.gdoc.docx'
 
         content = await result.read()
         assert content == file_content
@@ -459,7 +459,7 @@ class TestDownload:
         aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
 
         result = await provider.download(path, revision=self.MAGIC_REVISION)
-        assert result.name == 'editable_gdoc.docx'
+        assert result.name == 'editable_gdoc.gdoc.docx'
 
         content = await result.read()
         assert content == file_content
@@ -485,7 +485,7 @@ class TestDownload:
         aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
 
         result = await provider.download(path)
-        assert result.name == 'viewable_gdoc.docx'
+        assert result.name == 'viewable_gdoc.gdoc.docx'
 
         content = await result.read()
         assert content == file_content
@@ -529,7 +529,7 @@ class TestDownload:
         aiohttpretty.register_uri('GET', download_file_url, body=file_content, auto_length=True)
 
         result = await provider.download(path, revision=self.MAGIC_REVISION)
-        assert result.name == 'viewable_gdoc.docx'
+        assert result.name == 'viewable_gdoc.gdoc.docx'
 
         content = await result.read()
         assert content == file_content

--- a/waterbutler/providers/googledrive/metadata.py
+++ b/waterbutler/providers/googledrive/metadata.py
@@ -124,7 +124,7 @@ class GoogleDriveFileMetadata(BaseGoogleDriveMetadata, metadata.BaseFileMetadata
 
     @property
     def export_name(self):
-        title = self._file_title
+        title = self.name
         if self.is_google_doc:
             ext = utils.get_download_extension(self.raw)
             title += ext


### PR DESCRIPTION
##Purpose

When a gFile, (.gdoc, .gslides etc) gets exported we change the ext to .docx, .ppt etc. If this happens one file at a time waterbulter will deal with conflicts appropriately and prompt the user to rename/replace the file, but when multiple files are exported and uploaded coherently (like during registration or a folder drop, WB will over look conflict and replace files with export conflicts. For example: a test.gdoc and test.docx will cause a naming conflict when exported as they will both be called test.docx. This fix will modify the export path to append to the new extension. so test.gdoc and test.docx will be test.gdoc.docx and test.docx .

##Changes

Simple change to metadata path property and modification so tests fit the new behavior.

## Side Effects

Exported paths retain their old extensions, new extensions are appended.

## Ticket

https://openscience.atlassian.net/browse/SVCS-146