### PR TITLE
[SVCS-27] Validate copy/move destination path 

### DIFF
--- a/waterbutler/server/api/v1/provider/movecopy.py
+++ b/waterbutler/server/api/v1/provider/movecopy.py
@@ -69,6 +69,9 @@ class MoveCopyMixin:
             if 'path' not in self.json:
                 raise exceptions.InvalidParameters('Path is required for moves or copies')
 
+            if not self.json['path'].endswith('/'):
+                raise exceptions.InvalidParameters('Path requires a trailing slash to indicate it is a folder')
+
             action = self.json['action']
 
             # Note: attached to self so that _send_hook has access to these


### PR DESCRIPTION
## Purpose

The path attribute in these requests needs to be validated as a proper folder path using a trailing slash.

## Changes 

Add logic preventing slash-less move/copy

## Side Effect

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/SVCS-27