### PR TITLE
WB S3 provider: Assign resp.headers before releasing resp

### DIFF
--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -419,8 +419,9 @@ class S3Provider(provider.BaseProvider):
             expects=(200, ),
             throws=exceptions.MetadataError,
         )
+        resp_headers = resp.headers
         await resp.release()
-        return S3FileMetadataHeaders(path.path, resp.headers)
+        return S3FileMetadataHeaders(path.path, resp_headers)
 
     async def _metadata_folder(self, path):
         await self._check_region()


### PR DESCRIPTION
While working SVCS-314 ran into issue during testing where I was receiving "Key not found: 'X-WATERBUTLER-METADATA'" error from s3/provider.py def _metadata_file . This PR fixes the issue.