### PR TITLE
Make sentry errors searchable by node

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,7 +13,7 @@ TODO: v0 api docs
 v1 API
 ------
 
-The version 1 WaterButler API tries to conform to RESTful principals. A v1 url takes the form:
+The version 1 WaterButler API tries to conform to RESTful principles. A v1 url takes the form:
 
 ::
 

--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -85,6 +85,12 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
             return self.set_status(int(http.client.NOT_IMPLEMENTED))  # Metadata on the folder itself TODO
         return (await self.header_file_metadata())
 
+    def get_sentry_data_from_request(self):
+        payload = super(ProviderHandler, self).get_sentry_data_from_request()
+        tags = payload.setdefault('tags', {})
+        tags['resource.id'] = self.resource
+        return payload
+
     async def get(self, **_):
         """Download a file
         Will redirect to a signed URL if possible and accept_url is not False


### PR DESCRIPTION
Ticket: https://openscience.atlassian.net/browse/SVCS-356

# Purpose
Make it possible to search for an error report given only the node ID. (sentry search isn't super smart and sometimes it needs help)

# Summary of changes
Add a `resource.id` tag to every error, from WB APIv1 only. This tag name was chosen to be usage-agnostic, and to match the name used internally in the code/ url args.

# Testing notes
This should be a developer facing change and not affect QA. The main symptom would be easier-to-find error reports on sentry.

To test this as a developer running locally:
1. Get the sentry DSN associated with a live sentry server instance (I used a trial account on sentry.io)
2. Set the `SENTRY_DSN` value in configuration. If you are running dockerized OSF, this can be done by adding the line `SENTRY_DSN=https://secret:really@sentry.io/someid` to the file `.docker-compose.wb.env`, then restarting your WB container so that the new env variables are loaded.
3. Generate an exception in waterbutler in some way (I did so by adding a manual `raise Exception('mymessage')`  to every get request, then loading an osf project. https://github.com/abought/waterbutler/blob/f5818319e648bc06d4197ddcaf771b34c9719885/waterbutler/server/api/v1/provider/__init__.py#L99-L99 )
4. Go to your sentry project page and check the error page. There should be a new tag, `resource.id:nodeid` for that error. Then try searching `resource.id:nodeid`- **it may take 3-5 min for the tag to get indexed and be properly searchable**.

![screen shot 2017-06-01 at 6 36 08 pm](https://cloud.githubusercontent.com/assets/2957073/26703754/4694da26-46f9-11e7-81ac-96d453b17544.png)

![screen shot 2017-06-01 at 6 22 13 pm](https://cloud.githubusercontent.com/assets/2957073/26703749/40fc413a-46f9-11e7-9c58-8ffeeab736b6.png)



# Side effects
There will be many nodes with errors, and I'm not sure the tags feature was designed to handle so many unique values. Monitor performance over time in case this becomes a problem.
