### PR TITLE
Added crud test in postman for providers

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -16,10 +16,10 @@ Quickstart for Newman:
 
 | copy_files:
 | copy_folders:
-| move_files:
-| move_folders:
+| crud_cases
 |
-| *copy_files, copy_folders, move_files, and move_folders can all share the same setup and environment.*
+| *copy_files, crud_cases and copy_folders can share the same setup and environment.*
+| *crud_cases only requires the first PID to be valid, and does not use the second one.*
 |
 
 Setup:
@@ -39,10 +39,7 @@ Environment file:
 
 Testing:
 
-1. Import the \*.json collections files from ``tests/postman/collections`` and the sample environment file you just updated into the Postman App.
+1. Import the collection you would like to run from ``tests/postman/collections`` and the environment file you just updated into the Postman App.
+#. **Note:** Importing your environment may give a few errors. It is most likely fine and should still run.
 #. Run the imported collections using the imported environment.
-
-Notes:
-
-1. A failed run may leave files and/or folders behind. You will need to manually remove these before starting another run.
-#. Some provider actions may take longer then the default 15 second timeout. It is recommended that you set the WAIT_TIMEOUT variable in waterbutler/tasks/settings.py to 600 instead to the default 15. Otherwise your tests may fail.
+#. **Note:** A failed run may leave files and/or folders behind. You will need to manually remove these before starting another run.

--- a/tests/postman/collections/crud_cases.json
+++ b/tests/postman/collections/crud_cases.json
@@ -1,0 +1,17276 @@
+{
+	"variables": [],
+	"info": {
+		"name": "CRUD tests",
+		"_postman_id": "6d260b95-5b21-6571-53b0-864fcb8c096d",
+		"description": "",
+		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Abuse cases",
+			"description": "",
+			"item": [
+				{
+					"name": "Acess folder with missing / in path",
+					"description": "",
+					"item": [
+						{
+							"name": "Access root folder missing /",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"var str = data.data.attributes.path;",
+													"str = str.substring(0, str.length - 1);",
+													"postman.setEnvironmentVariable(\"bad_folder1_path\", str);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{bad_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{bad_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file2 to folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=file&name=file2.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file2.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file2"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete 1 folder",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Access subdirectory missing /",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"var str = data.data.attributes.path;",
+													"str = str.substring(0, str.length - 1);",
+													"postman.setEnvironmentVariable(\"bad_folder2_path\", str);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{bad_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{bad_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Acess sub-subdirectory missing /",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder3 in folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder3_path\", data.data.attributes.path);",
+													"var str = data.data.attributes.path;",
+													"str = str.substring(0, str.length - 1);",
+													"postman.setEnvironmentVariable(\"bad_folder3_path\", str);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=folder&name=folder3",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder3"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{bad_folder3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{bad_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Access files with / in path",
+					"description": "",
+					"item": [
+						{
+							"name": "Root file with / in path",
+							"description": "",
+							"item": [
+								{
+									"name": "root upload file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file1_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"bad_file1_path\", data.data.attributes.path + \"/\");",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=file&name=file1.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file1.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file1"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{bad_file1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{bad_file1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file1 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{bad_file1_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "File in directory with / in path",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file2 to folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file2_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"bad_file2_path\", data.data.attributes.path + \"/\");",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=file&name=file2.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file2.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file2"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{bad_file2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{bad_file2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{bad_file2_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "File in subdirectory with / in path",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm empty contents\"] = data.data = [];",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file3 to folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file3_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"bad_file3_path\", data.data.attributes.path + \"/\");",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=file&name=file3.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file3.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file3"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{bad_file3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{bad_file3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file3 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{bad_file3_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "File in sub-subdirectory with / in path",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder3 in folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder3_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=folder&name=folder3",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder3"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file4 to folder 3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file4_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"bad_file4_path\", data.data.attributes.path + \"/\");",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?kind=file&name=file4.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file4.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file4"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{bad_file4_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{bad_file4_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file4 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{bad_file4_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Create folder with existing name",
+					"description": "",
+					"item": [
+						{
+							"name": "Create root folder with existing name",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 409\"] = responseCode.code === 409;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete 1 folder",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create subdirectory with existing name",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm empty contents\"] = data.data = [];",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 409\"] = responseCode.code === 409;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create sub-subdirctory with existing name",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder3 in folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder3_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=folder&name=folder3",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder3"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder3 in folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 409\"] = responseCode.code === 409;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=folder&name=folder3",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder3"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Upload file with existing name",
+					"description": "",
+					"item": [
+						{
+							"name": "Create root file with existing name",
+							"description": "",
+							"item": [
+								{
+									"name": "root upload file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file1_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"file1_size\", data.data.attributes.size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=file&name=file1.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file1.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file1"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file1_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file1 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file1';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "root upload file1 again",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 409\"] = responseCode.code === 409;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=file&name=file1.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file1.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file1"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create file in folder with existing name",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file2 to folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file2_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"file2_size\", data.data.attributes.size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=file&name=file2.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file2.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file2"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file2_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file2';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file2 to folder1 again",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 409\"] = responseCode.code === 409;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=file&name=file2.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file2.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file2"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create file in subdirectory with existing name",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm empty contents\"] = data.data = [];",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file3 to folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file3_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"file3_size\", data.data.attributes.size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=file&name=file3.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file3.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file3"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file3_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file3 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file3';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file3 to folder2 again",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 409\"] = responseCode.code === 409;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=file&name=file3.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file3.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file3"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create file in sub-subdirectory with existing name",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder3 in folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder3_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=folder&name=folder3",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder3"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file4 to folder 3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file4_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"file4_size\", data.data.attributes.size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?kind=file&name=file4.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file4.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file4"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file4_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file4_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file4 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file4';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file4 to folder 3 again",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 409\"] = responseCode.code === 409;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?kind=file&name=file4.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file4.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file4"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Create folders with missing parameters",
+					"description": "",
+					"item": [
+						{
+							"name": "Create root folder",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 400\"] = responseCode.code === 400;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create subdirectory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 400\"] = responseCode.code === 400;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create sub-subdirctory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder3 in folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 400\"] = responseCode.code === 400;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=folder",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Create files with missing parameters",
+					"description": "",
+					"item": [
+						{
+							"name": "Create root file with missing parameters",
+							"description": "",
+							"item": [
+								{
+									"name": "root upload file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 400\"] = responseCode.code === 400;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=file",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file1"
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create file in folder with missing parameters",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file2 to folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 400\"] = responseCode.code === 400;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=file",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file2"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create file  subdirectory with missing parameters",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm empty contents\"] = data.data = [];",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file3 to folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 400\"] = responseCode.code === 400;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=file",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file3"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create file in sub-subdirectory with missing parameters",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder3 in folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder3_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=folder&name=folder3",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder3"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file4 to folder 3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 400\"] = responseCode.code === 400;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?kind=file",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file4"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				}
+			]
+		},
+		{
+			"name": "Valid cases",
+			"description": "",
+			"item": [
+				{
+					"name": "Create folders",
+					"description": "",
+					"item": [
+						{
+							"name": "Create root folder",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file2 to folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=file&name=file2.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file2.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file2"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete 1 folder",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create subdirectory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm empty contents\"] = data.data = [];",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file3 to folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file3_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=file&name=file3.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file3.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file3"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create sub-subdirctory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder3 in folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder3_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=folder&name=folder3",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder3"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file4 to folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file3_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?kind=file&name=file4.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file4.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file4"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file3 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Create files",
+					"description": "",
+					"item": [
+						{
+							"name": "Create root file",
+							"description": "",
+							"item": [
+								{
+									"name": "root upload file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file1_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"file1_size\", data.data.attributes.size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=file&name=file1.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file1.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file1"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file1_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file1 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file1';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create file in folder",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file2 to folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file2_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"file2_size\", data.data.attributes.size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=file&name=file2.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file2.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file2"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file2_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file2';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create file  subdirectory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm empty contents\"] = data.data = [];",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file3 to folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file3_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"file3_size\", data.data.attributes.size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=file&name=file3.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file3.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file3"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file3_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file3 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file3';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Create file in sub-subdirectory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder3 in folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder3_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=folder&name=folder3",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder3"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm resource\"] = data.data[0].attributes.resource === environment.PID;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file4 to folder 3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file4_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"file4_size\", data.data.attributes.size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?kind=file&name=file4.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file4.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file4"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file4_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file4_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file4 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file4';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Update folders",
+					"description": "",
+					"item": [
+						{
+							"name": "Update root folder",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_folder1_move_path\", data.data.links.move);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "rename folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_folder1_move_path\", data.data.links.move);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';",
+													"tests[\"confirm name\"] = data.data.attributes.name === 'newfolder1';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{prov_folder1_move_path}}",
+										"method": "POST",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}",
+												"description": ""
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"description": ""
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"action\":   \"rename\",\n    \"conflict\": \"warn\",\n    \"rename\":   \"newfolder1\"\n\n}"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "rename again",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 409\"] = responseCode.code === 409;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{prov_folder1_move_path}}",
+										"method": "POST",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											},
+											{
+												"description": "",
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"action\":   \"rename\",\n    \"conflict\": \"warn\",\n    \"rename\":   \"newfolder1\"\n\n}"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file2 to folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"postman.setEnvironmentVariable(\"file2_size\", data.data.attributes.size);",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=file&name=file2.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file2.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file2"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file2_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Update subdirectory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_folder2_move_path\", data.data.links.move);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm empty contents\"] = data.data = [];",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "rename folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_folder2_move_path\", data.data.links.move);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';",
+													"tests[\"confirm name\"] = data.data.attributes.name === 'newfolder2';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{prov_folder2_move_path}}",
+										"method": "POST",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}",
+												"description": ""
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"description": ""
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"action\":   \"rename\",\n    \"conflict\": \"warn\",\n    \"rename\":   \"newfolder2\"\n\n}"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "rename again",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 409\"] = responseCode.code === 409;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{prov_folder2_move_path}}",
+										"method": "POST",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											},
+											{
+												"description": "",
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"action\":   \"rename\",\n    \"conflict\": \"warn\",\n    \"rename\":   \"newfolder2\"\n\n}"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file3 to folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file3_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"file3_size\", data.data.attributes.size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=file&name=file3.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file3.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file3"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file2_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Update sub-subdirectory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder3 in folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder3_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_folder3_move_path\", data.data.links.move);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=folder&name=folder3",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder3"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm empty contents\"] = data.data = [];",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "rename folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder3_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_folder3_move_path\", data.data.links.move);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';",
+													"tests[\"confirm name\"] = data.data.attributes.name === 'newfolder3';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{prov_folder3_move_path}}",
+										"method": "POST",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}",
+												"description": ""
+											},
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"description": ""
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"action\":   \"rename\",\n    \"conflict\": \"warn\",\n    \"rename\":   \"newfolder3\"\n\n}"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "rename again",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 409\"] = responseCode.code === 409;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{prov_folder3_move_path}}",
+										"method": "POST",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											},
+											{
+												"description": "",
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"action\":   \"rename\",\n    \"conflict\": \"warn\",\n    \"rename\":   \"newfolder3\"\n\n}"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file4 to folder 3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file4_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"file4_size\", data.data.attributes.size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?kind=file&name=file4.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file4.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file4"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file4_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file4_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Update files",
+					"description": "",
+					"item": [
+						{
+							"name": "Update root file",
+							"description": "",
+							"item": [
+								{
+									"name": "root upload file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file1_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"file1_size\", data.data.attributes.size);",
+													"postman.setEnvironmentVariable(\"prov_file1_upload_path\", data.data.links.upload);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=file&name=file1.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file1.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file1"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file1_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file1 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file1';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "update file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"file1_size\", data.data.attributes.size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"postman.setEnvironmentVariable(\"prov_file1_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_file1_upload_path\", data.data.links.upload);"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{prov_file1_upload_path}}",
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}",
+												"description": ""
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file1 updated"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get updated file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file1_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get updated file1 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file1 updated';",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Update file in directory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_folder1_move_path\", data.data.links.move);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file2 to folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"postman.setEnvironmentVariable(\"file2_size\", data.data.attributes.size);",
+													"postman.setEnvironmentVariable(\"prov_file2_upload_path\", data.data.links.upload);",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=file&name=file2.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file2.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file2"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file2_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file2';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "update file2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"file2_size\", data.data.attributes.size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"postman.setEnvironmentVariable(\"prov_file2_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_file2_upload_path\", data.data.links.upload);"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{prov_file2_upload_path}}",
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}",
+												"description": ""
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file2 updated"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get updated file2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file2_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get updated file2 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file2 updated';",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Update file in subdirectory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_folder1_move_path\", data.data.links.move);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_folder2_move_path\", data.data.links.move);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm empty contents\"] = data.data = [];",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file3 to folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file3_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"postman.setEnvironmentVariable(\"file3_size\", data.data.attributes.size);",
+													"postman.setEnvironmentVariable(\"prov_file3_upload_path\", data.data.links.upload);",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=file&name=file3.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file3.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file3"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file3_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file3 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file3';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "update file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"file3_size\", data.data.attributes.size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"postman.setEnvironmentVariable(\"prov_file3_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_file3_upload_path\", data.data.links.upload);"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{prov_file3_upload_path}}",
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}",
+												"description": ""
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file3 updated"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get updated file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file3_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get updated file3 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file3 updated';",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Update file in sub-subdirectory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder3 in folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder3_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=folder&name=folder3",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder3"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm empty contents\"] = data.data = [];",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file4 to folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file4_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"file4_size\", data.data.attributes.size);",
+													"postman.setEnvironmentVariable(\"prov_file4_upload_path\", data.data.links.upload);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?kind=file&name=file4.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file4.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file4"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file4_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file4_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file4 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file4';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "update file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"file4_size\", data.data.attributes.size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"postman.setEnvironmentVariable(\"prov_file4_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_file4_upload_path\", data.data.links.upload);"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{prov_file4_upload_path}}",
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}",
+												"description": ""
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file4 updated"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get updated file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file4_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file4_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get updated file4 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file4 updated';",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Delete folders",
+					"description": "",
+					"item": [
+						{
+							"name": "Delete root folder",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get deleted folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1 again",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Delete subdirectory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm empty contents\"] = data.data = [];",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2 again",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Delete sub-subdirectory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder3 in folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder3_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=folder&name=folder3",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder3"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm empty contents\"] = data.data = [];",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder3 again",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Delete files",
+					"description": "",
+					"item": [
+						{
+							"name": "Delete root file",
+							"description": "",
+							"item": [
+								{
+									"name": "root upload file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file1_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"file1_size\", data.data.attributes.size);",
+													"postman.setEnvironmentVariable(\"prov_file1_upload_path\", data.data.links.upload);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=file&name=file1.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file1.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file1"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file1_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file1 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file1';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file1 again",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Delete file in a directory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_folder1_move_path\", data.data.links.move);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file2 to folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"postman.setEnvironmentVariable(\"file2_size\", data.data.attributes.size);",
+													"postman.setEnvironmentVariable(\"prov_file2_upload_path\", data.data.links.upload);",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=file&name=file2.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file2.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file2"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file2_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file2';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file1 again",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Delete file in subdirectory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_folder1_move_path\", data.data.links.move);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"prov_folder2_move_path\", data.data.links.move);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm empty contents\"] = data.data = [];",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file3 to folder 2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file3_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"postman.setEnvironmentVariable(\"file3_size\", data.data.attributes.size);",
+													"postman.setEnvironmentVariable(\"prov_file3_upload_path\", data.data.links.upload);",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=file&name=file3.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file3.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file3"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file3_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file3 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file3';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file3 again",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Delete file in sub-subdirectory",
+							"description": "",
+							"item": [
+								{
+									"name": "root create folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder1_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}/?kind=folder&name=folder1",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}",
+												""
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder1"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder2 in folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder2_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?kind=folder&name=folder2",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder2"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "create folder3 in folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_folder3_path\", data.data.attributes.path);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'folder';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?kind=folder&name=folder3",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "folder"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "folder3"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder1_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder2_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm empty contents\"] = data.data = [];",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "upload file4 to folder 3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 201\"] = responseCode.code === 201;",
+													"var data = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"prov_file4_path\", data.data.attributes.path);",
+													"postman.setEnvironmentVariable(\"file4_size\", data.data.attributes.size);",
+													"postman.setEnvironmentVariable(\"prov_file4_upload_path\", data.data.links.upload);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}?kind=file&name=file4.txt",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_folder3_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "kind",
+													"value": "file"
+												},
+												{
+													"description": "",
+													"equals": true,
+													"key": "name",
+													"value": "file4.txt"
+												}
+											],
+											"variable": []
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "file4"
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = JSON.parse(responseBody);",
+													"tests[\"confirm size\"] = data.data.attributes.size === parseInt(environment.file4_size);",
+													"tests[\"confirm resource\"] = data.data.attributes.resource === environment.PID;",
+													"tests[\"confirm kind\"] = data.data.attributes.kind === 'file';",
+													"",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file4_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file4 download",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 200\"] = responseCode.code === 200;",
+													"var data = responseBody;",
+													"tests[\"confirm file contents\"] = data === 'file4';",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}",
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "get file4",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;",
+													""
+												]
+											}
+										}
+									],
+									"request": {
+										"url": {
+											"raw": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}?meta=",
+											"host": [
+												"{{protocol}}{{host}}{{port}}"
+											],
+											"path": [
+												"v1",
+												"resources",
+												"{{PID}}",
+												"providers",
+												"{{provider}}{{prov_file4_path}}"
+											],
+											"query": [
+												{
+													"description": "",
+													"equals": true,
+													"key": "meta",
+													"value": ""
+												}
+											],
+											"variable": []
+										},
+										"method": "GET",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete file4 again",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 404\"] = responseCode.code === 404;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_file4_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder3",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder3_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder2",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder2_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								},
+								{
+									"name": "delete folder1",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													"tests[\"Status code is 204\"] = responseCode.code === 204;"
+												]
+											}
+										}
+									],
+									"request": {
+										"url": "{{protocol}}{{host}}{{port}}/v1/resources/{{PID}}/providers/{{provider}}{{prov_folder1_path}}",
+										"method": "DELETE",
+										"header": [
+											{
+												"description": "",
+												"key": "Authorization",
+												"value": "Basic {{basic_auth}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"description": ""
+									},
+									"response": []
+								}
+							],
+							"_postman_isSubFolder": true
+						}
+					],
+					"_postman_isSubFolder": true
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
tests should work with name and id based file providers.

refs: https://openscience.atlassian.net/browse/SVCS-419
https://openscience.atlassian.net/browse/SVCS-472

## Purpose
Add crud related and abuse case testing collections to waterbutlers Postman tests.

## Summary of changes

Updated the documents to reflect added tests and clarified a few things.

Added Valid case CRUD testing
*Added Create file/folders testing
*Added Update file/folders testing
*Added Delete file/folders testing

Added Abuse case testings
* Missing / in path testing
* Extra / in path testing on files
* Create files/folders with missing name parameter
* Create file/folders with an already existing name

## QA/testing notes

None, for internal use only.
