### PR TITLE
[SVCS-327][SVCS-292] Make Box give folder children’s metadata on moves and copies

### DIFF
--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -210,14 +210,14 @@ class BoxProvider(provider.BaseProvider):
 
 
     async def intra_move_copy_metadata(self, path, data: dict) -> BaseBoxMetadata:
+        created = path.identifier is None
         if data['type'] == 'file':
-            return self._serialize_item(data, path), path.identifier is None
+            return self._serialize_item(data, path), created
         else:
             folder = self._serialize_item(data, path)
             path.parts[-1]._id = data['id']
             folder._children = await self._get_folder_meta(path)
-            return folder, path.identifier is None
-
+            return folder, created
 
     async def intra_move(self,  # type: ignore
                          dest_provider: provider.BaseProvider,

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -208,7 +208,6 @@ class BoxProvider(provider.BaseProvider):
 
         return (await self.intra_move_copy_metadata(dest_path, data))
 
-
     async def intra_move_copy_metadata(self, path, data: dict) -> BaseBoxMetadata:
         created = path.identifier is None
         if data['type'] == 'file':

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -206,7 +206,18 @@ class BoxProvider(provider.BaseProvider):
         ) as resp:
             data = await resp.json()
 
-        return self._serialize_item(data, dest_path), dest_path.identifier is None
+        return (await self.intra_move_copy_metadata(dest_path, data))
+
+
+    async def intra_move_copy_metadata(self, path, data: dict) -> BaseBoxMetadata:
+        if data['type'] == 'file':
+            return self._serialize_item(data, path), path.identifier is None
+        else:
+            folder = self._serialize_item(data, path)
+            path.parts[-1]._id = data['id']
+            folder._children = await self._get_folder_meta(path)
+            return folder, path.identifier is None
+
 
     async def intra_move(self,  # type: ignore
                          dest_provider: provider.BaseProvider,
@@ -233,7 +244,7 @@ class BoxProvider(provider.BaseProvider):
         ) as resp:
             data = await resp.json()
 
-        return self._serialize_item(data, dest_path), dest_path.identifier is None
+        return (await self.intra_move_copy_metadata(dest_path, data))
 
     @property
     def default_headers(self) -> dict:


### PR DESCRIPTION
# Purpose

On inter/intra moves/copies Box doesn't return the folder's children, this fixes that.

# Changes

Changes item serializer to include children to metadata.

# Side Effects

None that I know of.

# Ticket

https://openscience.atlassian.net/browse/SVCS-292

# Old PR

https://github.com/CenterForOpenScience/waterbutler/pull/220