### PR TITLE
[SVCS-492] Remove unused path property from BoxRevision

### DIFF
--- a/tests/providers/box/test_metadata.py
+++ b/tests/providers/box/test_metadata.py
@@ -133,7 +133,6 @@ class TestBoxMetadata:
         data = BoxRevision(item)
         assert data.version == '25065971851'
         assert data.version_identifier == 'revision'
-        assert data.path == '/25065971851/lode.txt'
         assert data.modified == '2015-02-24T09:26:02-08:00'
         assert data.modified_utc == '2015-02-24T17:26:02+00:00'
         assert data.serialized() == {

--- a/waterbutler/providers/box/metadata.py
+++ b/waterbutler/providers/box/metadata.py
@@ -81,13 +81,6 @@ class BoxRevision(metadata.BaseFileRevisionMetadata):
         return 'revision'
 
     @property
-    def path(self):
-        try:
-            return '/{0}/{1}'.format(self.raw['id'], self.raw['name'])
-        except KeyError:
-            return self.raw.get('path')
-
-    @property
     def modified(self):
         try:
             return self.raw['modified_at']


### PR DESCRIPTION
refs: https://openscience.atlassian.net/browse/SVCS-492


## Purpose

BoxRevision had an unused `path` property. Removing it keeps code and tests clean.

## Summary of Changes

Did git archeology to make sure the propery was unused. It was last touched around 3 years ago when the box addon was initially being set up. It was indeed unused.

Removed the unused `path` property and removed the test referencing it.

## QA/Testing Notes

I went through and tested edits/revisions locally a bit on the OSF. There seem to be some errors with requesting the most recent revision via the revision picker, but that is unrelated to this change.