### PR TITLE
Increasing coverage for dropbox provider and metadata pytests.

### DIFF
--- a/tests/providers/dropbox/fixtures.py
+++ b/tests/providers/dropbox/fixtures.py
@@ -1,0 +1,28 @@
+import pytest
+import os
+import json
+
+
+@pytest.fixture
+def root_provider_fixtures():
+    # fixtures for testing validate_v1_path for root provider
+    with open(os.path.join(os.path.dirname(__file__), 'fixtures/root_provider.json'), 'r') as fp:
+        return json.load(fp)
+
+
+@pytest.fixture
+def revision_fixtures():
+    with open(os.path.join(os.path.dirname(__file__), 'fixtures/revisions.json'), 'r') as fp:
+        return json.load(fp)
+
+
+@pytest.fixture
+def intra_copy_fixtures():
+    with open(os.path.join(os.path.dirname(__file__), 'fixtures/intra_copy.json'), 'r') as fp:
+        return json.load(fp)
+
+
+@pytest.fixture
+def error_fixtures():
+    with open(os.path.join(os.path.dirname(__file__), 'fixtures/errors.json'), 'r') as fp:
+        return json.load(fp)

--- a/tests/providers/dropbox/fixtures/errors.json
+++ b/tests/providers/dropbox/fixtures/errors.json
@@ -1,0 +1,51 @@
+{
+    "rename_conflict_file_metadata": {"error_summary": "to/conflict/file/",
+                    "error": {"to": {".tag": "conflict",
+                    "conflict": {".tag": "file"}},
+                        ".tag": "to"
+                    }
+            },
+
+    "rename_conflict_folder_metadata": {
+                    "error_summary": "to/conflict/file/",
+                    "error": {"to": {".tag": "conflict",
+                    "conflict": {".tag": "folder"}},
+                        ".tag": "to"
+                    }
+            },
+
+
+    "not_found_metadata_data": {"error_summary": "path/not_found/",
+                "error": {".tag": "path",
+                          "path": {".tag": "not_found"}
+                         }
+               },
+
+    "deleted_file_metadata": {
+            "path_display": "/conflict folder/1dragon.rtf",
+            "client_modified": "2017-08-25T17:14:41Z",
+            "content_hash": "060a25a56cfce28e8aefa8e32a55ff9e890cbd714cabb156e5feb41f9a7b1624",
+            "path_lower": "/conflict folder/1dragon.rtf",
+            ".tag": "deleted",
+            "server_modified": "2017-08-25T17:14:41Z",
+            "name": "1dragon.rtf",
+            "id": "id:jki_ZJstdSAAAAAAAAAACQ",
+            "rev": "45bb27d11",
+            "size": 364
+        },
+
+    "file_metadata_folder_tag": {
+            "path_display": "/conflict folder/1dragon.rtf",
+            "client_modified": "2017-08-25T17:14:41Z",
+            "content_hash": "060a25a56cfce28e8aefa8e32a55ff9e890cbd714cabb156e5feb41f9a7b1624",
+            "path_lower": "/conflict folder/1dragon.rtf",
+            ".tag": "folder",
+            "server_modified": "2017-08-25T17:14:41Z",
+            "name": "1dragon.rtf",
+            "id": "id:jki_ZJstdSAAAAAAAAAACQ",
+            "rev": "45bb27d11",
+            "size": 364
+        }
+
+
+}

--- a/tests/providers/dropbox/fixtures/intra_copy.json
+++ b/tests/providers/dropbox/fixtures/intra_copy.json
@@ -1,0 +1,34 @@
+{
+   "intra_copy_file_metadata": {
+        "metadata": {
+        "path_lower": "/conflict folder/rename.rtf",
+        "id": "id:jki_ZJstdSAAAAAAAAAACQ",
+        "rev": "3d5bb27d11",
+        "server_modified": "2017-08-29T15:26:16Z",
+        ".tag": "file",
+        "content_hash": "2722228970da1ca23d68d6283a33bf85f7b1dbf909acfbe96a6c44d530bfa0ad",
+        "client_modified": "2017-08-28T19:43:11Z",
+        "size": 372,
+        "path_display": "/conflict folder/rename.rtf",
+        "name": "rename.rtf"
+    },
+    "expires": "2047-08-22T15:34:03Z",
+    "copy_reference": "AAAAAFuyfRE5aWhyemZmaTJzZXc"
+    },
+
+    "intra_copy_other_provider_file_metadata":{
+        "metadata": {
+            "rev": "4f5bb27d11",
+            "content_hash": "2722228970da1ca23d68d6283a33bf85f7b1dbf909acfbe96a6c44d530bfa0ad",
+            "size": 372,
+            "id": "id:jki_ZJstdSAAAAAAAAAAHw",
+            "path_display": "/conflict folder/copy2/asdf/rename.rtf",
+            ".tag": "file",
+            "client_modified": "2017-08-28T19:43:11Z",
+            "path_lower": "/conflict folder/copy2/asdf/rename.rtf",
+            "name": "rename.rtf",
+            "server_modified": "2017-08-29T15:37:04Z"
+        }
+    }
+
+}

--- a/tests/providers/dropbox/fixtures/revisions.json
+++ b/tests/providers/dropbox/fixtures/revisions.json
@@ -1,0 +1,83 @@
+{
+    "file_revision_metadata": {
+        "entries": [
+            {"rev": "95bb27d11",
+            "content_hash": "2c411653e4bb3b32971f405d7a8c9d44631c10b64591b98ae3f5186b3ae0080f",
+            "path_lower": "/1dragon.rtf",
+            "id": "id:jki_ZJstdSAAAAAAAAAABw",
+            "server_modified": "2017-08-25T17:36:44Z",
+            "size": 364,
+            "path_display": "/1dragon.rtf",
+            "name": "1dragon.rtf",
+            "client_modified": "2017-08-25T17:36:44Z"},
+            {"rev": "85bb27d11",
+            "content_hash": "2c6c1e59a6ca5716386bbb76e7fff8cfc21a595e868abaf1547309b0342300a8",
+            "path_lower": "/1dragon.rtf",
+            "id": "id:jki_ZJstdSAAAAAAAAAABw",
+            "server_modified": "2017-08-25T17:36:35Z",
+            "size": 364,
+            "path_display": "/1dragon.rtf",
+            "name": "1dragon.rtf",
+            "client_modified": "2017-08-25T17:36:35Z"},
+            {"rev": "25bb27d11",
+            "content_hash": "060a25a56cfce28e8aefa8e32a55ff9e890cbd714cabb156e5feb41f9a7b1624",
+            "path_lower": "/1dragon.rtf",
+            "id": "id:jki_ZJstdSAAAAAAAAAABw",
+            "server_modified": "2017-08-25T17:13:06Z",
+            "size": 364,
+            "path_display": "/1dragon.rtf",
+            "name": "1dragon.rtf",
+            "client_modified": "2017-08-25T17:13:05Z"}
+        ],
+        "is_deleted": false
+    },
+
+    "single_file_revision_metadata":{
+        "path_lower": "/conflict folder/rename.rtf",
+        "id": "id:jki_ZJstdSAAAAAAAAAACQ",
+        "server_modified": "2017-08-28T16:12:44Z",
+        "client_modified": "2017-08-25T17:14:41Z",
+        "path_display": "/conflict folder/rename.rtf",
+        "size": 364,
+        ".tag": "file",
+        "content_hash": "060a25a56cfce28e8aefa8e32a55ff9e890cbd714cabb156e5feb41f9a7b1624",
+        "name": "rename.rtf",
+        "rev": "c5bb27d11"
+    },
+
+    "deleted_file_revision_metadata": {
+        "entries": [
+            {"rev": "95bb27d11",
+            "content_hash": "2c411653e4bb3b32971f405d7a8c9d44631c10b64591b98ae3f5186b3ae0080f",
+            "path_lower": "/1dragon.rtf",
+            "id": "id:jki_ZJstdSAAAAAAAAAABw",
+            "server_modified": "2017-08-25T17:36:44Z",
+            "size": 364,
+            "path_display": "/1dragon.rtf",
+            "name": "1dragon.rtf",
+            "client_modified": "2017-08-25T17:36:44Z"},
+            {"rev": "85bb27d11",
+            "content_hash": "2c6c1e59a6ca5716386bbb76e7fff8cfc21a595e868abaf1547309b0342300a8",
+            "path_lower": "/1dragon.rtf",
+            "id": "id:jki_ZJstdSAAAAAAAAAABw",
+            "server_modified": "2017-08-25T17:36:35Z",
+            "size": 364,
+            "path_display": "/1dragon.rtf",
+            "name": "1dragon.rtf",
+            "client_modified": "2017-08-25T17:36:35Z"},
+            {"rev": "25bb27d11",
+            "content_hash": "060a25a56cfce28e8aefa8e32a55ff9e890cbd714cabb156e5feb41f9a7b1624",
+            "path_lower": "/1dragon.rtf",
+            "id": "id:jki_ZJstdSAAAAAAAAAABw",
+            "server_modified": "2017-08-25T17:13:06Z",
+            "size": 364,
+            "path_display": "/1dragon.rtf",
+            "name": "1dragon.rtf",
+            "client_modified": "2017-08-25T17:13:05Z"}
+        ],
+        "is_deleted": true
+    }
+
+
+
+}

--- a/tests/providers/dropbox/fixtures/root_provider.json
+++ b/tests/providers/dropbox/fixtures/root_provider.json
@@ -1,0 +1,82 @@
+{
+    "folder_metadata": {
+        ".tag": "folder",
+        "name": "newfolder",
+        "path_lower": "/newfolder",
+        "path_display": "/newfolder",
+        "id": "id:67BLXqRKo-gAAAAAAAADZg"
+    },
+    "folder_children": {
+        "entries": [
+            {".tag": "file",
+            "name": "flower.jpg",
+            "path_lower": "/photos/flower.jpg",
+            "path_display": "/Photos/flower.jpg",
+            "id": "id:8y8sAJlrhuAAAAAAAAAAAQ",
+            "client_modified": "2016-06-13T19:08:17Z",
+            "server_modified": "2016-06-13T19:08:17Z",
+            "rev": "38af1b183490",
+            "size": 124778}
+        ],
+        "cursor": "AAGFHXqUgavlrBd2TBDxKNdV2rnu48QeThbxccGEvaSwiAAIt5-iho9P8EJIIVdSh6RKRNHq-An2lyyjJ34yCOhyBcIa6Gh6tYOko_okZgZTP_Ga0-kqHtm1HaQOQNdOmPPoNwiXB_rflzSLwq6AXi_F",
+        "has_more": false
+    },
+    "file_metadata": {
+        ".tag": "file",
+        "name": "Getting_Started.pdf",
+        "path_lower": "/photos/getting_started.pdf",
+        "path_display": "/Photos/Getting_Started.pdf",
+        "id": "id:8y8sAJlrhuAAAAAAAAAAAQ",
+        "client_modified": "2016-06-13T19:08:17Z",
+        "server_modified": "2016-06-13T19:08:17Z",
+        "rev": "2ba1017a0c1e",
+        "size": 124778
+    },
+
+    "folder_with_subdirectory_metadata": {
+        "has_more": false,
+        "entries": [
+            {"name": "randomfolder",
+            "path_lower": "/conflict folder/randomfolder",
+            ".tag": "folder",
+            "path_display": "/conflict folder/randomfolder",
+            "id": "id:jki_ZJstdSAAAAAAAAAACw"},
+            {"server_modified": "2017-08-25T17:14:41Z",
+            "path_lower": "/conflict folder/1dragon.rtf",
+            ".tag": "file",
+            "size": 364,
+            "client_modified": "2017-08-25T17:14:41Z",
+            "name": "1dragon.rtf",
+            "content_hash": "060a25a56cfce28e8aefa8e32a55ff9e890cbd714cabb156e5feb41f9a7b1624",
+            "rev": "45bb27d11",
+            "path_display": "/conflict folder/1dragon.rtf",
+            "id": "id:jki_ZJstdSAAAAAAAAAACQ"}
+        ],
+        "cursor": "AAHv3crtaRWT0SKHClfYwa4vmR72KjiW1wjLYSE3BLatCZSJ6pJnD4nWlmAXCZPDXGrxMaIZ0lrRMMAxACEmhJn47aYQCyb1pgOhYqWyinyADa99SpqL2gxdKsq-3I0nUrWd3AaGUiw6GzH5Lg8i_FYy2YyeLkETb7tjRTc6KUTjHCjD61T4A3ZYiNrDp_cSxWg"
+    },
+    "folder_with_hasmore_metadata": {
+        "has_more": true,
+        "entries": [
+            {"name": "randomfolder",
+            "path_lower": "/conflict folder/randomfolder",
+            ".tag": "folder",
+            "path_display": "/conflict folder/randomfolder",
+            "id": "id:jki_ZJstdSAAAAAAAAAACw"},
+            {"server_modified": "2017-08-25T17:14:41Z",
+            "path_lower": "/conflict folder/1dragon.rtf",
+            ".tag": "file",
+            "size": 364,
+            "client_modified": "2017-08-25T17:14:41Z",
+            "name": "1dragon.rtf",
+            "content_hash": "060a25a56cfce28e8aefa8e32a55ff9e890cbd714cabb156e5feb41f9a7b1624",
+            "rev": "45bb27d11",
+            "path_display": "/conflict folder/1dragon.rtf",
+            "id": "id:jki_ZJstdSAAAAAAAAAACQ"}
+        ],
+        "cursor": "AAHv3crtaRWT0SKHClfYwa4vmR72KjiW1wjLYSE3BLatCZSJ6pJnD4nWlmAXCZPDXGrxMaIZ0lrRMMAxACEmhJn47aYQCyb1pgOhYqWyinyADa99SpqL2gxdKsq-3I0nUrWd3AaGUiw6GzH5Lg8i_FYy2YyeLkETb7tjRTc6KUTjHCjD61T4A3ZYiNrDp_cSxWg"
+    }
+
+
+
+
+}

--- a/tests/providers/dropbox/test_provider.py
+++ b/tests/providers/dropbox/test_provider.py
@@ -1,6 +1,7 @@
 import pytest
 
 import io
+import json
 from http import client
 
 import aiohttpretty
@@ -11,8 +12,15 @@ from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
 
 from waterbutler.providers.dropbox import DropboxProvider
-from waterbutler.providers.dropbox.metadata import DropboxFileMetadata
-from waterbutler.providers.dropbox.exceptions import DropboxNamingConflictError
+from waterbutler.providers.dropbox.metadata import DropboxFileMetadata, DropboxRevision, DropboxFolderMetadata
+from waterbutler.providers.dropbox.exceptions import DropboxNamingConflictError, DropboxUnhandledConflictError
+
+from tests.providers.dropbox.fixtures import(
+    root_provider_fixtures,
+    revision_fixtures,
+    intra_copy_fixtures,
+    error_fixtures
+)
 
 
 @pytest.fixture
@@ -29,6 +37,11 @@ def credentials():
 
 
 @pytest.fixture
+def other_credentials():
+    return {'token': 'did not write harry potter'}
+
+
+@pytest.fixture
 def settings():
     return {'folder': '/Photos'}
 
@@ -36,6 +49,13 @@ def settings():
 @pytest.fixture
 def provider(auth, credentials, settings):
     return DropboxProvider(auth, credentials, settings)
+
+
+@pytest.fixture
+def other_provider(auth, other_credentials, settings):
+    return DropboxProvider(auth, other_credentials, settings)
+
+# file stream fixtures
 
 
 @pytest.fixture
@@ -53,62 +73,8 @@ def file_stream(file_like):
     return streams.FileStreamReader(file_like)
 
 
-@pytest.fixture
-def folder_children():
-    return {"entries":
-               [
-                   {".tag": "file",
-                    "name": "flower.jpg",
-                    "path_lower": "/photos/flower.jpg",
-                    "path_display": "/Photos/flower.jpg",
-                    "id": "id:8y8sAJlrhuAAAAAAAAAAAQ",
-                    "client_modified": "2016-06-13T19:08:17Z",
-                    "server_modified": "2016-06-13T19:08:17Z",
-                    "rev": "38af1b183490",
-                    "size": 124778}
-               ],
-            "cursor": "AAGFHXqUgavlrBd2TBDxKNdV2rnu48QeThbxccGEvaSwiAAIt5-iho9P8EJIIVdSh6RKRNHq-An2lyyjJ34yCOhyBcIa6Gh6tYOko_okZgZTP_Ga0-kqHtm1HaQOQNdOmPPoNwiXB_rflzSLwq6AXi_F",
-            "has_more": False
-           }
-
-
-@pytest.fixture
-def folder_metadata():
-    return {
-        ".tag": "folder",
-        "name": "newfolder",
-        "path_lower": "/newfolder",
-        "path_display": "/newfolder",
-        "id": "id:67BLXqRKo-gAAAAAAAADZg"
-    }
-
-
-@pytest.fixture
-def file_metadata():
-    return {
-        ".tag": "file",
-        "name": "Getting_Started.pdf",
-        "path_lower": "/photos/getting_started.pdf",
-        "path_display": "/Photos/Getting_Started.pdf",
-        "id": "id:8y8sAJlrhuAAAAAAAAAAAQ",
-        "client_modified": "2016-06-13T19:08:17Z",
-        "server_modified": "2016-06-13T19:08:17Z",
-        "rev": "2ba1017a0c1e",
-        "size": 124778
-    }
-
-
 def build_folder_metadata_data(path):
     return {'path': path.full_path}
-
-
-@pytest.fixture
-def not_found_metadata_data():
-    return {"error_summary": "path/not_found/",
-            "error": {".tag": "path",
-                      "path": {".tag": "not_found"}
-                     }
-           }
 
 
 class TestValidatePath:
@@ -116,13 +82,13 @@ class TestValidatePath:
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     @pytest.mark.parametrize('settings', [{'folder': '/'}])
-    async def test_validate_v1_path_file(self, provider, file_metadata):
+    async def test_validate_v1_path_file(self, provider, root_provider_fixtures):
         file_path = '/Photos/Getting_Started.pdf'
         data = {"path": file_path}
 
         metadata_url = provider.build_url('files', 'get_metadata')
         aiohttpretty.register_json_uri('POST', metadata_url, data=data,
-                                       body=file_metadata)
+                                       body=root_provider_fixtures['file_metadata'])
 
         try:
             wb_path_v1 = await provider.validate_v1_path(file_path)
@@ -141,13 +107,13 @@ class TestValidatePath:
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     @pytest.mark.parametrize('settings', [{'folder': '/'}])
-    async def test_validate_v1_path_folder(self, provider, folder_metadata):
+    async def test_validate_v1_path_folder(self, provider, root_provider_fixtures):
         folder_path = '/Photos'
         data = {"path": folder_path}
 
         metadata_url = provider.build_url('files', 'get_metadata')
         aiohttpretty.register_json_uri('POST', metadata_url, data=data,
-                                       body=folder_metadata)
+                                       body=root_provider_fixtures['folder_metadata'])
 
         try:
             wb_path_v1 = await provider.validate_v1_path(folder_path + '/')
@@ -181,6 +147,15 @@ class TestValidatePath:
         assert path.name == 'folder'
         assert provider.folder in path.full_path
 
+    @pytest.mark.asyncio
+    async def test_validate_v1_path_base(self, provider):
+        path = await provider.validate_v1_path('/')
+
+        assert path.is_dir
+        assert len(path.parts) == 1
+        assert path.name == ''
+        assert provider.folder in path.full_path
+
 
 class TestCRUD:
 
@@ -197,11 +172,11 @@ class TestCRUD:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_download_not_found(self, provider, not_found_metadata_data):
+    async def test_download_not_found(self, provider, error_fixtures):
         path = await provider.validate_path('/vectors.txt')
         url = provider._build_content_url('files', 'download')
         aiohttpretty.register_json_uri('POST', url, status=409,
-                                       body=not_found_metadata_data)
+                                       body=error_fixtures['not_found_metadata_data'])
 
         with pytest.raises(exceptions.NotFoundError) as e:
             await provider.download(path)
@@ -210,8 +185,8 @@ class TestCRUD:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_upload(self, provider, file_metadata,
-                          not_found_metadata_data, file_stream, settings):
+    async def test_upload(self, provider, root_provider_fixtures,
+                          error_fixtures, file_stream, settings):
         path = await provider.validate_path('/phile')
 
         metadata_url = provider.build_url('files', 'get_metadata')
@@ -219,12 +194,12 @@ class TestCRUD:
         url = provider._build_content_url('files', 'upload')
 
         aiohttpretty.register_json_uri('POST', metadata_url, data=data,
-                                       status=409, body=not_found_metadata_data)
+                                       status=409, body=error_fixtures['not_found_metadata_data'])
         aiohttpretty.register_json_uri('POST', url, status=200,
-                                       body=file_metadata)
+                                       body=root_provider_fixtures['file_metadata'])
 
         metadata, created = await provider.upload(file_stream, path)
-        expected = DropboxFileMetadata(file_metadata, provider.folder)
+        expected = DropboxFileMetadata(root_provider_fixtures['file_metadata'], provider.folder)
 
         assert created is True
         assert metadata == expected
@@ -232,7 +207,7 @@ class TestCRUD:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_delete_file(self, provider, file_metadata):
+    async def test_delete_file(self, provider):
         url = provider.build_url('files', 'delete')
         path = await provider.validate_path('/The past')
         data = {'path': path.full_path}
@@ -243,17 +218,47 @@ class TestCRUD:
 
         assert aiohttpretty.has_call(method='POST', uri=url)
 
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_delete_root_bad(self, provider):
+        url = provider.build_url('files', 'delete')
+        path = await provider.validate_path('/')
+        data = {'path': path.full_path}
+
+        aiohttpretty.register_json_uri('POST', url, data=data, status=200)
+
+        with pytest.raises(exceptions.DeleteError) as e:
+            await provider.delete(path)
+        assert e.value.code == 400
+        assert e.value.message == 'confirm_delete=1 is required for deleting root provider folder'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_delete_root(self, provider, root_provider_fixtures):
+        url = provider.build_url('files', 'list_folder')
+        path = await provider.validate_path('/')
+        data = {'path': path.full_path}
+        aiohttpretty.register_json_uri('POST', url, data=data, body=root_provider_fixtures['folder_children'], status=200)
+        path2 = await provider.validate_path('/photos/flower.jpg')
+        url = provider.build_url('files', 'delete')
+        data = {'path': provider.folder.rstrip('/') + '/' + path2.path.rstrip('/')}
+        aiohttpretty.register_json_uri('POST', url, data=data, status=200)
+
+        await provider.delete(path, 1)
+
+        assert aiohttpretty.has_call(method='POST', uri=url)
+
 
 class TestMetadata:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_metadata(self, provider, folder_children):
+    async def test_metadata(self, provider, root_provider_fixtures):
         path = await provider.validate_path('/')
         url = provider.build_url('files', 'list_folder')
         data = {'path': path.full_path}
         aiohttpretty.register_json_uri('POST', url, data=data,
-                                       body=folder_children)
+                                       body=root_provider_fixtures['folder_children'])
         result = await provider.metadata(path)
 
         assert isinstance(result, list)
@@ -264,12 +269,91 @@ class TestMetadata:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_metadata_root_file(self, provider, file_metadata):
+    async def test_revision_metadata(self, provider, revision_fixtures):
+        path = await provider.validate_path('/testfile')
+        url = provider.build_url('files', 'get_metadata')
+        revision = 'c5bb27d11'
+        data = {'path': 'rev:' + revision}
+        aiohttpretty.register_json_uri('POST', url, data=data,
+                                       body=revision_fixtures['single_file_revision_metadata'])
+        result = await provider.metadata(path, revision)
+        expected = DropboxFileMetadata(revision_fixtures['single_file_revision_metadata'], provider.folder)
+
+        assert result == expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_folder_with_subdirectory_metadata(self, provider, root_provider_fixtures):
+        path = await provider.validate_path('/')
+        url = provider.build_url('files', 'list_folder')
+        data = {'path': path.full_path}
+        aiohttpretty.register_json_uri('POST', url, data=data,
+                                       body=root_provider_fixtures['folder_with_subdirectory_metadata'])
+        result = await provider.metadata(path)
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0].kind == 'folder'
+        assert result[0].name == 'randomfolder'
+        assert result[0].path == '/conflict folder/randomfolder/'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_folder_with_hasmore_metadata(self, provider, root_provider_fixtures):
+        path = await provider.validate_path('/')
+        url = provider.build_url('files', 'list_folder')
+        data = {'path': path.full_path}
+        aiohttpretty.register_json_uri('POST', url, data=data,
+                                       body=root_provider_fixtures['folder_with_hasmore_metadata'])
+        aiohttpretty.register_json_uri('POST', url + '/continue', data=data,
+                                       body=root_provider_fixtures['folder_with_subdirectory_metadata'])
+
+        result = await provider.metadata(path)
+
+        assert isinstance(result, list)
+        assert len(result) == 4
+        assert result[0].kind == 'folder'
+        assert result[0].name == 'randomfolder'
+        assert result[0].path == '/conflict folder/randomfolder/'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_get_revisions(self, provider, revision_fixtures):
+        path = WaterButlerPath('/pfile', prepend=provider.folder)
+        url = provider.build_url('files', 'list_revisions')
+        data = {'path': path.full_path.rstrip('/'), 'limit': 100}
+        aiohttpretty.register_json_uri('POST', url, data=data,
+                                        body=revision_fixtures['file_revision_metadata'])
+
+        result = await provider.revisions(path)
+        expected = [DropboxRevision(item) for item in revision_fixtures['file_revision_metadata']['entries']]
+
+        assert result == expected
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_deleted_revision_metadata(self, provider, revision_fixtures):
+        path = WaterButlerPath('/pfile', prepend=provider.folder)
+        url = provider.build_url('files', 'list_revisions')
+        data = {'path': path.full_path.rstrip('/'), 'limit': 100}
+        aiohttpretty.register_json_uri('POST', url, data=data,
+                                        body=revision_fixtures['deleted_file_revision_metadata'])
+
+        with pytest.raises(exceptions.RevisionsError) as e:
+            result = await provider.revisions(path)
+
+        assert e.value.code == 404
+        assert e.value.message == "Could not retrieve '/pfile'"
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_root_file(self, provider, root_provider_fixtures):
         path = WaterButlerPath('/pfile', prepend=provider.folder)
         url = provider.build_url('files', 'get_metadata')
         data = {'path': path.full_path}
         aiohttpretty.register_json_uri('POST', url, data=data,
-                                       body=file_metadata)
+                                       body=root_provider_fixtures['file_metadata'])
         result = await provider.metadata(path)
 
         assert isinstance(result, metadata.BaseMetadata)
@@ -279,12 +363,53 @@ class TestMetadata:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_metadata_missing(self, provider, not_found_metadata_data):
+    async def test_metadata_root_file(self, provider, root_provider_fixtures):
+        path = WaterButlerPath('/pfile', prepend=provider.folder)
+        url = provider.build_url('files', 'get_metadata')
+        data = {'path': path.full_path}
+        aiohttpretty.register_json_uri('POST', url, data=data,
+                                       body=root_provider_fixtures['file_metadata'])
+        result = await provider.metadata(path)
+
+        assert isinstance(result, metadata.BaseMetadata)
+        assert result.kind == 'file'
+        assert result.name == 'Getting_Started.pdf'
+        assert result.path == '/Getting_Started.pdf'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_deleted_file_metadata(self, provider, error_fixtures):
+        path = WaterButlerPath('/pfile', prepend=provider.folder)
+        url = provider.build_url('files', 'get_metadata')
+        data = {'path': path.full_path}
+        aiohttpretty.register_json_uri('POST', url, data=data,
+                                       body=error_fixtures['deleted_file_metadata'])
+
+        with pytest.raises(exceptions.MetadataError) as e:
+            await provider.metadata(path)
+        assert e.value.code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_file_metadata_folder_tag(self, provider, error_fixtures):
+        path = WaterButlerPath('/pfile', prepend=provider.folder)
+        url = provider.build_url('files', 'get_metadata')
+        data = {'path': path.full_path}
+        aiohttpretty.register_json_uri('POST', url, data=data,
+                                       body=error_fixtures['file_metadata_folder_tag'])
+
+        with pytest.raises(exceptions.MetadataError) as e:
+            await provider.metadata(path)
+        assert e.value.code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_missing(self, provider, error_fixtures):
         path = WaterButlerPath('/pfile', prepend=provider.folder)
         url = provider.build_url('files', 'get_metadata')
         data = {"path": "/pfile"}
         aiohttpretty.register_json_uri('POST', url, data=data, status=409,
-                                       body=not_found_metadata_data)
+                                       body=error_fixtures['not_found_metadata_data'])
 
         with pytest.raises(exceptions.NotFoundError):
             await provider.metadata(path)
@@ -298,13 +423,16 @@ class TestCreateFolder:
         path = WaterButlerPath('/newfolder/', prepend=provider.folder)
         url = provider.build_url('files', 'create_folder')
         data = build_folder_metadata_data(path)
-        body = {"error_summary": "path/conflict/folder/...",
-                "error": {".tag": "path",
-                          "path": {".tag": "conflict",
-                                   "conflict": {".tag": "folder"}
-                                  }
-                         }
-               }
+        body = {
+            "error_summary": "path/conflict/folder/...",
+            "error": {
+                ".tag": "path",
+                "path": {
+                    ".tag": "conflict",
+                    "conflict": {".tag": "folder"}
+                }
+            }
+        }
         aiohttpretty.register_json_uri('POST', url, data=data, status=409,
                                        body=body)
 
@@ -316,12 +444,28 @@ class TestCreateFolder:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
+    async def test_already_exists_unhandled_conflict(self, provider, root_provider_fixtures):
+        # This test is just to hit the last line of dropbox_conflict_error_handler and not much else
+        path = WaterButlerPath('/newfolder/', prepend=provider.folder)
+        url = provider.build_url('files', 'create_folder')
+        data = build_folder_metadata_data(path)
+
+        aiohttpretty.register_json_uri('POST', url, data=data, status=409,
+                                       body=root_provider_fixtures['folder_metadata'])
+
+        with pytest.raises(DropboxUnhandledConflictError) as e:
+            await provider.create_folder(path)
+
+        assert e.value.code == 409
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
     async def test_forbidden(self, provider):
         path = WaterButlerPath('/newfolder/', prepend=provider.folder)
         url = provider.build_url('files', 'create_folder')
         data = build_folder_metadata_data(path)
 
-        aiohttpretty.register_json_uri('POST', url, data=data, status=403, body={ 'error': 'because I hate you' })
+        aiohttpretty.register_json_uri('POST', url, data=data, status=403, body={'error': 'because I hate you'})
 
         with pytest.raises(exceptions.CreateFolderError) as e:
             await provider.create_folder(path)
@@ -345,17 +489,178 @@ class TestCreateFolder:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_returns_metadata(self, provider, folder_metadata):
+    async def test_returns_metadata(self, provider, root_provider_fixtures):
         path = WaterButlerPath('/newfolder/', prepend=provider.folder)
         url = provider.build_url('files', 'create_folder')
         data = build_folder_metadata_data(path)
 
-        aiohttpretty.register_json_uri('POST', url, data=data, status=200, body=folder_metadata)
+        aiohttpretty.register_json_uri('POST', url, data=data, status=200, body=root_provider_fixtures['folder_metadata'])
 
         resp = await provider.create_folder(path)
 
         assert resp.kind == 'folder'
         assert resp.name == 'newfolder'
+        assert resp.path == '/newfolder/'
+
+
+class TestIntra:
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_copy_file(self, provider, root_provider_fixtures):
+        src_path = WaterButlerPath('/pfile', prepend=provider.folder)
+        dest_path = WaterButlerPath('/pfile_renamed', prepend=provider.folder)
+
+        url = provider.build_url('files', 'copy')
+        data = {'from_path': src_path.full_path.rstrip('/'), 'to_path': dest_path.full_path.rstrip('/')},
+        aiohttpretty.register_json_uri('POST', url, data=data, body=root_provider_fixtures['file_metadata'])
+
+        result = await provider.intra_copy(provider, src_path, dest_path)
+        expected = (DropboxFileMetadata(root_provider_fixtures['file_metadata'], provider.folder), True)
+
+        assert result == expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_copy_replace_file(self, provider, root_provider_fixtures, error_fixtures):
+        url = provider.build_url('files', 'delete')
+        path = await provider.validate_path('/The past')
+        data = {'path': path.full_path}
+        aiohttpretty.register_json_uri('POST', url, data=data, status=200)
+
+        src_path = WaterButlerPath('/pfile', prepend=provider.folder)
+        dest_path = WaterButlerPath('/pfile_renamed', prepend=provider.folder)
+
+        url = provider.build_url('files', 'copy')
+        data = {'from_path': src_path.full_path.rstrip('/'), 'to_path': dest_path.full_path.rstrip('/')}
+        aiohttpretty.register_json_uri('POST', url, **{
+            "responses": [
+                {'headers': {'Content-Type': 'application/json'}, 'data': data, 'body': json.dumps(error_fixtures['rename_conflict_folder_metadata']).encode('utf-8'), 'status': 409},
+                {'headers': {'Content-Type': 'application/json'}, 'data': data, 'body': json.dumps(root_provider_fixtures['file_metadata']).encode('utf-8')},
+            ]})
+
+        result = await provider.intra_copy(provider, src_path, dest_path)
+        expected = (DropboxFileMetadata(root_provider_fixtures['file_metadata'], provider.folder), False)
+
+        assert expected == result
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_copy_file_different_provider(self, provider, other_provider, intra_copy_fixtures):
+        src_path = WaterButlerPath('/pfile', prepend=provider.folder)
+        dest_path = WaterButlerPath('/pfile_renamed', prepend=other_provider.folder)
+
+        url = provider.build_url('files', 'copy_reference', 'get')
+        data = {'path': src_path.full_path.rstrip('/')},
+        aiohttpretty.register_json_uri('POST', url, data=data, body=intra_copy_fixtures['intra_copy_file_metadata'])
+
+        url1 = provider.build_url('files', 'copy_reference', 'save')
+        data1 = {'copy_reference': 'test', 'path': dest_path.full_path.rstrip('/')}
+        aiohttpretty.register_json_uri('POST', url1, data=data1, body=intra_copy_fixtures['intra_copy_other_provider_file_metadata'])
+
+        result = await provider.intra_copy(other_provider, src_path, dest_path)
+        expected = (DropboxFileMetadata(intra_copy_fixtures['intra_copy_other_provider_file_metadata']['metadata'], provider.folder), True)
+
+        assert result == expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_copy_folder(self, provider, root_provider_fixtures):
+        src_path = WaterButlerPath('/pfile/', prepend=provider.folder)
+        dest_path = WaterButlerPath('/pfile_renamed/', prepend=provider.folder)
+
+        url = provider.build_url('files', 'copy')
+        data = {'from_path': src_path.full_path.rstrip('/'), 'to_path': dest_path.full_path.rstrip('/')}
+        aiohttpretty.register_json_uri('POST', url, data=data, body=root_provider_fixtures['folder_metadata'])
+
+        url = provider.build_url('files', 'list_folder')
+        data = {'path': dest_path.full_path}
+        aiohttpretty.register_json_uri('POST', url, data=data, body=root_provider_fixtures['folder_children'], status=200)
+
+        result = await provider.intra_copy(provider, src_path, dest_path)
+        expected = DropboxFolderMetadata(root_provider_fixtures['folder_metadata'], provider.folder)
+        expected.children = ([DropboxFileMetadata(item, provider.folder) for item in root_provider_fixtures['folder_children']['entries']])
+
+        assert expected == result[0]
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_move_file(self, provider, root_provider_fixtures):
+        src_path = WaterButlerPath('/pfile', prepend=provider.folder)
+        dest_path = WaterButlerPath('/pfile_renamed', prepend=provider.folder)
+
+        url = provider.build_url('files', 'move')
+        data = {'from_path': src_path.full_path.rstrip('/'), 'to_path': dest_path.full_path.rstrip('/')},
+        aiohttpretty.register_json_uri('POST', url, data=data, body=root_provider_fixtures['file_metadata'])
+
+        result = await provider.intra_move(provider, src_path, dest_path)
+        expected = (DropboxFileMetadata(root_provider_fixtures['file_metadata'], provider.folder), True)
+
+        assert result == expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_move_replace_file(self, provider, root_provider_fixtures, error_fixtures):
+        url = provider.build_url('files', 'delete')
+        path = await provider.validate_path('/The past')
+        data = {'path': path.full_path}
+        aiohttpretty.register_json_uri('POST', url, data=data, status=200)
+
+        src_path = WaterButlerPath('/pfile', prepend=provider.folder)
+        dest_path = WaterButlerPath('/pfile_renamed', prepend=provider.folder)
+
+        url = provider.build_url('files', 'move')
+        data = {'from_path': src_path.full_path.rstrip('/'), 'to_path': dest_path.full_path.rstrip('/')},
+        aiohttpretty.register_json_uri('POST', url, **{
+            "responses": [
+                {'headers': {'Content-Type': 'application/json'}, 'data': data, 'body': json.dumps(error_fixtures['rename_conflict_file_metadata']).encode('utf-8'), 'status': 409},
+                {'headers': {'Content-Type': 'application/json'}, 'data': data, 'body': json.dumps(root_provider_fixtures['file_metadata']).encode('utf-8')},
+            ]})
+
+        result = await provider.intra_move(provider, src_path, dest_path)
+        expected = (DropboxFileMetadata(root_provider_fixtures['file_metadata'], provider.folder), False)
+
+        assert expected == result
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_move_replace_folder(self, provider, root_provider_fixtures, error_fixtures):
+        url = provider.build_url('files', 'delete')
+        path = await provider.validate_path('/newfolder/')
+        data = {'path': path.full_path}
+        aiohttpretty.register_json_uri('POST', url, data=data, status=200)
+
+        url = provider.build_url('files', 'list_folder')
+        data = {'path': path.full_path}
+        aiohttpretty.register_json_uri('POST', url, data=data, body=root_provider_fixtures['folder_children'], status=200)
+
+        src_path = WaterButlerPath('/pfile/', prepend=provider.folder)
+        dest_path = WaterButlerPath('/pfile_renamed/', prepend=provider.folder)
+
+        url = provider.build_url('files', 'move')
+        data = {'from_path': src_path.full_path.rstrip('/'), 'to_path': dest_path.full_path.rstrip('/')}
+        aiohttpretty.register_json_uri('POST', url, **{
+            "responses": [
+                {'headers': {'Content-Type': 'application/json'}, 'data': data, 'body': json.dumps(error_fixtures['rename_conflict_folder_metadata']).encode('utf-8'), 'status': 409},
+                {'headers': {'Content-Type': 'application/json'}, 'data': data, 'body': json.dumps(root_provider_fixtures['folder_metadata']).encode('utf-8')},
+            ]})
+
+        result = await provider.intra_move(provider, src_path, dest_path)
+        expected = DropboxFolderMetadata(root_provider_fixtures['folder_metadata'], provider.folder)
+        expected.children = ([DropboxFileMetadata(item, provider.folder) for item in root_provider_fixtures['folder_children']['entries']])
+
+        assert expected == result[0]
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_move_casing_change(self, provider):
+        src_path = WaterButlerPath('/pfile/', prepend=provider.folder)
+        dest_path = WaterButlerPath('/pfile/', prepend=provider.folder)
+
+        with pytest.raises(exceptions.InvalidPathError) as e:
+            await provider.intra_move(provider, src_path, dest_path)
+
+        assert e.value.code == 400
 
 
 class TestOperations:
@@ -366,8 +671,15 @@ class TestOperations:
     def test_can_intra_move(self, provider):
         assert provider.can_intra_move(provider)
 
-    def test_conflict_error_handler_not_found(self, provider, not_found_metadata_data):
+    def test_conflict_error_handler_not_found(self, provider, error_fixtures):
         error_path = '/Photos/folder/file'
         with pytest.raises(exceptions.NotFoundError) as exc:
-            provider.dropbox_conflict_error_handler(not_found_metadata_data, error_path=error_path)
+            provider.dropbox_conflict_error_handler(error_fixtures['not_found_metadata_data'], error_path=error_path)
         assert str(exc.value).endswith(' /folder/file')
+
+    def test_can_duplicate_names(self, provider):
+        assert provider.can_duplicate_names() is False
+
+    def test_shares_storage_root(self, provider, other_provider):
+        assert provider.shares_storage_root(other_provider) is False
+        assert provider.shares_storage_root(provider)


### PR DESCRIPTION
Wrote tests for intra_move, intra_copy, delete, revisions, various file and folder metadata calls, a few exceptions and a few operation functions.
Added various fixtures to accommodate these tests.
Moved the fixtures into a fixture file and out of the main test file.

refs: https://openscience.atlassian.net/browse/SVCS-437

## Purpose
increase the coverage of tests for the dropbox addon (provider, exceptions, metadata)

## Summary of changes
Wrote tests for intra_move, intra_copy, delete, revisions, various file and folder metadata calls, a few exceptions and a few operation functions.

moved fixture data to its own file. Put json data into its own seperate files under /fixtures. Fixtures are loaded from these files into batches. 

## Testing
Tests should complete, coverage should be much higher for drop box.