### PR TITLE
Add support and CI for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
   - "3.5"
+  - "3.6"
 
 sudo: false
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ agent==0.1.2
 aiohttp==0.18.2
 git+https://github.com/felliott/boto.git@feature/gen-url-query-params-6#egg=boto
 celery==3.1.17
-cryptography==1.5.2
 furl==0.4.2
 humanfriendly==1.31
 invoke==0.13.0


### PR DESCRIPTION
Ticket: https://openscience.atlassian.net/browse/SVCS-354

# Purpose
Run CI against multiple supported python versions

Updates dependencies/requirements

# Changes/ side effects
This should not be a user facing change. See the linked ticket for an assessment of potential impacts, which all stem from upgrading the cryptography library:
- WB install should now support for python 3.6
- Minimum mac os version is now 10.8 (released 2012)
- May be small breaking API changes, but they do not seem to affect our limited usages

# Testing notes
No user facing changes expected, but I encourage general regression testing. The upgraded library involves crypto signing of credentials, so in theory breakage will be obvious.

Load an OSF project (with at least one addon) and verify the list of files can be viewed as normal from the osf project page. 

Visit a specific file and verify it renders in mfr as expected- for osfstorage, and for one provider.