### PR TITLE
[SVCS-552] Remove unneeded API calls in folder_file_ops

### DIFF
--- a/tests/core/test_provider.py
+++ b/tests/core/test_provider.py
@@ -104,6 +104,15 @@ class TestBaseProvider:
         assert str(path) == str(new_path.parent)
         assert new_path.name == 'text_file.txt'
 
+    @pytest.mark.asyncio
+    async def test_construct_empty_path(self, provider1):
+        path = await provider1.validate_path('/folder/')
+        data = utils.MockFileMetadata()
+        empty_path = await provider1.construct_empty_path(path, data)
+
+        # Make sure its actually not a real path
+        assert empty_path.identifier is None
+
 
 class TestHandleNameConflict:
 

--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -834,23 +834,31 @@ class TestOperations:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_can_duplicate_names(self, provider):
+    async def test_construct_path(self, provider, root_provider_fixtures):
+        path = WaterButlerPath('/50 shades of nope/', _ids=(provider.folder, '0'))
+        item = root_provider_fixtures['revalidate_metadata']['entries'][0]
+        data = BoxFileMetadata(item, path)
+
+        url = provider.build_url('folders', path.identifier, 'items',
+                           fields='id,name,type', limit=1000)
+        aiohttpretty.register_json_uri('GET', url, body=root_provider_fixtures['revalidate_metadata'])
+
+        con_metadata = await provider.construct_path(path, data)
+
+        path_metadata = await provider.revalidate_path(path, data.name)
+        assert con_metadata == path_metadata
+
+    def test_can_duplicate_names(self, provider):
         assert provider.can_duplicate_names() is False
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_shares_storage_root(self, provider, other_provider):
+    def test_shares_storage_root(self, provider, other_provider):
         assert provider.shares_storage_root(other_provider) is False
         assert provider.shares_storage_root(provider) is True
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_can_intra_move(self, provider, other_provider):
+    def test_can_intra_move(self, provider, other_provider):
         assert provider.can_intra_move(other_provider) is False
         assert provider.can_intra_move(provider) is True
 
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_can_intra_copy(self, provider, other_provider):
+    def test_can_intra_copy(self, provider, other_provider):
         assert provider.can_intra_copy(other_provider) is False
         assert provider.can_intra_copy(provider) is True

--- a/tests/providers/dropbox/test_provider.py
+++ b/tests/providers/dropbox/test_provider.py
@@ -722,6 +722,18 @@ class TestIntra:
 
 class TestOperations:
 
+    @pytest.mark.asyncio
+    async def test_construct_path(self, provider, root_provider_fixtures):
+        # Construct replaces revalidate_path in some instances, so it should always
+        # be tested against it, even if calls revalidate_path
+        path = WaterButlerPath('/file.txt')
+
+        data = DropboxFileMetadata(root_provider_fixtures['file_metadata'], folder=False)
+
+        rev_path = await provider.revalidate_path(path.parent, data.name)
+        con_path = await provider.construct_path(path.parent, data)
+        assert rev_path == con_path
+
     def test_can_intra_copy(self, provider):
         assert provider.can_intra_copy(provider)
 
@@ -732,7 +744,7 @@ class TestOperations:
         assert provider.can_intra_move(provider)
 
     def test_cannot_intra_move_other(self, provider, other_provider):
-        assert provider.can_intra_move(other_provider) == False
+        assert provider.can_intra_move(other_provider) is False
 
     def test_conflict_error_handler_not_found(self, provider, error_fixtures):
         error_path = '/Photos/folder/file'

--- a/tests/providers/filesystem/test_provider.py
+++ b/tests/providers/filesystem/test_provider.py
@@ -25,6 +25,17 @@ def credentials():
 
 
 @pytest.fixture
+def file_metadata():
+    return {
+        'path': '/code/website/osfstoragecache/77094244-aa24-48da-9437-d8ce6f7a94e9',
+        'modified_utc': '2017-09-20T15:16:02.601916+00:00',
+        'mime_type': None,
+        'size': 35981,
+        'modified': 'Wed, 20 Sep 2017 15:16:02 +0000'
+    }
+
+
+@pytest.fixture
 def settings(tmpdir):
     return {'folder': str(tmpdir)}
 
@@ -270,6 +281,14 @@ class TestIntra:
 
 
 class TestOperations:
+
+    @pytest.mark.asyncio
+    async def test_construct_path(self, provider, file_metadata):
+        data = FileSystemFileMetadata(file_metadata, '/')
+        path = await provider.validate_path('/folder/')
+        con_path = await provider.construct_path(path, data)
+        rev_path = await provider.revalidate_path(path, data.name)
+        assert con_path == rev_path
 
     def test_can_duplicate_names(self, provider):
         assert provider.can_duplicate_names() is False

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -1349,6 +1349,18 @@ class TestCreateFolder:
 
 class TestOperations:
 
+    @pytest.mark.asyncio
+    async def test_construct_path(self, provider, root_provider_fixtures):
+        path = GitHubPath('/folder/', _ids=[("master", ''), ('whatever', '')])
+        item = root_provider_fixtures['content_repo_metadata_root'][0]
+        data = GitHubFileContentMetadata(
+            item, web_view=item['html_url'], ref=provider.default_branch
+        )
+
+        con_path = await provider.construct_path(path, data)
+        rev_path = await provider.revalidate_path(path, data.name)
+        assert con_path == rev_path
+
     def test_can_duplicate_names(self, provider):
         assert provider.can_duplicate_names() is False
 

--- a/tests/providers/osfstorage/test_provider.py
+++ b/tests/providers/osfstorage/test_provider.py
@@ -495,6 +495,23 @@ class TestIntraMove:
 
 class TestUtils:
 
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_construct_path(self, provider, folder_path, folder_children_metadata,
+                                            mock_time):
+        url, params = build_signed_url_without_auth(provider, 'GET', folder_path.identifier,
+                                                    'children')
+        aiohttpretty.register_json_uri('GET', url, params=params, status=200,
+                                       body=folder_children_metadata)
+
+        rev_path = await provider.revalidate_path(folder_path,
+                                                          folder_children_metadata[1]['name'],
+                                                          folder=False)
+
+        data = OsfStorageFileMetadata(folder_children_metadata[1], '/')
+        con_path = await provider.construct_path(folder_path, data)
+        assert rev_path == con_path
+
     def test_intra_move_copy_utils(self, provider):
         assert provider.can_duplicate_names()
 

--- a/tests/providers/owncloud/test_provider.py
+++ b/tests/providers/owncloud/test_provider.py
@@ -360,6 +360,14 @@ class TestRevisions:
 
 class TestOperations:
 
+    @pytest.mark.asyncio
+    async def test_construct_path(self, provider, file_metadata):
+        data = OwnCloudFileMetadata(file_metadata, '/')
+        path = WaterButlerPath('/dissertation/', prepend=provider.folder)
+        con_path = await provider.construct_path(path, data)
+        rev_path = await provider.revalidate_path(path, data.name)
+        assert con_path == rev_path
+
     def test_can_intra_copy(self, provider, provider_different_credentials):
         assert provider.can_intra_copy(provider)
         assert not provider.can_intra_copy(provider_different_credentials)

--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -808,6 +808,13 @@ class TestCreateFolder:
 class TestOperations:
 
     @pytest.mark.asyncio
+    async def test_construct_path(self, provider, file_metadata_object):
+        path = WaterButlerPath('/dissertation/')
+        con_path = await provider.construct_path(path, file_metadata_object)
+        rev_path = await provider.revalidate_path(path, file_metadata_object.name)
+        assert con_path == rev_path
+
+    @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_intra_copy(self, provider, file_header_metadata, mock_time):
 

--- a/waterbutler/providers/bitbucket/provider.py
+++ b/waterbutler/providers/bitbucket/provider.py
@@ -127,10 +127,16 @@ class BitbucketProvider(provider.BaseProvider):
 
         return path_obj
 
+    async def construct_path(self,  # type: ignore
+                           parent_path: BitbucketPath,
+                           meta_data) -> BitbucketPath:
+
+        return self.path_from_metadata(parent_path, meta_data)
+
     def path_from_metadata(self,  # type: ignore
                            parent_path: BitbucketPath,
-                           metadata) -> BitbucketPath:
-        return parent_path.child(metadata.name, folder=metadata.is_folder)
+                           meta_data) -> BitbucketPath:
+        return parent_path.child(meta_data.name, folder=meta_data.is_folder)
 
     async def metadata(self, path: BitbucketPath, **kwargs):  # type: ignore
         """Get metadata about the requested file or folder.

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -9,10 +9,10 @@ from waterbutler.core import provider
 from waterbutler.core import exceptions
 from waterbutler.core import path as wb_path
 from waterbutler.providers.box import settings
-from waterbutler.providers.box.metadata import (BaseBoxMetadata,
+from waterbutler.providers.box.metadata import (BoxRevision,
+                                                BaseBoxMetadata,
                                                 BoxFileMetadata,
-                                                BoxFolderMetadata,
-                                                BoxRevision)
+                                                BoxFolderMetadata)
 
 
 class BoxProvider(provider.BaseProvider):
@@ -141,6 +141,11 @@ class BoxProvider(provider.BaseProvider):
             return await self.revalidate_path(ret, new_name, folder=is_folder)
 
         return ret
+
+    async def construct_path(self,
+                           parent_path: wb_path.WaterButlerPath,
+                           meta_data: BaseBoxMetadata) -> wb_path.WaterButlerPath:
+        return self.path_from_metadata(parent_path, meta_data)
 
     async def revalidate_path(self, base: wb_path.WaterButlerPath, path: str,
                               folder: bool=None) -> wb_path.WaterButlerPath:

--- a/waterbutler/providers/cloudfiles/provider.py
+++ b/waterbutler/providers/cloudfiles/provider.py
@@ -14,9 +14,10 @@ from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
 
 from waterbutler.providers.cloudfiles import settings
-from waterbutler.providers.cloudfiles.metadata import CloudFilesFileMetadata
-from waterbutler.providers.cloudfiles.metadata import CloudFilesFolderMetadata
-from waterbutler.providers.cloudfiles.metadata import CloudFilesHeaderMetadata
+from waterbutler.providers.cloudfiles.metadata import (BaseCloudFilesMetadata,
+                                                        CloudFilesFileMetadata,
+                                                        CloudFilesFolderMetadata,
+                                                        CloudFilesHeaderMetadata)
 
 
 def ensure_connection(func):
@@ -172,6 +173,11 @@ class CloudFilesProvider(provider.BaseProvider):
                 throws=exceptions.DeleteError,
             )
         await resp.release()
+
+    async def construct_path(self,
+                           parent_path: WaterButlerPath,
+                           meta_data: BaseCloudFilesMetadata) -> WaterButlerPath:
+        return await self.revalidate_path(parent_path, meta_data.name, folder=meta_data.is_folder)
 
     @ensure_connection
     async def metadata(self, path, recursive=False, **kwargs):

--- a/waterbutler/providers/dataverse/provider.py
+++ b/waterbutler/providers/dataverse/provider.py
@@ -5,8 +5,8 @@ from http import HTTPStatus
 from waterbutler.core import streams
 from waterbutler.core import provider
 from waterbutler.core import exceptions
-from waterbutler.core.path import WaterButlerPath
 from waterbutler.core.utils import AsyncIterator
+from waterbutler.core.path import WaterButlerPath
 
 from waterbutler.providers.dataverse import settings
 from waterbutler.providers.dataverse.metadata import DataverseRevision
@@ -227,6 +227,13 @@ class DataverseProvider(provider.BaseProvider):
                 "Could not retrieve file '{}'".format(path),
                 code=HTTPStatus.NOT_FOUND,
             )
+
+    async def construct_path(self,
+                           parent_path: WaterButlerPath,
+                           meta_data) -> WaterButlerPath:
+        # This still makes API calls. Was unsure if Dataverse even can copy/move folders
+        # Since I doubt it will hit this ever or often, it should be fine
+        return await self.revalidate_path(parent_path, meta_data.name, folder=meta_data.is_folder)
 
     async def revisions(self, path, **kwargs):
         """Get past versions of the request file. Orders versions based on

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -290,6 +290,11 @@ class DropboxProvider(provider.BaseProvider):
             throws=exceptions.DeleteError,
         )
 
+    async def construct_path(self,
+                           parent_path: WaterButlerPath,
+                           meta_data: BaseDropboxMetadata) -> WaterButlerPath:
+        return await self.revalidate_path(parent_path, meta_data.name, folder=meta_data.is_folder)
+
     async def metadata(self,  # type: ignore
                        path: WaterButlerPath,
                        revision: str=None,

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -456,6 +456,11 @@ class FigshareProjectProvider(BaseFigshareProvider):
         # Return for v0 folder creation
         return FigsharePath(path, _ids=('', ''), folder=True, is_public=False)
 
+    async def construct_path(self,
+                           parent_path: FigsharePath,
+                           meta_data: metadata.BaseFigshareMetadata) -> FigsharePath:
+        return self.path_from_metadata(parent_path, meta_data)
+
     async def revalidate_path(self, parent_path, child_name, folder):
         """Look for file or folder named ``child_name`` under ``parent_path``. If it finds a match,
         it returns a FigsharePath object with the appropriate ids set.  Otherwise, it returns a

--- a/waterbutler/providers/filesystem/provider.py
+++ b/waterbutler/providers/filesystem/provider.py
@@ -9,8 +9,9 @@ from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
 
 from waterbutler.providers.filesystem import settings
-from waterbutler.providers.filesystem.metadata import FileSystemFileMetadata
-from waterbutler.providers.filesystem.metadata import FileSystemFolderMetadata
+from waterbutler.providers.filesystem.metadata import (FileSystemFileMetadata,
+                                                        BaseFileSystemMetadata,
+                                                        FileSystemFolderMetadata)
 
 
 class FileSystemProvider(provider.BaseProvider):
@@ -85,6 +86,11 @@ class FileSystemProvider(provider.BaseProvider):
             shutil.rmtree(path.full_path)
             if path.is_root:
                 os.makedirs(self.folder, exist_ok=True)
+
+    async def construct_path(self,
+                           parent_path: WaterButlerPath,
+                           meta_data: BaseFileSystemMetadata) -> WaterButlerPath:
+        return await self.revalidate_path(parent_path, meta_data.name, folder=meta_data.is_folder)
 
     async def metadata(self, path, **kwargs):
         if path.is_dir:

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -10,12 +10,13 @@ from waterbutler.core import exceptions
 
 from waterbutler.providers.github import settings
 from waterbutler.providers.github.path import GitHubPath
-from waterbutler.providers.github.metadata import GitHubRevision
-from waterbutler.providers.github.metadata import GitHubFileContentMetadata
-from waterbutler.providers.github.metadata import GitHubFolderContentMetadata
-from waterbutler.providers.github.metadata import GitHubFileTreeMetadata
-from waterbutler.providers.github.metadata import GitHubFolderTreeMetadata
 from waterbutler.providers.github.exceptions import GitHubUnsupportedRepoError
+from waterbutler.providers.github.metadata import (GitHubRevision,
+                                                    BaseGitHubMetadata,
+                                                    GitHubFileTreeMetadata,
+                                                    GitHubFolderTreeMetadata,
+                                                    GitHubFileContentMetadata,
+                                                    GitHubFolderContentMetadata)
 
 
 GIT_EMPTY_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
@@ -131,6 +132,11 @@ class GitHubProvider(provider.BaseProvider):
         self.metrics.add('file_sha_given', True if kwargs.get('fileSha') else False)
 
         return gh_path
+
+    async def construct_path(self,
+                           parent_path: GitHubPath,
+                           meta_data: BaseGitHubMetadata) -> GitHubPath:
+        return await self.revalidate_path(parent_path, meta_data.name, folder=meta_data.is_folder)
 
     async def revalidate_path(self, base, path, folder=False):
         return base.child(path, _id=((base.branch_ref, None)), folder=folder)

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -106,10 +106,15 @@ class GoogleDriveProvider(provider.BaseProvider):
         names, ids = zip(*[(parse.quote(x['title'], safe=''), x['id']) for x in parts])
         return GoogleDrivePath('/'.join(names), _ids=ids, folder='folder' in parts[-1]['mimeType'])
 
+    async def construct_path(self,
+                           parent_path: wb_path.WaterButlerPath,
+                           meta_data: BaseGoogleDriveMetadata) -> wb_path.WaterButlerPath:
+        return self.path_from_metadata(parent_path, meta_data)
+
     async def revalidate_path(self,
                               base: wb_path.WaterButlerPath,
                               name: str,
-                              folder: bool = None) -> wb_path.WaterButlerPath:
+                              folder: bool=None) -> wb_path.WaterButlerPath:
         # TODO Redo the logic here folders names ending in /s
         # Will probably break
         if '/' in name.lstrip('/') and '%' not in name:

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -15,9 +15,10 @@ from waterbutler.core.utils import RequestHandlerContext
 from waterbutler.providers.osfstorage import settings
 from waterbutler.providers.osfstorage.tasks import backup
 from waterbutler.providers.osfstorage.tasks import parity
-from waterbutler.providers.osfstorage.metadata import OsfStorageFileMetadata
-from waterbutler.providers.osfstorage.metadata import OsfStorageFolderMetadata
-from waterbutler.providers.osfstorage.metadata import OsfStorageRevisionMetadata
+from waterbutler.providers.osfstorage.metadata import (OsfStorageFileMetadata,
+                                                        BaseOsfStorageMetadata,
+                                                        OsfStorageFolderMetadata,
+                                                        OsfStorageRevisionMetadata)
 
 
 QUERY_METHODS = ('GET', 'DELETE')
@@ -431,6 +432,11 @@ class OSFStorageProvider(provider.BaseProvider):
         if not path.is_dir:
             return await self._item_metadata(path)
         return await self._children_metadata(path)
+
+    async def construct_path(self,
+                           parent_path: WaterButlerPath,
+                           meta_data: BaseOsfStorageMetadata) -> WaterButlerPath:
+        return self.path_from_metadata(parent_path, meta_data)
 
     async def revisions(self, path, view_only=None, **kwargs):
         if path.identifier is None:

--- a/waterbutler/providers/owncloud/provider.py
+++ b/waterbutler/providers/owncloud/provider.py
@@ -6,7 +6,8 @@ from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
 
 from waterbutler.providers.owncloud import utils
-from waterbutler.providers.owncloud.metadata import OwnCloudFileRevisionMetadata
+from waterbutler.providers.owncloud.metadata import (BaseOwnCloudMetadata,
+                                                    OwnCloudFileRevisionMetadata)
 
 
 class OwnCloudProvider(provider.BaseProvider):
@@ -200,6 +201,11 @@ class OwnCloudProvider(provider.BaseProvider):
         )
         await delete_resp.release()
         return
+
+    async def construct_path(self,
+                           parent_path: WaterButlerPath,
+                           meta_data: BaseOwnCloudMetadata) -> WaterButlerPath:
+        return await self.revalidate_path(parent_path, meta_data.name, folder=meta_data.is_folder)
 
     async def metadata(self, path, **kwargs):
         """Queries the remote host for metadata and returns metadata objects based on the return

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -20,11 +20,12 @@ from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
 
 from waterbutler.providers.s3 import settings
-from waterbutler.providers.s3.metadata import S3Revision
-from waterbutler.providers.s3.metadata import S3FileMetadata
-from waterbutler.providers.s3.metadata import S3FolderMetadata
-from waterbutler.providers.s3.metadata import S3FolderKeyMetadata
-from waterbutler.providers.s3.metadata import S3FileMetadataHeaders
+from waterbutler.providers.s3.metadata import (S3Metadata,
+                                                S3Revision,
+                                                S3FileMetadata,
+                                                S3FolderMetadata,
+                                                S3FolderKeyMetadata,
+                                                S3FileMetadataHeaders)
 
 
 class S3Provider(provider.BaseProvider):
@@ -368,6 +369,11 @@ class S3Provider(provider.BaseProvider):
             for item in versions
             if item['Key'] == path.path
         ]
+
+    async def construct_path(self,
+                           parent_path: WaterButlerPath,
+                           meta_data: S3Metadata) -> WaterButlerPath:
+        return await self.revalidate_path(parent_path, meta_data.name, folder=meta_data.is_folder)
 
     async def metadata(self, path, revision=None, **kwargs):
         """Get Metadata about the requested file or folder


### PR DESCRIPTION
Added construct_path and construct_empty_path to base-
provider for individual providers to make paths for folder-file-ops
without needing to make API calls

<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket
https://openscience.atlassian.net/browse/SVCS-552
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/SVCS-1234 -->

## Purpose
the Baseprovider class `folder_file_op` function was making calls to get metadata, and then making the same calls again when calling revalidate path. It is possible to create paths from this metadata and forgo making more API calls.

<!-- Describe the purpose of your changes -->

## Changes
Added 2 new functions to the Baseprovider. `construct_path` and `construct_empty_path`. 
Construct_path takes the parent path and metadata. Each provider then has its own implementation on how to get a path from this. Some will simply use it as a proxy to `revalidate_path` since their `revalidate_path` does not make API calls. If an individual providers `revalidate_path` does make api calls, it will instead call `path_from_metadata` or something similar.

`construct_empty_path` returns a math from metadata where the identifier is none( ie it doesnt actually exit at that location). 

Added tests to test these new functions. `construct_empty_path` is tested in core/test_provider since almost all providers use the base definition.

`construct_path` is tested individually in providers and is ALWAYS tested against the output of `revalidate_path` because that is what it is replacing.

Dataverse is the only provider that could still makes API calls here, however I am fairly certain that dataverse cannot perform `folder_file_ops` so it should never call those functions.

<!-- Briefly describe or list your changes  -->

## Side effects

There could be some timing issues, however this seems unlikely

<!-- Any possible side effects? -->

## QA Notes

To test, move or copy a folder containing at least one file across 2 providers.
ie move folder1 from OSFstorage to GoogleDrive. It should work and make less API calls

Figshare may not work quite correctly. It is very hard to test with the many bugs figshare has.

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
