### PR TITLE
[SVCS-413] Unable to add a file to a renamed folder for Google drive

### DIFF
--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -148,7 +148,7 @@ class GoogleDriveProvider(provider.BaseProvider):
                          dest_provider: provider.BaseProvider,
                          src_path: wb_path.WaterButlerPath,
                          dest_path: wb_path.WaterButlerPath) \
-                         -> typing.Tuple[GoogleDriveFileMetadata, bool]:
+                         -> typing.Tuple[BaseGoogleDriveMetadata, bool]:
         self.metrics.add('intra_move.destination_exists', dest_path.identifier is not None)
         if dest_path.identifier:
             await dest_provider.delete(dest_path)
@@ -170,13 +170,14 @@ class GoogleDriveProvider(provider.BaseProvider):
         ) as resp:
             data = await resp.json()
 
-        return GoogleDriveFileMetadata(data, dest_path), dest_path.identifier is None
+        metadata_class = GoogleDriveFolderMetadata if dest_path.is_dir else GoogleDriveFileMetadata
+        return metadata_class(data, dest_path), dest_path.identifier is None
 
     async def intra_copy(self,
                          dest_provider: provider.BaseProvider,
                          src_path: wb_path.WaterButlerPath,
                          dest_path: wb_path.WaterButlerPath) \
-                         -> typing.Tuple[GoogleDriveFileMetadata, bool]:
+                         -> typing.Tuple[BaseGoogleDriveMetadata, bool]:
         self.metrics.add('intra_copy.destination_exists', dest_path.identifier is not None)
         if dest_path.identifier:
             await dest_provider.delete(dest_path)
@@ -195,7 +196,9 @@ class GoogleDriveProvider(provider.BaseProvider):
             throws=exceptions.IntraMoveError,
         ) as resp:
             data = await resp.json()
-        return GoogleDriveFileMetadata(data, dest_path), dest_path.identifier is None
+
+        metadata_class = GoogleDriveFolderMetadata if dest_path.is_dir else GoogleDriveFileMetadata
+        return metadata_class(data, dest_path), dest_path.identifier is None
 
     async def download(self,  # type: ignore
                        path: GoogleDrivePath,


### PR DESCRIPTION
## Purpose

When you rename an item in google drive the response metadata always shows the item as a file, this break fangorn which rightly assumes you can upload something to a file. This PR delivers the correct metadata/

## Changes 

This changes the return class for intra_move and intra_copy on the googledrive provider so it doesn't just return file metadata. Also changes the type annotations to reflect this.

## Side Effects 

None that I know of.

## Ticket

Moved to Services.
New ticket: https://openscience.atlassian.net/browse/SVCS-413
Old ticket: https://openscience.atlassian.net/browse/OSF-5837 