### PR TITLE
[SVCS-496] Fixing filesystem folder metadata name property

### DIFF
--- a/tests/providers/filesystem/test_metadata.py
+++ b/tests/providers/filesystem/test_metadata.py
@@ -100,7 +100,7 @@ class TestMetadata:
     def test_folder_metadata(self, folder_metadata):
         data = FileSystemFolderMetadata(folder_metadata, '/')
         assert data.path == '/folder1/'
-        assert data.name == ''
+        assert data.name == 'folder1'
         assert data.provider == 'filesystem'
         assert data.build_path('') == '/'
         assert data.materialized_path == '/folder1/'
@@ -111,7 +111,7 @@ class TestMetadata:
         assert data.serialized() == {
             'extra': {},
             'kind': 'folder',
-            'name': '',
+            'name': 'folder1',
             'path': '/folder1/',
             'provider': 'filesystem',
             'materialized': '/folder1/',
@@ -124,7 +124,7 @@ class TestMetadata:
             'attributes': {
                 'extra': {},
                 'kind': 'folder',
-                'name': '',
+                'name': 'folder1',
                 'path': '/folder1/',
                 'provider': 'filesystem',
                 'materialized': '/folder1/',

--- a/waterbutler/providers/filesystem/metadata.py
+++ b/waterbutler/providers/filesystem/metadata.py
@@ -25,7 +25,7 @@ class FileSystemFolderMetadata(BaseFileSystemMetadata, metadata.BaseFolderMetada
     @property
     def name(self):
         if self.raw['path'].endswith('/'):
-            return os.path.split(self.raw['path'][:-1])[1]
+            return os.path.split(self.raw['path'].rstrip('/'))[1]
         else:
             return os.path.split(self.raw['path'])[1]
 

--- a/waterbutler/providers/filesystem/metadata.py
+++ b/waterbutler/providers/filesystem/metadata.py
@@ -24,7 +24,10 @@ class FileSystemFolderMetadata(BaseFileSystemMetadata, metadata.BaseFolderMetada
 
     @property
     def name(self):
-        return os.path.split(self.raw['path'])[1]
+        if self.raw['path'].endswith('/'):
+            return os.path.split(self.raw['path'][:-1])[1]
+        else:
+            return os.path.split(self.raw['path'])[1]
 
     @property
     def path(self):

--- a/waterbutler/providers/filesystem/metadata.py
+++ b/waterbutler/providers/filesystem/metadata.py
@@ -24,10 +24,7 @@ class FileSystemFolderMetadata(BaseFileSystemMetadata, metadata.BaseFolderMetada
 
     @property
     def name(self):
-        if self.raw['path'].endswith('/'):
-            return os.path.split(self.raw['path'].rstrip('/'))[1]
-        else:
-            return os.path.split(self.raw['path'])[1]
+        return os.path.split(self.raw['path'].rstrip('/'))[1]
 
     @property
     def path(self):


### PR DESCRIPTION
refs: https://openscience.atlassian.net/browse/SVCS-496

## Purpose
Filesystems folder metadata name was returning an empty string. This is a bug and should be fixed.

## Summary of Changes
changed the way the name property is parsed. Fixed test cases so the name value is now correct, (was just the empty string before)

## QA/Test Notes

Nothing to note