### PR TITLE
[HOTFIX][SVCS-533] Don't error when GDrive file is missing md5sum

### DIFF
--- a/waterbutler/providers/googledrive/metadata.py
+++ b/waterbutler/providers/googledrive/metadata.py
@@ -120,7 +120,7 @@ class GoogleDriveFileMetadata(BaseGoogleDriveMetadata, metadata.BaseFileMetadata
         else:
             if not hasattr(ret, 'hashes'):
                 ret['hashes'] = {}
-            ret['hashes']['md5'] = self.raw['md5Checksum']
+            ret['hashes']['md5'] = self.raw.get('md5Checksum')  # no md5 for non-exportable file
 
         return ret
 


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-553

## Purpose

GDrive throws an error when listing the hash for a non-exportable file, this prevents that.

## Changes

One line fix with comment.

## Side effects

None that I know of.

## QA Notes

This effects traditional non-exportable files and files with view permissions, but no download permissions.

## Deployment Notes

Hot fix.
