### PR TITLE
[SVCS-462] Removed 3 functions that are no longer in use

### DIFF
--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -460,26 +460,6 @@ class GoogleDriveProvider(provider.BaseProvider):
         ) as resp:
             return await resp.json()
 
-    async def _materialized_path_to_id(self, path, parent_id=None):
-        parts = path.parts
-        item_id = parent_id or self.folder['id']
-
-        while parts:
-            query = self._build_query(path.identifier)
-            async with self.request(
-                'GET',
-                self.build_url('files', item_id, 'children', q=query),
-                expects=(200, ),
-                throws=exceptions.MetadataError,
-            ) as resp:
-                try:
-                    item_id = (await resp.json())['items'][0]['id']
-                except (KeyError, IndexError):
-                    raise exceptions.MetadataError('{} not found'.format(str(path)),
-                                                   code=HTTPStatus.NOT_FOUND)
-
-        return item_id
-
     async def _resolve_path_to_ids(self, path, start_at=None):
         """Takes a path and traverses the file tree (ha!) beginning at ``start_at``, looking for
         something that matches ``path``.  Returns a list of dicts for each part of the path, with
@@ -549,50 +529,6 @@ class GoogleDriveProvider(provider.BaseProvider):
             ) as resp:
                 ret.append(await resp.json())
         return ret
-
-    async def _resolve_id_to_parts(self, _id, accum=None):
-        self.metrics.incr('called_resolve_id_to_parts')
-        if _id == self.folder['id']:
-            return [{
-                'title': '',
-                'mimeType': 'folder',
-                'id': self.folder['id'],
-            }] + (accum or [])
-
-        if accum is None:
-            async with self.request(
-                'GET',
-                self.build_url('files', _id, fields='id,title,mimeType'),
-                expects=(200, ),
-                throws=exceptions.MetadataError,
-            ) as resp:
-                accum = [await resp.json()]
-
-        for parent in await self._get_parent_ids(_id):
-            if self.folder['id'] == parent['id']:
-                return [parent] + (accum or [])
-        # TODO Custom exception here
-        raise exceptions.MetadataError('ID is out of scope')
-
-    async def _get_parent_ids(self, _id):
-        async with self.request(
-            'GET',
-            self.build_url('files', _id, 'parents', fields='items(id)'),
-            expects=(200, ),
-            throws=exceptions.MetadataError,
-        ) as resp:
-            parents_data = await resp.json()
-
-        parents = []
-        for parent in parents_data['items']:
-            async with self.request(
-                'GET',
-                self.build_url('files', parent['id'], fields='id,title,labels/trashed'),
-                expects=(200, ),
-                throws=exceptions.MetadataError,
-            ) as p_resp:
-                parents.append(await p_resp.json())
-        return parents
 
     async def _handle_docs_versioning(self, path: GoogleDrivePath, item: dict, raw: bool=True):
         """Sends an extra request to GDrive to fetch revision information for Google Docs. Needed


### PR DESCRIPTION
Removed _materialized_path_to_id. It was added and seemed to never be used, or if it was, it was removed and rewritten long ago

Removed _resolve_id_to_parts. This was once used in validate_path, but was commented out and removed at one point. no longer in use

Removed _get_parent_ids. was only used by the above function.


refs: https://openscience.atlassian.net/browse/SVCS-462


## Purpose
Trim unused code from googledrive provider.

## Summary of Changes
removed 3 functions that were no longer in use, see commit message above for more details

## QA Notes
I did some local testing of moving files, creating folders, uploading files, copy files and folders just to make sure everything seemed okay.

Nothing bad happened and everything should be fine since the functions were not in use. Probably needs more rigorous testing however.