### PR TITLE
[SVCS-395] Document that children are returned in the intra-provider move repsonse

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -140,6 +140,8 @@ Move and copy actions both use the same request structure, a POST to the move ur
 
 Files and folders can also be moved between nodes and providers. The resource parameter is the id of the node under which the file/folder should be moved. It must agree with the path parameter, that is the path must identify a valid folder under the node identified by resource. Likewise, the provider parameter may be used to move the file/folder to another storage provider, but both the resource and path parameters must belong to a node and folder already extant on that provider. Both resource and provider default to the current node and providers.
 
+The return value for a successful move or copy will be the metadata associated will the file or in the case of folders the metadata associated with that folder and it's immediate children.
+
 If a moved/copied file is overwriting an existing file, a 200 OK response will be returned. Otherwise, a 201 Created will be returned.
 
 **Delete (file, folders)**


### PR DESCRIPTION
## Purpose

We've standardized the intra-move/copy response across providers, now the docs should explain this.

## Changes

Simple doc changes.

## Ticket
https://openscience.atlassian.net/browse/SVCS-395