### PR TITLE
Adding a check to box provider validate_v1_path to make sure requested file has pr…

### DIFF
--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -63,6 +63,11 @@ class BoxProvider(provider.BaseProvider):
 
         data = await response.json()
 
+        if self.folder != '0':
+            path_ids = [entry['id'] for entry in data['path_collection']['entries']]
+            if self.folder not in path_ids:
+                raise exceptions.NotFoundError(path)
+
         names, ids = zip(*[
             (x['name'], x['id'])
             for x in


### PR DESCRIPTION
…ovider.folder in its full path.

refs: https://openscience.atlassian.net/browse/SVCS-463

## Purpose
Currently if someone does not have their full box path accessible in their project, you could possibly access parts of their box account that should not be available. This fix adds to check to make sure that the requested file has provider.folder in its full path reference.

## Summary of changes
added a check to make sure that provider.folder is available in the path reference from a files metadata in the box provider. If it is not available, throw an error. If it is available, continue on as normal. This check is not applied to 'root' since all files are available from root.

## QA notes
The best way to test this is with postman. 
Set up your box provider to look something like this:
root>
     bar.txt
     /testfolder/
            .......
set your osf box addons current folder to /testfolder/

Now in post man, send a request to:
http://{{host}}{{port}}/v1/resources/{{project_id}}/providers/box/{{bar.txt_file_id}}
You should receive a 404 back, and not a 500 response code.

if you set your box providers current folder back to root, the above command should give back the info for bar.txt

