### PR TITLE
[SVCS-479]  Raise exception for copy/move replace folder that orphans itself.

### DIFF
--- a/tests/core/test_provider.py
+++ b/tests/core/test_provider.py
@@ -277,6 +277,15 @@ class TestCopy:
         )
 
     @pytest.mark.asyncio
+    async def test_copy_will_self_overwrite(self, provider1):
+        src_path = await provider1.validate_path('/source/path')
+        dest_path = await provider1.validate_path('/destination/')
+        provider1.will_self_overwrite = utils.MockCoroutine()
+
+        with pytest.raises(exceptions.OverwriteSelfError):
+            await provider1.copy(provider1, src_path, dest_path)
+
+    @pytest.mark.asyncio
     async def test_checks_can_intra_copy(self, provider1):
         provider1.can_intra_copy = mock.Mock(return_value=False)
         src_path = await provider1.validate_path('/source/path')
@@ -392,6 +401,15 @@ class TestMove:
             rename='Baz',
             conflict='replace',
         )
+
+    @pytest.mark.asyncio
+    async def test_move_will_self_overwrite(self, provider1):
+        src_path = await provider1.validate_path('/source/path')
+        dest_path = await provider1.validate_path('/destination/')
+        provider1.will_self_overwrite = utils.MockCoroutine()
+
+        with pytest.raises(exceptions.OverwriteSelfError):
+            await provider1.move(provider1, src_path, dest_path)
 
     @pytest.mark.asyncio
     async def test_checks_can_intra_move(self, provider1):

--- a/tests/core/test_provider.py
+++ b/tests/core/test_provider.py
@@ -4,6 +4,7 @@ from tests import utils
 from unittest import mock
 from waterbutler.core import metadata
 from waterbutler.core import exceptions
+from waterbutler.core.path import WaterButlerPath
 
 
 @pytest.fixture
@@ -36,6 +37,36 @@ class TestBaseProvider:
 
     def test_can_intra_move(self, provider2):
         assert provider2.can_intra_move(provider2) is True
+
+    @pytest.mark.asyncio
+    async def test_will_orphan_dest_is_file(self, provider1):
+        src_path =  WaterButlerPath('/folder1/folder1/',
+                                    _ids=['root', 'folder', 'Folder'],
+                                    folder=True)
+        dest_path = WaterButlerPath('/folder1/',
+                                    _ids=['root','folder'],
+                                    folder=False)
+        assert provider1.replace_will_orphan(src_path, dest_path) == False
+
+    @pytest.mark.asyncio
+    async def test_will_orphan_dest_different_names(self, provider1):
+        src_path =  WaterButlerPath('/folder1/folder1/',
+                                    _ids=['root', 'folder', 'Folder'],
+                                    folder=True)
+        dest_path = WaterButlerPath('/folder2/',
+                                    _ids=['root','folder'],
+                                    folder=True)
+        assert provider1.replace_will_orphan(src_path, dest_path) == False
+
+    @pytest.mark.asyncio
+    async def test_will_orphan_dest_different_branch(self, provider1):
+        src_path =  WaterButlerPath('/other_folder/folder1/',
+                                    _ids=['root', 'other_folder', 'Folder'],
+                                    folder=True)
+        dest_path = WaterButlerPath('/folder1/',
+                                    _ids=['root','folder'],
+                                    folder=True)
+        assert provider1.replace_will_orphan(src_path, dest_path) == False
 
     @pytest.mark.asyncio
     async def test_exists(self, provider1):
@@ -310,6 +341,19 @@ class TestCopy:
         provider1.intra_copy.assert_called_once_with(provider1, src_path, dest_path)
 
     @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_copy_folder_orphan(self, provider1):
+        src_path = await provider1.validate_path('/folder1/folder1/')
+        dest_path = await provider1.validate_path('/')
+
+        provider1.can_intra_copy = mock.Mock(return_value=True)
+
+        with pytest.raises(exceptions.OrphanSelfError) as exc:
+            await provider1.copy(provider1, src_path, dest_path)
+        assert exc.value.code == 400
+        assert exc.typename == 'OrphanSelfError'
+
+    @pytest.mark.asyncio
     async def test_calls_folder_op_on_dir(self, provider1):
         src_path = await provider1.validate_path('/source/path/')
         dest_path = await provider1.validate_path('/destination/path/')
@@ -434,6 +478,19 @@ class TestMove:
         assert data == 'Someratheruniquevalue'
         provider1.can_intra_move.assert_called_once_with(provider1, src_path)
         provider1.intra_move.assert_called_once_with(provider1, src_path, dest_path)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_move_folder_orphan(self, provider1):
+        src_path = await provider1.validate_path('/folder1/folder1/')
+        dest_path = await provider1.validate_path('/')
+
+        provider1.can_intra_move = mock.Mock(return_value=True)
+
+        with pytest.raises(exceptions.OrphanSelfError) as exc:
+            await provider1.move(provider1, src_path, dest_path)
+        assert exc.value.code == 400
+        assert exc.typename == 'OrphanSelfError'
 
     @pytest.mark.asyncio
     async def test_calls_folder_op_on_dir_and_delete(self, provider1):

--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -165,7 +165,9 @@ class TestValidatePath:
         provider.folder = '0'
         folder_id = '0'
 
-        good_url = provider.build_url('folders', folder_id, 'items', fields='id,name,type', limit=1000)
+        good_url = provider.build_url('folders', folder_id, 'items',
+                                      fields='id,name,type', limit=1000)
+
         aiohttpretty.register_json_uri('GET', good_url,
                                        body=root_provider_fixtures['revalidate_metadata'],
                                        status=200)
@@ -295,7 +297,7 @@ class TestUpload:
         aiohttpretty.register_json_uri('POST', upload_url, status=201,
                                        body=root_provider_fixtures['checksum_mismatch_metadata'])
 
-        with pytest.raises(exceptions.UploadChecksumMismatchError) as exc:
+        with pytest.raises(exceptions.UploadChecksumMismatchError):
             await provider.upload(file_stream, path)
 
         assert aiohttpretty.has_call(method='POST', uri=upload_url)
@@ -360,8 +362,11 @@ class TestDelete:
         url = provider.build_url('folders', root_path.identifier, 'items',
                                  fields='id,name,size,modified_at,etag,total_count',
                                  offset=(0), limit=1000)
-        aiohttpretty.register_json_uri('GET', url,
-                                       body=root_provider_fixtures['one_entry_folder_list_metadata'])
+        aiohttpretty.register_json_uri(
+            'GET',
+            url,
+            body=root_provider_fixtures['one_entry_folder_list_metadata']
+        )
 
         url = provider.build_url('files', item['id'], fields='id,name,path_collection')
         delete_url = provider.build_url('files', path.identifier)
@@ -568,6 +573,7 @@ class TestRevisions:
 
 
 class TestIntraCopy:
+
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_intra_copy_file(self, provider, root_provider_fixtures):
@@ -582,16 +588,6 @@ class TestIntraCopy:
         expected = (BoxFileMetadata(item, dest_path), True)
 
         assert result == expected
-
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_intra_copy_overwrite_error(self, provider, root_provider_fixtures):
-        item = root_provider_fixtures['file_metadata']['entries'][0]
-        src_path = WaterButlerPath('/name.txt', _ids=(provider, item['id']))
-        with pytest.raises(exceptions.IntraCopyError) as e:
-            await provider.intra_copy(provider, src_path, src_path)
-
-        assert e.value.code == 409
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -630,7 +626,9 @@ class TestIntraCopy:
         expected_folder = BoxFolderMetadata(item, dest_path)
         expected_folder._children = []
         for child_item in list_metadata['entries']:
-            child_path = dest_path.child(child_item['name'], folder=(child_item['type'] == 'folder'))
+            child_path = dest_path.child(child_item['name'],
+                                         folder=(child_item['type'] == 'folder'))
+
             serialized_child = provider._serialize_item(child_item, child_path)
             expected_folder._children.append(serialized_child)
         expected = (expected_folder, True)
@@ -641,7 +639,10 @@ class TestIntraCopy:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_intra_copy_folder_replace(self, provider, intra_fixtures, root_provider_fixtures):
+    async def test_intra_copy_folder_replace(self,
+                                             provider,
+                                             intra_fixtures,
+                                             root_provider_fixtures):
         item = intra_fixtures['intra_folder_metadata']
         list_metadata = root_provider_fixtures['folder_list_metadata']
 
@@ -661,7 +662,9 @@ class TestIntraCopy:
         expected_folder = BoxFolderMetadata(item, dest_path)
         expected_folder._children = []
         for child_item in list_metadata['entries']:
-            child_path = dest_path.child(child_item['name'], folder=(child_item['type'] == 'folder'))
+            child_path = dest_path.child(child_item['name'],
+                                         folder=(child_item['type'] == 'folder'))
+
             serialized_child = provider._serialize_item(child_item, child_path)
             expected_folder._children.append(serialized_child)
         expected = (expected_folder, False)
@@ -691,20 +694,11 @@ class TestIntraMove:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_intra_move_overwrite_error(self, provider, root_provider_fixtures):
-        item = root_provider_fixtures['file_metadata']['entries'][0]
-        src_path = WaterButlerPath('/name.txt', _ids=(provider, item['id']))
-        with pytest.raises(exceptions.IntraCopyError) as e:
-            await provider.intra_move(provider, src_path, src_path)
-
-        assert e.value.code == 409
-
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
     async def test_intra_move_file_replace(self, provider, root_provider_fixtures):
         item = root_provider_fixtures['file_metadata']['entries'][0]
         src_path = WaterButlerPath('/name.txt', _ids=(provider, item['id']))
-        dest_path = WaterButlerPath('/charmander/name.txt', _ids=(provider, item['id'], 'YgzZejrj834j'))
+        dest_path = WaterButlerPath('/charmander/name.txt',
+                                    _ids=(provider, item['id'], 'YgzZejrj834j'))
 
         file_url = provider.build_url('files', src_path.identifier)
         delete_url = provider.build_url('files', dest_path.identifier)
@@ -736,7 +730,10 @@ class TestIntraMove:
         expected_folder = BoxFolderMetadata(item, dest_path)
         expected_folder._children = []
         for child_item in list_metadata['entries']:
-            child_path = dest_path.child(child_item['name'], folder=(child_item['type'] == 'folder'))
+            child_path = dest_path.child(
+                child_item['name'],
+                folder=(child_item['type'] == 'folder')
+            )
             serialized_child = provider._serialize_item(child_item, child_path)
             expected_folder._children.append(serialized_child)
         expected = (expected_folder, True)
@@ -747,7 +744,10 @@ class TestIntraMove:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_intra_move_folder_replace(self, provider, intra_fixtures, root_provider_fixtures):
+    async def test_intra_move_folder_replace(self,
+                                             provider,
+                                             intra_fixtures,
+                                             root_provider_fixtures):
         item = intra_fixtures['intra_folder_metadata']
         list_metadata = root_provider_fixtures['folder_list_metadata']
 
@@ -767,7 +767,9 @@ class TestIntraMove:
         expected_folder = BoxFolderMetadata(item, dest_path)
         expected_folder._children = []
         for child_item in list_metadata['entries']:
-            child_path = dest_path.child(child_item['name'], folder=(child_item['type'] == 'folder'))
+            child_path = dest_path.child(child_item['name'],
+                                         folder=(child_item['type'] == 'folder'))
+
             serialized_child = provider._serialize_item(child_item, child_path)
             expected_folder._children.append(serialized_child)
         expected = (expected_folder, False)
@@ -851,25 +853,29 @@ class TestCreateFolder:
 
 class TestOperations:
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_can_duplicate_names(self, provider):
+    def test_will_self_overwrite(self, provider, other_provider):
+        src_path = WaterButlerPath('/50 shades of nope.txt',
+                                    _ids=(provider.folder, '12231'))
+        dest_path = WaterButlerPath('/50 shades of nope2223.txt',
+                                    _ids=(provider.folder, '2342sdfsd'))
+
+        result = provider.will_self_overwrite(other_provider, src_path, dest_path)
+        assert result is False
+
+        result = provider.will_self_overwrite(other_provider, src_path, src_path)
+        assert result is True
+
+    def test_can_duplicate_names(self, provider):
         assert provider.can_duplicate_names() is False
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_shares_storage_root(self, provider, other_provider):
+    def test_shares_storage_root(self, provider, other_provider):
         assert provider.shares_storage_root(other_provider) is False
         assert provider.shares_storage_root(provider) is True
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_can_intra_move(self, provider, other_provider):
+    def test_can_intra_move(self, provider, other_provider):
         assert provider.can_intra_move(other_provider) is False
         assert provider.can_intra_move(provider) is True
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_can_intra_copy(self, provider, other_provider):
+    def test_can_intra_copy(self, provider, other_provider):
         assert provider.can_intra_copy(other_provider) is False
         assert provider.can_intra_copy(provider) is True

--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -585,10 +585,20 @@ class TestIntraCopy:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
+    async def test_intra_copy_overwrite_error(self, provider, root_provider_fixtures):
+        item = root_provider_fixtures['file_metadata']['entries'][0]
+        src_path = WaterButlerPath('/name.txt', _ids=(provider, item['id']))
+        with pytest.raises(exceptions.IntraCopyError) as e:
+            await provider.intra_copy(provider, src_path, src_path)
+
+        assert e.value.code == 409
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
     async def test_intra_copy_file_replace(self, provider, root_provider_fixtures):
         item = root_provider_fixtures['file_metadata']['entries'][0]
         src_path = WaterButlerPath('/name.txt', _ids=(provider, item['id']))
-        dest_path = WaterButlerPath('/charmander/name.txt', _ids=(provider, item['id'], item['id']))
+        dest_path = WaterButlerPath('/charmander/name.txt', _ids=(provider, item['id'], 'cats77831'))
 
         file_url = provider.build_url('files', src_path.identifier, 'copy')
         delete_url = provider.build_url('files', dest_path.identifier)
@@ -636,7 +646,7 @@ class TestIntraCopy:
         list_metadata = root_provider_fixtures['folder_list_metadata']
 
         src_path = WaterButlerPath('/name/', _ids=(provider, item['id']))
-        dest_path = WaterButlerPath('/charmander/name/', _ids=(provider, item['id'], item['id']))
+        dest_path = WaterButlerPath('/charmander/name/', _ids=(provider, item['id'], '4jkmrm4zzerj'))
 
         file_url = provider.build_url('folders', src_path.identifier, 'copy')
         delete_url = provider.build_url('folders', dest_path.identifier, recursive=True)
@@ -681,10 +691,20 @@ class TestIntraMove:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
+    async def test_intra_move_overwrite_error(self, provider, root_provider_fixtures):
+        item = root_provider_fixtures['file_metadata']['entries'][0]
+        src_path = WaterButlerPath('/name.txt', _ids=(provider, item['id']))
+        with pytest.raises(exceptions.IntraCopyError) as e:
+            await provider.intra_move(provider, src_path, src_path)
+
+        assert e.value.code == 409
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
     async def test_intra_move_file_replace(self, provider, root_provider_fixtures):
         item = root_provider_fixtures['file_metadata']['entries'][0]
         src_path = WaterButlerPath('/name.txt', _ids=(provider, item['id']))
-        dest_path = WaterButlerPath('/charmander/name.txt', _ids=(provider, item['id'], item['id']))
+        dest_path = WaterButlerPath('/charmander/name.txt', _ids=(provider, item['id'], 'YgzZejrj834j'))
 
         file_url = provider.build_url('files', src_path.identifier)
         delete_url = provider.build_url('files', dest_path.identifier)
@@ -725,7 +745,6 @@ class TestIntraMove:
 
         assert result == expected
 
-
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_intra_move_folder_replace(self, provider, intra_fixtures, root_provider_fixtures):
@@ -733,7 +752,7 @@ class TestIntraMove:
         list_metadata = root_provider_fixtures['folder_list_metadata']
 
         src_path = WaterButlerPath('/name/', _ids=(provider, item['id']))
-        dest_path = WaterButlerPath('/charmander/name/', _ids=(provider, item['id'], item['id']))
+        dest_path = WaterButlerPath('/charmander/name/', _ids=(provider, item['id'], '7759994812'))
 
         file_url = provider.build_url('folders', src_path.identifier)
         delete_url = provider.build_url('folders', dest_path.identifier, recursive=True)

--- a/tests/providers/dropbox/test_provider.py
+++ b/tests/providers/dropbox/test_provider.py
@@ -290,8 +290,12 @@ class TestMetadata:
         path = await provider.validate_path('/')
         url = provider.build_url('files', 'list_folder')
         data = {'path': path.full_path}
-        aiohttpretty.register_json_uri('POST', url, data=data,
-                                       body=root_provider_fixtures['folder_with_subdirectory_metadata'])
+        aiohttpretty.register_json_uri(
+            'POST',
+            url,
+            data=data,
+            body=root_provider_fixtures['folder_with_subdirectory_metadata']
+        )
         result = await provider.metadata(path)
 
         assert isinstance(result, list)
@@ -308,8 +312,12 @@ class TestMetadata:
         data = {'path': path.full_path}
         aiohttpretty.register_json_uri('POST', url, data=data,
                                        body=root_provider_fixtures['folder_with_hasmore_metadata'])
-        aiohttpretty.register_json_uri('POST', url + '/continue', data=data,
-                                       body=root_provider_fixtures['folder_with_subdirectory_metadata'])
+        aiohttpretty.register_json_uri(
+            'POST',
+            url + '/continue',
+            data=data,
+            body=root_provider_fixtures['folder_with_subdirectory_metadata']
+        )
 
         result = await provider.metadata(path)
 
@@ -544,7 +552,9 @@ class TestIntra:
                 {
                     'headers': {'Content-Type': 'application/json'},
                     'data': data,
-                    'body': json.dumps(error_fixtures['rename_conflict_folder_metadata']).encode('utf-8'),
+                    'body': json.dumps(
+                        error_fixtures['rename_conflict_folder_metadata']
+                    ).encode('utf-8'),
                     'status': 409
                 },
                 {
@@ -574,8 +584,12 @@ class TestIntra:
 
         url1 = provider.build_url('files', 'copy_reference', 'save')
         data1 = {'copy_reference': 'test', 'path': dest_path.full_path.rstrip('/')}
-        aiohttpretty.register_json_uri('POST', url1, data=data1,
-                                       body=intra_copy_fixtures['intra_copy_other_provider_file_metadata'])
+        aiohttpretty.register_json_uri(
+            'POST',
+            url1,
+            data=data1,
+            body=intra_copy_fixtures['intra_copy_other_provider_file_metadata']
+        )
 
         result = await provider.intra_copy(other_provider, src_path, dest_path)
         expected = (DropboxFileMetadata(
@@ -648,7 +662,9 @@ class TestIntra:
                 {
                     'headers': {'Content-Type': 'application/json'},
                     'data': data,
-                    'body': json.dumps(error_fixtures['rename_conflict_file_metadata']).encode('utf-8'),
+                    'body': json.dumps(
+                        error_fixtures['rename_conflict_file_metadata']
+                    ).encode('utf-8'),
                     'status': 409
                 },
                 {
@@ -689,7 +705,9 @@ class TestIntra:
                 {
                     'headers': {'Content-Type': 'application/json'},
                     'data': data,
-                    'body': json.dumps(error_fixtures['rename_conflict_folder_metadata']).encode('utf-8'),
+                    'body': json.dumps(
+                        error_fixtures['rename_conflict_folder_metadata']
+                    ).encode('utf-8'),
                     'status': 409
                 },
                 {
@@ -719,23 +737,20 @@ class TestIntra:
 
         assert e.value.code == 400
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_intra_overwrite_error(self, provider):
-        src_path = WaterButlerPath('/pfile.txt', prepend=provider.folder)
-
-        with pytest.raises(exceptions.IntraCopyError) as e:
-            await provider.intra_move(provider, src_path, src_path)
-
-        assert e.value.code == 409
-
-        with pytest.raises(exceptions.IntraCopyError) as e:
-            await provider.intra_copy(provider, src_path, src_path)
-
-        assert e.value.code == 409
-
 
 class TestOperations:
+
+    def test_will_self_overwrite(self, provider, other_provider):
+        src_path = WaterButlerPath('/50 shades of nope.txt',
+                                   _ids=(provider.folder, '12231'))
+        dest_path = WaterButlerPath('/50 shades of nope2223.txt',
+                                    _ids=(provider.folder, '2342sdfsd'))
+
+        result = provider.will_self_overwrite(other_provider, src_path, dest_path)
+        assert result is False
+
+        result = provider.will_self_overwrite(other_provider, src_path, src_path)
+        assert result is True
 
     def test_can_intra_copy(self, provider):
         assert provider.can_intra_copy(provider)
@@ -747,7 +762,7 @@ class TestOperations:
         assert provider.can_intra_move(provider)
 
     def test_cannot_intra_move_other(self, provider, other_provider):
-        assert provider.can_intra_move(other_provider) == False
+        assert provider.can_intra_move(other_provider) is False
 
     def test_conflict_error_handler_not_found(self, provider, error_fixtures):
         error_path = '/Photos/folder/file'

--- a/tests/providers/dropbox/test_provider.py
+++ b/tests/providers/dropbox/test_provider.py
@@ -719,6 +719,21 @@ class TestIntra:
 
         assert e.value.code == 400
 
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_intra_overwrite_error(self, provider):
+        src_path = WaterButlerPath('/pfile.txt', prepend=provider.folder)
+
+        with pytest.raises(exceptions.IntraCopyError) as e:
+            await provider.intra_move(provider, src_path, src_path)
+
+        assert e.value.code == 409
+
+        with pytest.raises(exceptions.IntraCopyError) as e:
+            await provider.intra_copy(provider, src_path, src_path)
+
+        assert e.value.code == 409
+
 
 class TestOperations:
 

--- a/tests/providers/googledrive/test_provider.py
+++ b/tests/providers/googledrive/test_provider.py
@@ -1573,51 +1573,36 @@ class TestIntraFunctions:
         assert result == expected
         assert aiohttpretty.has_call(method='PUT', uri=delete_url)
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_intra_copy_move_overwrite_error(self, provider, root_provider_fixtures):
-        item = root_provider_fixtures['docs_file_metadata']
-        src_path = WaterButlerPath('/unsure.txt', _ids=('0', item['id']))
-
-        with pytest.raises(exceptions.IntraCopyError) as e:
-            await provider.intra_copy(provider, src_path, src_path)
-
-        assert e.value.code == 409
-        with pytest.raises(exceptions.IntraCopyError) as e:
-            await provider.intra_move(provider, src_path, src_path)
-
-        assert e.value.code == 409
-
 
 class TestOperationsOrMisc:
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_can_duplicate_names(self, provider):
+    def test_will_self_overwrite(self, provider, other_provider):
+        src_path = GoogleDrivePath('/root/Gear1.stl', _ids=['0', '10', '11'])
+        dest_path = GoogleDrivePath('/root/Gear23123.stl', _ids=['0', '10', '12'])
+
+        result = provider.will_self_overwrite(other_provider, src_path, dest_path)
+        assert result is False
+
+        result = provider.will_self_overwrite(other_provider, src_path, src_path)
+        assert result is True
+
+    def test_can_duplicate_names(self, provider):
         assert provider.can_duplicate_names() is True
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_shares_storage_root(self, provider, other_provider):
+    def test_shares_storage_root(self, provider, other_provider):
         assert provider.shares_storage_root(other_provider) is True
         assert provider.shares_storage_root(provider) is True
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_can_intra_move(self, provider, other_provider):
+    def test_can_intra_move(self, provider, other_provider):
         assert provider.can_intra_move(other_provider) is False
         assert provider.can_intra_move(provider) is True
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test__serialize_item_raw(self, provider, root_provider_fixtures):
+    def test__serialize_item_raw(self, provider, root_provider_fixtures):
         item = root_provider_fixtures['docs_file_metadata']
 
         assert provider._serialize_item(None, item, True) == item
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_can_intra_copy(self, provider, other_provider, root_provider_fixtures):
+    def test_can_intra_copy(self, provider, other_provider, root_provider_fixtures):
         item = root_provider_fixtures['list_file']['items'][0]
         path = WaterButlerPath('/birdie.jpg', _ids=(provider.folder['id'], item['id']))
 
@@ -1654,7 +1639,7 @@ class TestOperationsOrMisc:
                                        body=error_fixtures['parts_file_missing_metadata'])
 
         with pytest.raises(exceptions.MetadataError) as e:
-            result = await provider._resolve_path_to_ids(file_name)
+            await provider._resolve_path_to_ids(file_name)
 
         assert e.value.message == '{} not found'.format(str(path))
         assert e.value.code == 404

--- a/tests/providers/osfstorage/test_provider.py
+++ b/tests/providers/osfstorage/test_provider.py
@@ -341,7 +341,6 @@ class TestIntraCopy:
         src_mock._children_metadata.assert_not_called()
         src_mock.validate_v1_path.assert_not_called()
 
-
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_intra_copy_file(self, provider_and_mock, provider_and_mock2,

--- a/tests/providers/owncloud/test_provider.py
+++ b/tests/providers/owncloud/test_provider.py
@@ -36,6 +36,7 @@ from tests.providers.owncloud.fixtures import (
 def file_like(file_content):
     return io.BytesIO(file_content)
 
+
 @pytest.fixture
 def file_stream(file_like):
     return streams.FileStreamReader(file_like)
@@ -321,6 +322,7 @@ class TestIntraMoveCopy:
         assert metadata.name == 'dissertation.aux'
         assert metadata.kind == 'file'
 
+
 class TestMetadata:
 
     @pytest.mark.asyncio
@@ -358,6 +360,18 @@ class TestRevisions:
 
 
 class TestOperations:
+
+    def test_will_self_overwrite(self, provider):
+        src_path = WaterButlerPath('/50 shades of nope.txt',
+                                    _ids=(provider.folder, '12231'))
+        dest_path = WaterButlerPath('/50 shades of nope2223.txt',
+                                    _ids=(provider.folder, '2342sdfsd'))
+
+        result = provider.will_self_overwrite(provider, src_path, dest_path)
+        assert result is False
+
+        result = provider.will_self_overwrite(provider, src_path, src_path)
+        assert result is True
 
     def test_can_intra_copy(self, provider, provider_different_credentials):
         assert provider.can_intra_copy(provider)

--- a/tests/providers/owncloud/test_provider.py
+++ b/tests/providers/owncloud/test_provider.py
@@ -321,7 +321,6 @@ class TestIntraMoveCopy:
         assert metadata.name == 'dissertation.aux'
         assert metadata.kind == 'file'
 
-
 class TestMetadata:
 
     @pytest.mark.asyncio

--- a/waterbutler/core/exceptions.py
+++ b/waterbutler/core/exceptions.py
@@ -208,6 +208,15 @@ class OverwriteSelfError(InvalidParameters):
                          'folder onto itself is not supported.'.format(path))
 
 
+class OrphanSelfError(InvalidParameters):
+    """Error for conflict=replace sent to methods copy or move, when action would result
+    in removal of a directory containing the file or folder to be copied or moved.
+    """
+    def __init__(self, path):
+        super().__init__('Unable to move or copy \'{}\'. Moving or copying a folder onto parent '
+                         'folder of same name with "replace" is not supported.'.format(path))
+
+
 class UnsupportedOperationError(ProviderError):
     def __init__(self, message, code=HTTPStatus.FORBIDDEN, is_user_error=True):
         if not message:

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -223,18 +223,18 @@ class BaseProvider(metaclass=abc.ABCMeta):
             'got_rename': rename is not None,
         })
 
+        # This does not mean the `dest_path` is a folder, at this point it could just be the parent
+        # of the actual dest_path, or have a blank name
+        if not dest_path.is_file:
+            temp_path = await self.revalidate_path(
+                dest_path,
+                rename or src_path.name,
+                folder=src_path.is_dir
+            )
+            if self.will_self_overwrite(dest_provider, src_path, temp_path):
+                raise exceptions.OverwriteSelfError(src_path)
+
         if handle_naming:
-            # In handle_naming so we don't run it multiple times
-            # This does not mean the `dest_path` is a folder, at this point it could just be the parent
-            # of the actual dest_path, or have a blank name
-            if not dest_path.is_file:
-                temp_path = await self.revalidate_path(
-                    dest_path,
-                    rename or src_path.name,
-                    folder=src_path.is_dir
-                )
-                if self.will_self_overwrite(dest_provider, src_path, temp_path):
-                    raise exceptions.OverwriteSelfError(src_path)
 
             dest_path = await dest_provider.handle_naming(
                 src_path,
@@ -282,6 +282,8 @@ class BaseProvider(metaclass=abc.ABCMeta):
             'got_rename': rename is not None,
         })
 
+        # This does not mean the `dest_path` is a folder, at this point it could just be the parent
+        # of the actual dest_path, or have a blank name
         if not dest_path.is_file:
             temp_path = await self.revalidate_path(
                 dest_path,
@@ -292,17 +294,6 @@ class BaseProvider(metaclass=abc.ABCMeta):
                 raise exceptions.OverwriteSelfError(src_path)
 
         if handle_naming:
-            # In handle_naming so we don't run it multiple times
-            # This does not mean the `dest_path` is a folder, at this point it could just be the parent
-            # of the actual dest_path, or have a blank name
-            if not dest_path.is_file:
-                temp_path = await self.revalidate_path(
-                    dest_path,
-                    rename or src_path.name,
-                    folder=src_path.is_dir
-                )
-                if self.will_self_overwrite(dest_provider, src_path, temp_path):
-                    raise exceptions.OverwriteSelfError(src_path)
 
             dest_path = await dest_provider.handle_naming(
                 src_path,
@@ -457,6 +448,7 @@ class BaseProvider(metaclass=abc.ABCMeta):
 
        .. note::
             Defaults to False
+            Overridden by providers that need to run this check
 
         :param dest_provider: ( :class:`.BaseProvider` ) The provider to check against
         :param  src_path: ( :class:`.WaterButlerPath` ) The move/copy source path

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -207,12 +207,12 @@ class BaseProvider(metaclass=abc.ABCMeta):
         Performs a copy and then a delete.
         Calls :func:`BaseProvider.intra_move` if possible.
 
-        :param dest_provider: ( :class:`.BaseProvider` ) The provider to move to
+        :param dest_provider: ( :class:`BaseProvider` ) The provider to move to
         :param src_path: ( :class:`.WaterButlerPath` ) Path to where the resource can be found
         :param dest_path: ( :class:`.WaterButlerPath` ) Path to where the resource will be moved
         :param rename: ( :class:`str` ) The desired name of the resulting path, may be incremented
         :param conflict: ( :class:`str` ) What to do in the event of a name conflict, ``replace`` or ``keep``
-        :param handle_naming: ( :class:`bool` ) If a naming conflict is detected, should it be automatically handled?
+        :param handle_naming: ( :class:`bool` ) If true will be run through handle_naming method, and handled in accordance with conflict parameter.
         """
         args = (dest_provider, src_path, dest_path)
         kwargs = {'rename': rename, 'conflict': conflict}
@@ -251,6 +251,13 @@ class BaseProvider(metaclass=abc.ABCMeta):
             src_path.materialized_path == dest_path.materialized_path
         ):
             raise exceptions.OverwriteSelfError(src_path)
+
+        if (
+            self == dest_provider and
+            conflict == 'replace' and
+            dest_provider.replace_will_orphan(src_path, dest_path)
+        ):
+            raise exceptions.OrphanSelfError(src_path)
 
         self.provider_metrics.add('move.can_intra_move', False)
         if self.can_intra_move(dest_provider, src_path):
@@ -310,6 +317,13 @@ class BaseProvider(metaclass=abc.ABCMeta):
                 src_path.materialized_path == dest_path.materialized_path
         ):
             raise exceptions.OverwriteSelfError(src_path)
+
+        if (
+            self == dest_provider and
+            conflict == 'replace' and
+            dest_provider.replace_will_orphan(src_path, dest_path)
+        ):
+            raise exceptions.OrphanSelfError(src_path)
 
         self.provider_metrics.add('copy.can_intra_copy', False)
         if self.can_intra_copy(dest_provider, src_path):
@@ -522,6 +536,28 @@ class BaseProvider(metaclass=abc.ABCMeta):
         data, created = await self.intra_copy(dest_provider, src_path, dest_path)
         await self.delete(src_path)
         return data, created
+
+    def replace_will_orphan(self,
+                            src_path: wb_path.WaterButlerPath,
+                            dest_path: wb_path.WaterButlerPath) -> bool:
+        """Check if copy/move conflict=replace will orphan src_path.
+
+        Assumes src_provider == dest_provider and conflict == 'replace' have already been checked.
+        This can be an expensive operation. Should be used as last resort. Should be overridden if
+        provider has a cheaper option.
+        """
+        if not dest_path.kind == 'folder':
+            return False
+        if src_path.name != dest_path.name:
+            return False
+
+        incr_path = src_path
+        while incr_path.materialized_path != '/':
+            incr_path = incr_path.parent
+            if incr_path.materialized_path == dest_path.materialized_path:
+                return True
+
+        return False
 
     async def exists(self, path: wb_path.WaterButlerPath, **kwargs) \
             -> typing.Union[bool, wb_metadata.BaseMetadata, typing.List[wb_metadata.BaseMetadata]]:

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -182,6 +182,9 @@ class BoxProvider(provider.BaseProvider):
         Add a comparison of credentials to avoid this."""
         return super().shares_storage_root(other) and self.credentials == other.credentials
 
+    def will_self_overwrite(self, dest_provider, src_path, dest_path):
+        return self.NAME == dest_provider.NAME and src_path.identifier == dest_path.identifier
+
     def can_intra_move(self, other: provider.BaseProvider,
                        path: wb_path.WaterButlerPath=None) -> bool:
         return self == other
@@ -195,10 +198,6 @@ class BoxProvider(provider.BaseProvider):
                          src_path: wb_path.WaterButlerPath,
                          dest_path: wb_path.WaterButlerPath) \
             -> typing.Tuple[typing.Union[BoxFileMetadata, BoxFolderMetadata], bool]:
-
-        if src_path.identifier == dest_path.identifier:
-            raise exceptions.IntraCopyError("Cannot overwrite a file with itself",
-                                            code=HTTPStatus.CONFLICT)
 
         if dest_path.identifier is not None:
             await dest_provider.delete(dest_path)
@@ -228,10 +227,6 @@ class BoxProvider(provider.BaseProvider):
                          dest_provider: provider.BaseProvider,
                          src_path: wb_path.WaterButlerPath,
                          dest_path: wb_path.WaterButlerPath) -> typing.Tuple[BaseBoxMetadata, bool]:
-
-        if src_path.identifier == dest_path.identifier:
-            raise exceptions.IntraCopyError("Cannot overwrite a file with itself",
-                                            code=HTTPStatus.CONFLICT)
 
         if dest_path.identifier is not None and str(dest_path).lower() != str(src_path).lower():
             await dest_provider.delete(dest_path)

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -195,6 +195,11 @@ class BoxProvider(provider.BaseProvider):
                          src_path: wb_path.WaterButlerPath,
                          dest_path: wb_path.WaterButlerPath) \
             -> typing.Tuple[typing.Union[BoxFileMetadata, BoxFolderMetadata], bool]:
+
+        if src_path.identifier == dest_path.identifier:
+            raise exceptions.IntraCopyError("Cannot overwrite a file with itself",
+                                            code=HTTPStatus.CONFLICT)
+
         if dest_path.identifier is not None:
             await dest_provider.delete(dest_path)
 
@@ -223,6 +228,11 @@ class BoxProvider(provider.BaseProvider):
                          dest_provider: provider.BaseProvider,
                          src_path: wb_path.WaterButlerPath,
                          dest_path: wb_path.WaterButlerPath) -> typing.Tuple[BaseBoxMetadata, bool]:
+
+        if src_path.identifier == dest_path.identifier:
+            raise exceptions.IntraCopyError("Cannot overwrite a file with itself",
+                                            code=HTTPStatus.CONFLICT)
+
         if dest_path.identifier is not None and str(dest_path).lower() != str(src_path).lower():
             await dest_provider.delete(dest_path)
 

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -152,10 +152,6 @@ class DropboxProvider(provider.BaseProvider):
             -> typing.Tuple[typing.Union[DropboxFileMetadata, DropboxFolderMetadata], bool]:
         dest_folder = dest_provider.folder
 
-        if dest_path.full_path == src_path.full_path:
-            raise exceptions.IntraCopyError("Cannot overwrite a file with itself",
-                                                        code=HTTPStatus.CONFLICT)
-
         try:
             if self == dest_provider:
                 data = await self.dropbox_request(
@@ -197,10 +193,6 @@ class DropboxProvider(provider.BaseProvider):
                          dest_provider: 'DropboxProvider',
                          src_path: WaterButlerPath,
                          dest_path: WaterButlerPath) -> typing.Tuple[BaseDropboxMetadata, bool]:
-
-        if dest_path.full_path == src_path.full_path:
-            raise exceptions.IntraCopyError("Cannot overwrite a file with itself",
-                                                        code=HTTPStatus.CONFLICT)
 
         if dest_path.full_path.lower() == src_path.full_path.lower():
             # Dropbox does not support changing the casing in a file name
@@ -379,6 +371,9 @@ class DropboxProvider(provider.BaseProvider):
             throws=exceptions.CreateFolderError,
         )
         return DropboxFolderMetadata(data, self.folder)
+
+    def will_self_overwrite(self, dest_provider, src_path, dest_path):
+        return self.NAME == dest_provider.NAME and dest_path.full_path == src_path.full_path
 
     def can_intra_copy(self, dest_provider: provider.BaseProvider,
                        path: WaterButlerPath=None) -> bool:

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -151,6 +151,11 @@ class DropboxProvider(provider.BaseProvider):
                          dest_path: WaterButlerPath) \
             -> typing.Tuple[typing.Union[DropboxFileMetadata, DropboxFolderMetadata], bool]:
         dest_folder = dest_provider.folder
+
+        if dest_path.full_path == src_path.full_path:
+            raise exceptions.IntraCopyError("Cannot overwrite a file with itself",
+                                                        code=HTTPStatus.CONFLICT)
+
         try:
             if self == dest_provider:
                 data = await self.dropbox_request(
@@ -192,6 +197,11 @@ class DropboxProvider(provider.BaseProvider):
                          dest_provider: 'DropboxProvider',
                          src_path: WaterButlerPath,
                          dest_path: WaterButlerPath) -> typing.Tuple[BaseDropboxMetadata, bool]:
+
+        if dest_path.full_path == src_path.full_path:
+            raise exceptions.IntraCopyError("Cannot overwrite a file with itself",
+                                                        code=HTTPStatus.CONFLICT)
+
         if dest_path.full_path.lower() == src_path.full_path.lower():
             # Dropbox does not support changing the casing in a file name
             raise exceptions.InvalidPathError(

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -151,6 +151,11 @@ class GoogleDriveProvider(provider.BaseProvider):
                          src_path: wb_path.WaterButlerPath,
                          dest_path: wb_path.WaterButlerPath) \
                          -> typing.Tuple[BaseGoogleDriveMetadata, bool]:
+
+        if src_path.identifier == dest_path.identifier:
+            raise exceptions.IntraCopyError("Cannot overwrite a file with itself",
+                                            code=HTTPStatus.CONFLICT)
+
         self.metrics.add('intra_move.destination_exists', dest_path.identifier is not None)
         if dest_path.identifier:
             await dest_provider.delete(dest_path)
@@ -187,6 +192,11 @@ class GoogleDriveProvider(provider.BaseProvider):
                          src_path: wb_path.WaterButlerPath,
                          dest_path: wb_path.WaterButlerPath) \
                          -> typing.Tuple[GoogleDriveFileMetadata, bool]:
+
+        if src_path.identifier == dest_path.identifier:
+            raise exceptions.IntraCopyError("Cannot overwrite a file with itself",
+                                            code=HTTPStatus.CONFLICT)
+
         self.metrics.add('intra_copy.destination_exists', dest_path.identifier is not None)
         if dest_path.identifier:
             await dest_provider.delete(dest_path)

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -135,6 +135,9 @@ class GoogleDriveProvider(provider.BaseProvider):
     def default_headers(self) -> dict:
         return {'authorization': 'Bearer {}'.format(self.token)}
 
+    def will_self_overwrite(self, dest_provider, src_path, dest_path):
+        return self.NAME == dest_provider.NAME and src_path.identifier == dest_path.identifier
+
     def can_intra_move(self,
                        other: provider.BaseProvider,
                        path=None) -> bool:
@@ -151,10 +154,6 @@ class GoogleDriveProvider(provider.BaseProvider):
                          src_path: wb_path.WaterButlerPath,
                          dest_path: wb_path.WaterButlerPath) \
                          -> typing.Tuple[BaseGoogleDriveMetadata, bool]:
-
-        if src_path.identifier == dest_path.identifier:
-            raise exceptions.IntraCopyError("Cannot overwrite a file with itself",
-                                            code=HTTPStatus.CONFLICT)
 
         self.metrics.add('intra_move.destination_exists', dest_path.identifier is not None)
         if dest_path.identifier:
@@ -192,10 +191,6 @@ class GoogleDriveProvider(provider.BaseProvider):
                          src_path: wb_path.WaterButlerPath,
                          dest_path: wb_path.WaterButlerPath) \
                          -> typing.Tuple[GoogleDriveFileMetadata, bool]:
-
-        if src_path.identifier == dest_path.identifier:
-            raise exceptions.IntraCopyError("Cannot overwrite a file with itself",
-                                            code=HTTPStatus.CONFLICT)
 
         self.metrics.add('intra_copy.destination_exists', dest_path.identifier is not None)
         if dest_path.identifier:

--- a/waterbutler/providers/owncloud/provider.py
+++ b/waterbutler/providers/owncloud/provider.py
@@ -1,5 +1,4 @@
 import aiohttp
-from http import HTTPStatus
 
 from waterbutler.core import streams
 from waterbutler.core import provider
@@ -267,6 +266,9 @@ class OwnCloudProvider(provider.BaseProvider):
     def can_duplicate_names(self):
         return True
 
+    def will_self_overwrite(self, dest_provider, src_path, dest_path):
+        return self.NAME == dest_provider.NAME and src_path.identifier == dest_path.identifier
+
     def can_intra_copy(self, dest_provider, path=None):
         return self == dest_provider
 
@@ -291,10 +293,6 @@ class OwnCloudProvider(provider.BaseProvider):
         """
         if operation != 'MOVE' and operation != 'COPY':
             raise NotImplementedError("ownCloud move/copy only supports MOVE and COPY endpoints")
-
-        if src_path.full_path == dest_path.full_path:
-            raise exceptions.IntraCopyError("Cannot overwrite a file with itself",
-                                                        code=HTTPStatus.CONFLICT)
 
         resp = await self.make_request(
             operation,

--- a/waterbutler/providers/owncloud/provider.py
+++ b/waterbutler/providers/owncloud/provider.py
@@ -1,4 +1,5 @@
 import aiohttp
+from http import HTTPStatus
 
 from waterbutler.core import streams
 from waterbutler.core import provider
@@ -290,6 +291,10 @@ class OwnCloudProvider(provider.BaseProvider):
         """
         if operation != 'MOVE' and operation != 'COPY':
             raise NotImplementedError("ownCloud move/copy only supports MOVE and COPY endpoints")
+
+        if src_path.full_path == dest_path.full_path:
+            raise exceptions.IntraCopyError("Cannot overwrite a file with itself",
+                                                        code=HTTPStatus.CONFLICT)
 
         resp = await self.make_request(
             operation,


### PR DESCRIPTION
## Purpose:
[SVCS-479](https://openscience.atlassian.net/browse/SVCS-479)
Replace folder from inside folder deletes both.

## Changes:
Updated  waterbutler/core/provider.py
-- Add def replace_will_orphan
-- Update def move calls replace_will_orphan
-- Update def copy calls replace_will_orphan
Update  waterbutler/core/exceptions.py
-- Add class OrphanSelfError
Update tests/providers/osfstorage/test_provider.py
-- Add test test_intra_copy_folder_orphan

## Side effects
Folder move/copies that use conflict=replace may now be more costly