### PR TITLE
[SVCS-332][SVCS-292] Make Googledrive give folder children’s metadata on moves and copies

### DIFF
--- a/tests/providers/googledrive/test_provider.py
+++ b/tests/providers/googledrive/test_provider.py
@@ -818,8 +818,10 @@ class TestMetadata:
 
         query = provider._build_query(path.identifier)
         url = provider.build_url('files', q=query, alt='json', maxResults=1000)
+        url_children = provider.build_url('files', q="'{}' in parents".format(path.identifier))
 
         aiohttpretty.register_json_uri('GET', url, body=body)
+        aiohttpretty.register_json_uri('GET', url_children, body={'items': []})
 
         result = await provider.metadata(path)
 

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -173,11 +173,10 @@ class GoogleDriveProvider(provider.BaseProvider):
 
         if dest_path.is_dir:
             metadata = GoogleDriveFolderMetadata(data, dest_path)
-            metadata.children = await self._folder_metadata(src_path)
+            metadata.children = await self._folder_metadata(dest_path)
             return metadata, dest_path.identifier is None
         else:
             return GoogleDriveFileMetadata(data, dest_path), dest_path.identifier is None  # type: ignore
-
 
     async def intra_copy(self,
                          dest_provider: provider.BaseProvider,

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -171,13 +171,13 @@ class GoogleDriveProvider(provider.BaseProvider):
         ) as resp:
             data = await resp.json()
 
-        metadata_class = None
         if dest_path.is_dir:
-            metadata_class = GoogleDriveFolderMetadata  # type: ignore
+            metadata = GoogleDriveFolderMetadata(data, dest_path)
+            metadata.children = await self._folder_metadata(src_path)
+            return metadata, dest_path.identifier is None
         else:
-            metadata_class = GoogleDriveFileMetadata  # type: ignore
+            return GoogleDriveFileMetadata(data, dest_path), dest_path.identifier is None  # type: ignore
 
-        return metadata_class(data, dest_path), dest_path.identifier is None
 
     async def intra_copy(self,
                          dest_provider: provider.BaseProvider,

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -171,12 +171,15 @@ class GoogleDriveProvider(provider.BaseProvider):
         ) as resp:
             data = await resp.json()
 
+        created = dest_path.identifier is None
+        dest_path.parts[-1]._id = data['id']
+
         if dest_path.is_dir:
             metadata = GoogleDriveFolderMetadata(data, dest_path)
-            metadata.children = await self._folder_metadata(dest_path)
-            return metadata, dest_path.identifier is None
+            metadata._children = await self._folder_metadata(dest_path)
+            return metadata, created
         else:
-            return GoogleDriveFileMetadata(data, dest_path), dest_path.identifier is None  # type: ignore
+            return GoogleDriveFileMetadata(data, dest_path), created  # type: ignore
 
     async def intra_copy(self,
                          dest_provider: provider.BaseProvider,


### PR DESCRIPTION
# Purpose

On inter/intra moves/copies googledrive doesn't return the folder's children, this fixes that.

# Changes

Changes item serializer to recursively call the google drive api include children to metadata.

# Side Effects

None that I know of.

# Ticket

https://openscience.atlassian.net/browse/SVCS-332

# Old PR

https://github.com/CenterForOpenScience/waterbutler/pull/221