### PR TITLE
[SVCS-288] Fix Figshare stream

### DIFF
--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -287,7 +287,7 @@ class BaseFigshareProvider(provider.BaseProvider):
             upload_response = await self.make_request(
                 'PUT',
                 upload_url + '/' + str(part_number),
-                data=stream.readexactly(size),
+                data=stream.read(size),
                 expects=(200, ),
             )
             await upload_response.release()


### PR DESCRIPTION
## Purpose 

After Figshare got there act together and fixed they're API they likely made changes to their upload streaming system which effected the response messages we were receiving, causing successful uploads to display as failed this minor fix should solve that.

## Changes

Minor one line fix ensures we stream the correct amount of data per part.

## Side Effects 

None that I know of.

## Ticket 
semi-related to: https://openscience.atlassian.net/browse/SVCS-288