### PR TITLE
[SVCS-497] Fixing s3 metadata_headers path tests

### DIFF
--- a/tests/providers/s3/fixtures.py
+++ b/tests/providers/s3/fixtures.py
@@ -102,7 +102,7 @@ def file_header_metadata():
 
 @pytest.fixture
 def file_metadata_headers_object(file_header_metadata):
-    return S3FileMetadataHeaders('/test-path', file_header_metadata)
+    return S3FileMetadataHeaders('test-path', file_header_metadata)
 
 
 @pytest.fixture

--- a/tests/providers/s3/test_metadata.py
+++ b/tests/providers/s3/test_metadata.py
@@ -16,8 +16,8 @@ class TestFileMetadataHeaders:
         assert not file_metadata_headers_object.is_folder
         assert file_metadata_headers_object.is_file
         assert file_metadata_headers_object.name == 'test-path'
-        assert file_metadata_headers_object.path == '//test-path'
-        assert file_metadata_headers_object.materialized_path == '//test-path'
+        assert file_metadata_headers_object.path == '/test-path'
+        assert file_metadata_headers_object.materialized_path == '/test-path'
         assert file_metadata_headers_object.kind == 'file'
         assert file_metadata_headers_object.provider == 's3'
         assert file_metadata_headers_object.size == 9001


### PR DESCRIPTION
refs: https://openscience.atlassian.net/browse/SVCS-497
see comment on refs ^
## Purpose

S3 had an incorrect initialization of a metadata object. This lead to the tests not looking correct.
Path showed up as '//path' instead of '/path'

## Summary of Changes

Changed fixtures and tests to be correct.

## QA/Test notes

Should be no QA needed.