### PR TITLE
Increasing coverage for cloudfiles provider

### DIFF
--- a/tests/providers/cloudfiles/test_metadata.py
+++ b/tests/providers/cloudfiles/test_metadata.py
@@ -1,0 +1,244 @@
+import pytest
+import aiohttp
+from waterbutler.core.path import WaterButlerPath
+
+from waterbutler.providers.cloudfiles.metadata import CloudFilesFileMetadata
+from waterbutler.providers.cloudfiles.metadata import CloudFilesHeaderMetadata
+from waterbutler.providers.cloudfiles.metadata import CloudFilesFolderMetadata
+
+
+@pytest.fixture
+def file_header_metadata_txt():
+    return aiohttp.multidict.CIMultiDict([
+        ('ORIGIN', 'https://mycloud.rackspace.com'),
+        ('CONTENT-LENGTH', '216945'),
+        ('ACCEPT-RANGES', 'bytes'),
+        ('LAST-MODIFIED', 'Mon, 22 Dec 2014 19:01:02 GMT'),
+        ('ETAG', '44325d4f13b09f3769ede09d7c20a82c'),
+        ('X-TIMESTAMP', '1419274861.04433'),
+        ('CONTENT-TYPE', 'text/plain'),
+        ('X-TRANS-ID', 'tx836375d817a34b558756a-0054987deeiad3'),
+        ('DATE', 'Mon, 22 Dec 2014 20:24:14 GMT')
+    ])
+
+
+@pytest.fixture
+def file_metadata():
+    return {
+        'last_modified': '2014-12-19T23:22:14.728640',
+        'content_type': 'application/x-www-form-urlencoded;charset=utf-8',
+        'hash': 'edfa12d00b779b4b37b81fe5b61b2b3f',
+        'name': 'similar.file',
+        'bytes': 190
+    }
+
+
+class TestCloudfilesMetadata:
+
+    def test_header_metadata(self, file_header_metadata_txt):
+
+        path = WaterButlerPath('/file.txt')
+        data = CloudFilesHeaderMetadata(file_header_metadata_txt, path.path)
+        assert data.name == 'file.txt'
+        assert data.path == '/file.txt'
+        assert data.provider == 'cloudfiles'
+        assert data.size == 216945
+        assert data.modified == 'Mon, 22 Dec 2014 19:01:02 GMT'
+        assert data.created_utc is None
+        assert data.content_type == 'text/plain'
+        assert data.etag == '44325d4f13b09f3769ede09d7c20a82c'
+
+        assert data.kind == 'file'
+        assert data.modified_utc == '2014-12-22T19:01:02+00:00'
+        assert data.extra == {
+            'hashes': {
+                'md5': '44325d4f13b09f3769ede09d7c20a82c'
+            }
+        }
+
+        assert data.serialized() == {
+            'extra': {
+                'hashes': {'md5': '44325d4f13b09f3769ede09d7c20a82c'}},
+            'kind': 'file',
+            'name': 'file.txt',
+            'path': '/file.txt',
+            'provider': 'cloudfiles',
+            'materialized': '/file.txt',
+            'etag': 'b63e337b97c11034ab9db4635143754b807ad6f06b8bcdda06867096ab90b6fa',
+            'contentType': 'text/plain',
+            'modified': 'Mon, 22 Dec 2014 19:01:02 GMT',
+            'modified_utc': '2014-12-22T19:01:02+00:00',
+            'created_utc': None,
+            'size': 216945
+        }
+
+        assert data.json_api_serialized('cn42d') == {
+            'id': 'cloudfiles/file.txt',
+            'type': 'files',
+            'attributes': {
+                'extra': {
+                    'hashes': {
+                        'md5': '44325d4f13b09f3769ede09d7c20a82c'
+                    }
+                },
+                'kind': 'file',
+                'name': 'file.txt',
+                'path': '/file.txt',
+                'provider': 'cloudfiles',
+                'materialized': '/file.txt',
+                'etag': 'b63e337b97c11034ab9db4635143754b807ad6f06b8bcdda06867096ab90b6fa',
+                'contentType': 'text/plain',
+                'modified': 'Mon, 22 Dec 2014 19:01:02 GMT',
+                'modified_utc': '2014-12-22T19:01:02+00:00',
+                'created_utc': None,
+                'size': 216945,
+                'resource': 'cn42d'
+            },
+            'links': {
+                'move': 'http://localhost:7777/v1/resources/cn42d/providers/cloudfiles/file.txt',
+                'upload': ('http://localhost:7777/v1/'
+                    'resources/cn42d/providers/cloudfiles/file.txt?kind=file'),
+                'delete': 'http://localhost:7777/v1/resources/cn42d/providers/cloudfiles/file.txt',
+                'download': 'http://localhost:7777/v1/resources/cn42d/providers/cloudfiles/file.txt'
+            }
+        }
+
+        assert data._json_api_links('cn42d') == {
+            'move': 'http://localhost:7777/v1/resources/cn42d/providers/cloudfiles/file.txt',
+            'upload': ('http://localhost:7777/v1/resources/'
+                'cn42d/providers/cloudfiles/file.txt?kind=file'),
+            'delete': 'http://localhost:7777/v1/resources/cn42d/providers/cloudfiles/file.txt',
+            'download': 'http://localhost:7777/v1/resources/cn42d/providers/cloudfiles/file.txt'
+        }
+
+    def test_file_metadata(self, file_metadata):
+        data = CloudFilesFileMetadata(file_metadata)
+        assert data.name == 'similar.file'
+        assert data.provider == 'cloudfiles'
+        assert data.path == '/similar.file'
+        assert data.size == 190
+        assert data.modified == '2014-12-19T23:22:14.728640'
+        assert data.created_utc is None
+        assert data.content_type == 'application/x-www-form-urlencoded;charset=utf-8'
+        assert data.etag == 'edfa12d00b779b4b37b81fe5b61b2b3f'
+        assert data.kind == 'file'
+        assert data.modified_utc == '2014-12-19T23:22:14+00:00'
+        assert data.extra == {
+            'hashes': {
+                'md5': 'edfa12d00b779b4b37b81fe5b61b2b3f'
+            }
+        }
+
+        assert data.serialized() == {
+            'extra': {
+                'hashes': {'md5': 'edfa12d00b779b4b37b81fe5b61b2b3f'}},
+            'kind': 'file',
+            'name': 'similar.file',
+            'path': '/similar.file',
+            'provider': 'cloudfiles',
+            'materialized': '/similar.file',
+            'etag': '6ec17a9d5ecaf7f61ed46fa983361d2317fce07d36b40739b2f7529a1c0f47e0',
+            'contentType': 'application/x-www-form-urlencoded;charset=utf-8',
+            'modified': '2014-12-19T23:22:14.728640',
+            'modified_utc': '2014-12-19T23:22:14+00:00',
+            'created_utc': None,
+            'size': 190
+        }
+
+        assert data.json_api_serialized('cn42d') == {
+            'id': 'cloudfiles/similar.file',
+            'type': 'files',
+            'attributes': {
+                'extra': {
+                    'hashes': {
+                        'md5': 'edfa12d00b779b4b37b81fe5b61b2b3f'
+                    }
+                },
+                'kind': 'file',
+                'name': 'similar.file',
+                'path': '/similar.file',
+                'provider': 'cloudfiles',
+                'materialized': '/similar.file',
+                'etag': '6ec17a9d5ecaf7f61ed46fa983361d2317fce07d36b40739b2f7529a1c0f47e0',
+                'contentType': 'application/x-www-form-urlencoded;charset=utf-8',
+                'modified': '2014-12-19T23:22:14.728640',
+                'modified_utc': '2014-12-19T23:22:14+00:00',
+                'created_utc': None,
+                'size': 190,
+                'resource': 'cn42d'
+            },
+            'links': {
+                'move': ('http://localhost:7777/v1/resources/cn42d'
+                    '/providers/cloudfiles/similar.file'),
+                'upload': ('http://localhost:7777/v1/resources/cn42d'
+                    '/providers/cloudfiles/similar.file?kind=file'),
+                'delete': ('http://localhost:7777/v1/resources/cn42d'
+                    '/providers/cloudfiles/similar.file'),
+                'download': ('http://localhost:7777/v1/resources/cn42d'
+                    '/providers/cloudfiles/similar.file')
+            }
+        }
+
+        assert data._json_api_links('cn42d') == {
+            'move': 'http://localhost:7777/v1/resources/cn42d/providers/cloudfiles/similar.file',
+            'upload': ('http://localhost:7777/v1/resources/'
+                'cn42d/providers/cloudfiles/similar.file?kind=file'),
+            'delete': 'http://localhost:7777/v1/resources/cn42d/providers/cloudfiles/similar.file',
+            'download': 'http://localhost:7777/v1/resources/cn42d/providers/cloudfiles/similar.file'
+        }
+
+    def test_folder_metadata(self):
+        data = CloudFilesFolderMetadata({'subdir': 'level1/'})
+
+        assert data.name == 'level1'
+        assert data.path == '/level1/'
+        assert data.provider == 'cloudfiles'
+
+        assert data.build_path('') == '/'
+        assert data.materialized_path == '/level1/'
+        assert data.is_folder is True
+        assert data.children is None
+        assert data.kind == 'folder'
+        assert data.etag is None
+        assert data.serialized() == {
+            'extra': {},
+            'kind': 'folder',
+            'name': 'level1',
+            'path': '/level1/',
+            'provider': 'cloudfiles',
+            'materialized': '/level1/',
+            'etag': '69cf764abe6f2e90dc81fb4218e15f202f9b99bcd1963cf2d5f011629d6f0d8a'
+        }
+
+        assert data.json_api_serialized('cn42d') == {
+            'id': 'cloudfiles/level1/',
+            'type': 'files',
+            'attributes': {
+                'extra': {},
+                'kind': 'folder',
+                'name': 'level1',
+                'path': '/level1/',
+                'provider': 'cloudfiles',
+                'materialized': '/level1/',
+                'etag': '69cf764abe6f2e90dc81fb4218e15f202f9b99bcd1963cf2d5f011629d6f0d8a',
+                'resource': 'cn42d',
+                'size': None
+            },
+            'links': {
+                'move': 'http://localhost:7777/v1/resources/cn42d/providers/cloudfiles/level1/',
+                'upload': ('http://localhost:7777/v1/resources/'
+                    'cn42d/providers/cloudfiles/level1/?kind=file'),
+                'delete': 'http://localhost:7777/v1/resources/cn42d/providers/cloudfiles/level1/',
+                'new_folder': ('http://localhost:7777/v1/resources/'
+                    'cn42d/providers/cloudfiles/level1/?kind=folder')
+            }
+        }
+
+        assert data._json_api_links('cn42d') == {
+            'move': 'http://localhost:7777/v1/resources/cn42d/providers/cloudfiles/level1/',
+            'upload': ('http://localhost:7777/v1/resources/'
+                'cn42d/providers/cloudfiles/level1/?kind=file'),
+            'delete': 'http://localhost:7777/v1/resources/cn42d/providers/cloudfiles/level1/',
+            'new_folder': ('http://localhost:7777/v1/resources/'
+                'cn42d/providers/cloudfiles/level1/?kind=folder')
+        }

--- a/tests/providers/cloudfiles/test_provider.py
+++ b/tests/providers/cloudfiles/test_provider.py
@@ -3,6 +3,7 @@ import pytest
 from unittest import mock
 
 import io
+import os
 import json
 import time
 import hashlib
@@ -11,12 +12,13 @@ import furl
 import aiohttp
 import aiohttp.multidict
 import aiohttpretty
+import functools
 
 from waterbutler.core import streams
 from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
 
-from waterbutler.providers.cloudfiles import settings
+from waterbutler.providers.cloudfiles import settings as cloud_settings
 from waterbutler.providers.cloudfiles import CloudFilesProvider
 
 
@@ -57,10 +59,10 @@ def auth_json():
                     "type": "object-store",
                     "endpoints": [
                         {
-                            "publicURL": "https://storage101.iad3.clouddrive.com/v1/MossoCloudFS_926294",
-                            "internalURL": "https://snet-storage101.iad3.clouddrive.com/v1/MossoCloudFS_926294",
+                            "publicURL": "https://fakestorage",
+                            "internalURL": "https://intneral_fake_storage",
                             "region": "IAD",
-                            "tenantId": "MossoCloudFS_926294"
+                            "tenantId": "someid_123456"
                         },
                     ]
                 }
@@ -70,8 +72,8 @@ def auth_json():
                     "APIKEY"
                 ],
                 "tenant": {
-                    "name": "926294",
-                    "id": "926294"
+                    "name": "12345",
+                    "id": "12345"
                 },
                 "id": "2322f6b2322f4dbfa69802baf50b0832",
                 "expires": "2014-12-17T09:12:26.069Z"
@@ -88,13 +90,13 @@ def auth_json():
                         "name": "compute:default",
                         "description": "A Role that allows a user access to keystone Service methods",
                         "id": "6",
-                        "tenantId": "926294"
+                        "tenantId": "12345"
                     },
                     {
                         "name": "object-store:default",
                         "description": "A Role that allows a user access to keystone Service methods",
                         "id": "5",
-                        "tenantId": "MossoCloudFS_926294"
+                        "tenantId": "some_id_12345"
                     },
                     {
                         "name": "identity:default",
@@ -398,6 +400,31 @@ class TestCRUD:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
+    async def test_upload_check_none(self, connected_provider,
+                                    file_content, file_stream, file_metadata):
+        path = WaterButlerPath('/foo.bar')
+        content_md5 = hashlib.md5(file_content).hexdigest()
+        metadata_url = connected_provider.build_url(path.path)
+        url = connected_provider.sign_url(path, 'PUT')
+        aiohttpretty.register_uri(
+            'HEAD',
+            metadata_url,
+            responses=[
+                {'status': 404},
+                {'headers': file_metadata},
+            ]
+        )
+        aiohttpretty.register_uri('PUT', url, status=200,
+                                  headers={'ETag': '"{}"'.format(content_md5)})
+        metadata, created = await connected_provider.upload(
+            file_stream, path, check_created=False, fetch_metadata=False)
+
+        assert created is None
+        assert metadata is None
+        assert aiohttpretty.has_call(method='PUT', uri=url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
     async def test_upload_checksum_mismatch(self, connected_provider, file_stream, file_metadata):
         path = WaterButlerPath('/foo.bar')
         metadata_url = connected_provider.build_url(path.path)
@@ -412,21 +439,63 @@ class TestCRUD:
         )
         aiohttpretty.register_uri('PUT', url, status=200, headers={'ETag': '"Bogus MD5"'})
 
-        with pytest.raises(exceptions.UploadChecksumMismatchError) as exc:
+        with pytest.raises(exceptions.UploadChecksumMismatchError):
             await connected_provider.upload(file_stream, path)
 
         assert aiohttpretty.has_call(method='PUT', uri=url)
         assert aiohttpretty.has_call(method='HEAD', uri=metadata_url)
 
+    # @pytest.mark.asyncio
+    # @pytest.mark.aiohttpretty
+    # async def test_delete_folder(self, connected_provider, folder_root_empty, file_metadata):
+    #     # This test will probably fail on a live
+    #     # version of the provider because build_url is called wrong.
+    #     # Will comment out parts of this test till that is fixed.
+    #     path = WaterButlerPath('/delete/')
+    #     query = {'prefix': path.path}
+    #     url = connected_provider.build_url('', **query)
+    #     body = json.dumps(folder_root_empty).encode('utf-8')
+
+    #     delete_query = {'bulk-delete': ''}
+    #     delete_url = connected_provider.build_url('', **delete_query)
+
+    #     file_url = connected_provider.build_url(path.path)
+
+    #     aiohttpretty.register_uri('GET', url, body=body)
+    #     aiohttpretty.register_uri('HEAD', file_url, headers=file_metadata)
+
+    #     aiohttpretty.register_uri('DELETE', delete_url)
+
+    #     await connected_provider.delete(path)
+
+    #     assert aiohttpretty.has_call(method='DELETE', uri=delete_url)
+
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_delete(self, connected_provider):
+    async def test_delete_file(self, connected_provider):
         path = WaterButlerPath('/delete.file')
         url = connected_provider.build_url(path.path)
         aiohttpretty.register_uri('DELETE', url, status=204)
         await connected_provider.delete(path)
 
         assert aiohttpretty.has_call(method='DELETE', uri=url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_copy(self, connected_provider, file_metadata):
+        src_path = WaterButlerPath('/delete.file')
+        dest_path = WaterButlerPath('/folder1/delete.file')
+
+        dest_url = connected_provider.build_url(dest_path.path)
+
+        aiohttpretty.register_uri('HEAD', dest_url, headers=file_metadata)
+        aiohttpretty.register_uri('PUT', dest_url, status=201)
+
+        result = await connected_provider.intra_copy(connected_provider, src_path, dest_path)
+
+        assert result[0].path == '/folder1/delete.file'
+        assert result[0].name == 'delete.file'
+        assert result[0].etag == 'edfa12d00b779b4b37b81fe5b61b2b3f'
 
 
 class TestMetadata:
@@ -501,7 +570,8 @@ class TestMetadata:
                                                               file_root_level1_level2_file2_txt):
         path = WaterButlerPath('/level1/level2/file2.txt')
         url = connected_provider.build_url(path.path)
-        aiohttpretty.register_uri('HEAD', url, status=200, headers=file_root_level1_level2_file2_txt)
+        aiohttpretty.register_uri('HEAD', url, status=200,
+                        headers=file_root_level1_level2_file2_txt)
         result = await connected_provider.metadata(path)
 
         assert result.name == 'file2.txt'
@@ -512,7 +582,8 @@ class TestMetadata:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_metadata_folder_root_level1_empty(self, connected_provider, folder_root_level1_empty):
+    async def test_metadata_folder_root_level1_empty(self, connected_provider,
+                                                        folder_root_level1_empty):
         path = WaterButlerPath('/level1_empty/')
         folder_url = connected_provider.build_url('', prefix=path.path, delimiter='/')
         folder_body = json.dumps([]).encode('utf-8')
@@ -570,11 +641,83 @@ class TestMetadata:
         with pytest.raises(exceptions.MetadataError):
             await connected_provider.metadata(path)
 
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_metadata_file_bad_content_type(self, connected_provider, file_metadata):
+        item = file_metadata
+        item['Content-Type'] = 'application/directory'
+        path = WaterButlerPath('/does_not.exist')
+        url = connected_provider.build_url(path.path)
+        aiohttpretty.register_uri('HEAD', url, headers=item)
+        with pytest.raises(exceptions.MetadataError):
+            await connected_provider.metadata(path)
+
+
+class TestV1ValidatePath:
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_v1_validate_path(self, connected_provider):
+        path = '/ab4x3'
+        result = await connected_provider.validate_v1_path(path)
+
+        assert result.path == path.strip('/')
+
 
 class TestOperations:
 
-    async def test_can_intra_copy(self, connected_provider):
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_ensure_connection(self, provider, auth_json, mock_temp_key):
+        token_url = cloud_settings.AUTH_URL
+
+        aiohttpretty.register_json_uri('POST', token_url, body=auth_json)
+
+        await provider._ensure_connection()
+        assert aiohttpretty.has_call(method='POST', uri=token_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_ensure_connection_not_public(self, provider, auth_json, temp_url_key):
+
+        token_url = cloud_settings.AUTH_URL
+        provider.use_public = False
+        internal_endpoint = "https://intneral_fake_storage"
+
+        aiohttpretty.register_json_uri('POST', token_url, body=auth_json)
+        aiohttpretty.register_uri(
+            'HEAD',
+            internal_endpoint,
+            status=204,
+            headers={'X-Account-Meta-Temp-URL-Key': temp_url_key},
+        )
+        await provider._ensure_connection()
+        assert aiohttpretty.has_call(method='POST', uri=token_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_ensure_connection_bad_url(self, provider, auth_json, endpoint):
+        token_url = cloud_settings.AUTH_URL
+
+        aiohttpretty.register_json_uri('POST', token_url, body=auth_json)
+        aiohttpretty.register_uri(
+            'HEAD',
+            endpoint,
+            status=204,
+            headers={'bad': 'yes'}
+        )
+        with pytest.raises(exceptions.ProviderError) as e:
+            await provider._ensure_connection()
+
+        assert e.value.code == 503
+        assert aiohttpretty.has_call(method='POST', uri=token_url)
+        assert aiohttpretty.has_call(method='HEAD', uri=endpoint)
+
+    def test_can_duplicate_names(self, connected_provider):
+        assert connected_provider.can_duplicate_names() is False
+
+    def test_can_intra_copy(self, connected_provider):
         assert connected_provider.can_intra_copy(connected_provider)
 
-    async def test_can_intra_move(self, connected_provider):
+    def test_can_intra_move(self, connected_provider):
         assert connected_provider.can_intra_move(connected_provider)


### PR DESCRIPTION
## Purpose
Increase the coverage of tests for the cloudfile provider and metadata


## Summary of Changes

Added validate_v1_path test
Added various CRUD tests
Added metadata tests
Added tests for ensure connection
Added test_metadata.py tests

## Testing/QA Notes
There is one test that is commented out for `delete_folder` because a line in the provider has a bug in it, causing an exception. 