### PR TITLE
[SVCS-528] Look for `mfr` query param from mfr in v1 provider

### DIFF
--- a/tests/providers/googledrive/test_metadata.py
+++ b/tests/providers/googledrive/test_metadata.py
@@ -44,6 +44,7 @@ class TestMetadata:
         assert parsed.materialized_path == str(path)
         assert parsed.is_google_doc is False
         assert parsed.export_name == item['title']
+        assert parsed.alt_export_name == 'PART_1420130849837.pdf'
 
     def test_file_metadata_drive_slashes(self, basepath, root_provider_fixtures):
         item = root_provider_fixtures['file_forward_slash']
@@ -66,6 +67,7 @@ class TestMetadata:
         assert parsed.materialized_path == str(path)
         assert parsed.is_google_doc is False
         assert parsed.export_name == item['title']
+        assert parsed.alt_export_name == 'PART_1420130849837.pdf'
 
     def test_file_metadata_docs(self, basepath, root_provider_fixtures):
         item = root_provider_fixtures['docs_file_metadata']
@@ -80,6 +82,7 @@ class TestMetadata:
         }
         assert parsed.is_google_doc is True
         assert parsed.export_name == item['title'] + '.docx'
+        assert parsed.alt_export_name == 'version-test.pdf'
 
     def test_folder_metadata(self, root_provider_fixtures):
         item = root_provider_fixtures['folder_metadata']

--- a/waterbutler/providers/googledrive/metadata.py
+++ b/waterbutler/providers/googledrive/metadata.py
@@ -137,6 +137,14 @@ class GoogleDriveFileMetadata(BaseGoogleDriveMetadata, metadata.BaseFileMetadata
         return title
 
     @property
+    def alt_export_name(self):
+        title = self._file_title
+        if self.is_google_doc:
+            ext = utils.get_alt_download_extension(self.raw)
+            title += ext
+        return title
+
+    @property
     def _file_title(self):
         return self.raw['title']
 

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -234,16 +234,18 @@ class GoogleDriveProvider(provider.BaseProvider):
 
         metadata = await self.metadata(path, revision=revision)
 
-        if 'mfr' in kwargs and kwargs['mfr'] and kwargs['mfr'].lower() == 'true':
-            download_url = metadata.raw.get('downloadUrl') or drive_utils.get_alt_export_link(metadata.raw),  # type: ignore
+        if kwargs.get('mfr', None) and kwargs['mfr'].lower() == 'true':
+            download_url = drive_utils.get_alt_export_link(metadata.raw)  # type: ignore
             export_name = metadata.alt_export_name
         else:
-            download_url = metadata.raw.get('downloadUrl') or drive_utils.get_export_link(metadata.raw),  # type: ignore
+
+            # TODO figure out metadata.raw.get('downloadUrl')
+            download_url = metadata.raw.get('downloadUrl') or drive_utils.get_export_link(metadata.raw)  # type: ignore
             export_name = metadata.export_name  # type: ignore
 
         download_resp = await self.make_request(
             'GET',
-            *download_url,
+            download_url,
             range=range,
             expects=(200, 206),
             throws=exceptions.DownloadError,

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -234,9 +234,16 @@ class GoogleDriveProvider(provider.BaseProvider):
 
         metadata = await self.metadata(path, revision=revision)
 
+        if 'mfr' in kwargs and kwargs['mfr'] and kwargs['mfr'].lower() == 'true':
+            download_url = metadata.raw.get('downloadUrl') or drive_utils.get_alt_export_link(metadata.raw),  # type: ignore
+            export_name = metadata.alt_export_name
+        else:
+            download_url = metadata.raw.get('downloadUrl') or drive_utils.get_export_link(metadata.raw),  # type: ignore
+            export_name = metadata.export_name  # type: ignore
+
         download_resp = await self.make_request(
             'GET',
-            metadata.raw.get('downloadUrl') or drive_utils.get_export_link(metadata.raw),  # type: ignore
+            *download_url,
             range=range,
             expects=(200, 206),
             throws=exceptions.DownloadError,
@@ -251,7 +258,7 @@ class GoogleDriveProvider(provider.BaseProvider):
         if download_resp.headers.get('Content-Type'):
             # TODO: Add these properties to base class officially, instead of as one-off
             stream.content_type = download_resp.headers['Content-Type']  # type: ignore
-        stream.name = metadata.export_name  # type: ignore
+        stream.name = export_name  # type: ignore
         return stream
 
     async def upload(self, stream, path: wb_path.WaterButlerPath, *args, **kwargs) \

--- a/waterbutler/providers/googledrive/utils.py
+++ b/waterbutler/providers/googledrive/utils.py
@@ -69,7 +69,10 @@ def get_alt_download_extension(metadata):
 def get_alt_export_link(metadata):
     format_type = get_format(metadata)
     export_links = metadata['exportLinks']
-    return export_links.get(format_type['alt_type'], None) or export_links[format_type['type']]
+    if format_type.get('alt_type'):
+        return export_links.get(format_type['alt_type'])
+    else:
+        return export_links[format_type['type']]
 
 
 def get_export_link(metadata):

--- a/waterbutler/providers/googledrive/utils.py
+++ b/waterbutler/providers/googledrive/utils.py
@@ -4,6 +4,8 @@ DOCS_FORMATS = [
         'ext': '.gdoc',
         'download_ext': '.docx',
         'type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'alt_download_ext': '.pdf',
+        'alt_type': 'application/pdf',
     },
     {
         'mime_type': 'application/vnd.google-apps.drawing',
@@ -57,6 +59,22 @@ def get_extension(metadata):
 def get_download_extension(metadata):
     format = get_format(metadata)
     return format['download_ext']
+
+
+def get_alt_download_extension(metadata):
+    format = get_format(metadata)
+    try:
+        return format['alt_download_ext']
+    except:
+        return format['download_ext']
+
+
+def get_alt_export_link(metadata):
+    format = get_format(metadata)
+    try:
+        return metadata['exportLinks'][format['alt_type']]
+    except:
+        return metadata['exportLinks'][format['type']]
 
 
 def get_export_link(metadata):

--- a/waterbutler/providers/googledrive/utils.py
+++ b/waterbutler/providers/googledrive/utils.py
@@ -39,44 +39,39 @@ def is_docs_file(metadata):
 
 
 def get_mimetype_from_ext(ext):
-    for format in DOCS_FORMATS:
-        if format['ext'] == ext:
-            return format['mime_type']
+    for format_type in DOCS_FORMATS:
+        if format_type['ext'] == ext:
+            return format_type['mime_type']
 
 
 def get_format(metadata):
-    for format in DOCS_FORMATS:
-        if format['mime_type'] == metadata['mimeType']:
-            return format
+    for format_type in DOCS_FORMATS:
+        if format_type['mime_type'] == metadata['mimeType']:
+            return format_type
     return DOCS_DEFAULT_FORMAT
 
 
 def get_extension(metadata):
-    format = get_format(metadata)
-    return format['ext']
+    format_type = get_format(metadata)
+    return format_type['ext']
 
 
 def get_download_extension(metadata):
-    format = get_format(metadata)
-    return format['download_ext']
+    format_type = get_format(metadata)
+    return format_type['download_ext']
 
 
 def get_alt_download_extension(metadata):
-    format = get_format(metadata)
-    try:
-        return format['alt_download_ext']
-    except:
-        return format['download_ext']
+    format_type = get_format(metadata)
+    return format_type.get('alt_download_ext', None) or format_type['download_ext']
 
 
 def get_alt_export_link(metadata):
-    format = get_format(metadata)
-    try:
-        return metadata['exportLinks'][format['alt_type']]
-    except:
-        return metadata['exportLinks'][format['type']]
+    format_type = get_format(metadata)
+    export_links = metadata['exportLinks']
+    return export_links.get(format_type['alt_type'], None) or export_links[format_type['type']]
 
 
 def get_export_link(metadata):
-    format = get_format(metadata)
-    return metadata['exportLinks'][format['type']]
+    format_type = get_format(metadata)
+    return metadata['exportLinks'][format_type['type']]

--- a/waterbutler/server/api/v1/provider/metadata.py
+++ b/waterbutler/server/api/v1/provider/metadata.py
@@ -71,6 +71,7 @@ class MetadataMixin:
             range=request_range,
             accept_url='direct' not in self.request.query_arguments,
             mode=self.get_query_argument('mode', default=None),
+            mfr=self.get_query_argument('mfr', default=None)
         )
 
         if isinstance(stream, str):


### PR DESCRIPTION
We can export .gdoc as a pdf if we know its coming from
mfr. Added `alt_export` functions and properties to Gdrive
utils and metadata. Gdrive download now looks for 'mfr' in its
kwargs and will request file as pdf if used properly.

## This ticket should be merged BEFORE its MFR counterpart
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket
https://openscience.atlassian.net/browse/SVCS-528
MFR counterpart:  https://github.com/CenterForOpenScience/modular-file-renderer/pull/292
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/SVCS-1234 -->

## Purpose
Allow mfr to request .gdoc files in other export formats (to .pdf from .docx). However allow the osf to still download in .docx format

This will allow MFR to cut out the expensive unoconv conversion for .gdoc files

<!-- Describe the purpose of your changes -->

## Changes
v1 provider now looks for a 'mfr' query param. if true, the google drive provider will use `alt_export_name` and `alt_export_link()` instead of its normal counterparts. This will cause the file being sent to be a .pdf over a .docx
Added tests for new changes.

<!-- Briefly describe or list your changes  -->

## Side effects
There should be none. File downloads from gdrive will not be effected as long as they don't include `...&mfr=true` as a query param

<!-- Any possible side effects? -->

## QA Notes
This needs to be tested with its mfr counterpart to have noticeable changes.
<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
