### PR TITLE
[SVCS-545][ChunkedUploads] Update Box provider to use chunked-uploads

### DIFF
--- a/tests/providers/box/fixtures/root_provider.json
+++ b/tests/providers/box/fixtures/root_provider.json
@@ -1,402 +1,519 @@
 {
-    "file_metadata": {
-        "entries": [
-            {
-                "type": "file",
-                "id": "5000948880",
-                "sequence_id": "3",
-                "etag": "3",
-                "sha1": "134b65991ed521fcfe4724b7d814ab8ded5185dc",
-                "name": "tigers.jpeg",
-                "description": "a picture of tigers",
-                "size": 629644,
-                "path_collection": {
-                    "total_count": 2,
-                    "entries": [
-                        {
-                            "type": "folder",
-                            "id": "0",
-                            "sequence_id": null,
-                            "etag": null,
-                            "name": "All Files"
-                        },
-                        {
-                            "type": "folder",
-                            "id": "11446498",
-                            "sequence_id": "1",
-                            "etag": "1",
-                            "name": "Pictures"
-                        }
-                    ]
-                },
-                "created_at": "2012-12-12T10:55:30-08:00",
-                "modified_at": "2012-12-12T11:04:26-08:00",
-                "created_by": {
-                    "type": "user",
-                    "id": "17738362",
-                    "name": "sean rose",
-                    "login": "sean@box.com"
-                },
-                "modified_by": {
-                    "type": "user",
-                    "id": "17738362",
-                    "name": "sean rose",
-                    "login": "sean@box.com"
-                },
-                "owned_by": {
-                    "type": "user",
-                    "id": "17738362",
-                    "name": "sean rose",
-                    "login": "sean@box.com"
-                },
-                "shared_link": {
-                    "url": "https://www.box.com/s/rh935iit6ewrmw0unyul",
-                    "download_url": "https://www.box.com/shared/static/rh935iit6ewrmw0unyul.jpeg",
-                    "vanity_url": null,
-                    "is_password_enabled": false,
-                    "unshared_at": null,
-                    "download_count": 0,
-                    "preview_count": 0,
-                    "access": "open",
-                    "permissions": {
-                        "can_download": true,
-                        "can_preview": true
-                    }
-                },
-                "parent": {
-                    "type": "folder",
-                    "id": "11446498",
-                    "sequence_id": "1",
-                    "etag": "1",
-                    "name": "Pictures"
-                },
-                "item_status": "active"
-            }
-        ]
-    },
-
-    "folder_list_metadata": {
-        "total_count": 24,
-        "entries": [
-            {
-                "type": "folder",
-                "id": "192429928",
-                "sequence_id": "1",
-                "etag": "1",
-                "name": "Stephen Curry Three Pointers"
+   "file_metadata":{
+      "entries":[
+         {
+            "type":"file",
+            "id":"5000948880",
+            "sequence_id":"3",
+            "etag":"3",
+            "sha1":"134b65991ed521fcfe4724b7d814ab8ded5185dc",
+            "name":"tigers.jpeg",
+            "description":"a picture of tigers",
+            "size":629644,
+            "path_collection":{
+               "total_count":2,
+               "entries":[
+                  {
+                     "type":"folder",
+                     "id":"0",
+                     "sequence_id":null,
+                     "etag":null,
+                     "name":"All Files"
+                  },
+                  {
+                     "type":"folder",
+                     "id":"11446498",
+                     "sequence_id":"1",
+                     "etag":"1",
+                     "name":"Pictures"
+                  }
+               ]
             },
-            {
-                "type": "file",
-                "id": "818853862",
-                "modified_at": "2012-12-12T11:04:26-08:00",
-                "sequence_id": "0",
-                "etag": "0",
-                "name": "Warriors.jpg"
-            }
-        ],
-        "offset": 0,
-        "limit": 2,
-        "order": [
-            {
-                "by": "type",
-                "direction": "ASC"
+            "created_at":"2012-12-12T10:55:30-08:00",
+            "modified_at":"2012-12-12T11:04:26-08:00",
+            "created_by":{
+               "type":"user",
+               "id":"17738362",
+               "name":"sean rose",
+               "login":"sean@box.com"
             },
-            {
-                "by": "name",
-                "direction": "ASC"
-            }
-        ]
-    },
-
-    "one_entry_folder_list_metadata": {
-        "total_count": 24,
-        "entries": [
-            {
-                "type": "file",
-                "id": "5000948880",
-                "modified_at": "2012-12-12T11:04:26-08:00",
-                "sequence_id": "0",
-                "etag": "0",
-                "name": "Warriors.jpg"
-            }
-        ],
-        "offset": 0,
-        "limit": 2,
-        "order": [
-            {
-                "by": "type",
-                "direction": "ASC"
+            "modified_by":{
+               "type":"user",
+               "id":"17738362",
+               "name":"sean rose",
+               "login":"sean@box.com"
             },
+            "owned_by":{
+               "type":"user",
+               "id":"17738362",
+               "name":"sean rose",
+               "login":"sean@box.com"
+            },
+            "shared_link":{
+               "url":"https://www.box.com/s/rh935iit6ewrmw0unyul",
+               "download_url":"https://www.box.com/shared/static/rh935iit6ewrmw0unyul.jpeg",
+               "vanity_url":null,
+               "is_password_enabled":false,
+               "unshared_at":null,
+               "download_count":0,
+               "preview_count":0,
+               "access":"open",
+               "permissions":{
+                  "can_download":true,
+                  "can_preview":true
+               }
+            },
+            "parent":{
+               "type":"folder",
+               "id":"11446498",
+               "sequence_id":"1",
+               "etag":"1",
+               "name":"Pictures"
+            },
+            "item_status":"active"
+         }
+      ]
+   },
+   "folder_list_metadata":{
+      "total_count":24,
+      "entries":[
+         {
+            "type":"folder",
+            "id":"192429928",
+            "sequence_id":"1",
+            "etag":"1",
+            "name":"Stephen Curry Three Pointers"
+         },
+         {
+            "type":"file",
+            "id":"818853862",
+            "modified_at":"2012-12-12T11:04:26-08:00",
+            "sequence_id":"0",
+            "etag":"0",
+            "name":"Warriors.jpg"
+         }
+      ],
+      "offset":0,
+      "limit":2,
+      "order":[
+         {
+            "by":"type",
+            "direction":"ASC"
+         },
+         {
+            "by":"name",
+            "direction":"ASC"
+         }
+      ]
+   },
+   "one_entry_folder_list_metadata":{
+      "total_count":24,
+      "entries":[
+         {
+            "type":"file",
+            "id":"5000948880",
+            "modified_at":"2012-12-12T11:04:26-08:00",
+            "sequence_id":"0",
+            "etag":"0",
+            "name":"Warriors.jpg"
+         }
+      ],
+      "offset":0,
+      "limit":2,
+      "order":[
+         {
+            "by":"type",
+            "direction":"ASC"
+         },
+         {
+            "by":"name",
+            "direction":"ASC"
+         }
+      ]
+   },
+   "folder_object_metadata":{
+      "type":"folder",
+      "id":"11446498",
+      "sequence_id":"1",
+      "etag":"1",
+      "name":"Pictures",
+      "created_at":"2012-12-12T10:53:43-08:00",
+      "modified_at":"2012-12-12T11:15:04-08:00",
+      "description":"Some pictures I took",
+      "size":629644,
+      "path_collection":{
+         "total_count":1,
+         "entries":[
             {
-                "by": "name",
-                "direction": "ASC"
+               "type":"folder",
+               "id":"0",
+               "sequence_id":null,
+               "etag":null,
+               "name":"All Files"
             }
-        ]
-    },
-
-    "folder_object_metadata": {
-        "type": "folder",
-        "id": "11446498",
-        "sequence_id": "1",
-        "etag": "1",
-        "name": "Pictures",
-        "created_at": "2012-12-12T10:53:43-08:00",
-        "modified_at": "2012-12-12T11:15:04-08:00",
-        "description": "Some pictures I took",
-        "size": 629644,
-        "path_collection": {
-            "total_count": 1,
-            "entries": [
-                {
-                    "type": "folder",
-                    "id": "0",
-                    "sequence_id": null,
-                    "etag": null,
-                    "name": "All Files"
-                }
-            ]
-        },
-        "created_by": {
-            "type": "user",
-            "id": "17738362",
-            "name": "sean rose",
-            "login": "sean@box.com"
-        },
-        "modified_by": {
-            "type": "user",
-            "id": "17738362",
-            "name": "sean rose",
-            "login": "sean@box.com"
-        },
-        "owned_by": {
-            "type": "user",
-            "id": "17738362",
-            "name": "sean rose",
-            "login": "sean@box.com"
-        },
-        "shared_link": {
-            "url": "https://www.box.com/s/vspke7y05sb214wjokpk",
-            "download_url": null,
-            "vanity_url": null,
-            "is_password_enabled": false,
-            "unshared_at": null,
-            "download_count": 0,
-            "preview_count": 0,
-            "access": "open",
-            "permissions": {
-                "can_download": true,
-                "can_preview": true
-            }
-        },
-        "folder_upload_email": {
-            "access": "open",
-            "email": "upload.Picture.k13sdz1@u.box.com"
-        },
-        "parent": {
-            "type": "folder",
-            "id": "0",
-            "sequence_id": null,
-            "etag": null,
-            "name": "All Files"
-        },
-        "item_status": "active",
-        "item_collection": {
-            "total_count": 1,
-            "entries": [
-                {
-                    "type": "file",
-                    "id": "5000948880",
-                    "sequence_id": "3",
-                    "etag": "3",
-                    "sha1": "134b65991ed521fcfe4724b7d814ab8ded5185dc",
-                    "name": "tigers.jpeg"
-                }
-            ],
-            "offset": 0,
-            "limit": 100
-        },
-        "tags": [
-            "approved",
-            "ready to publish"
-        ]
-    },
-
-    "revalidate_metadata":{
-        "entries": [{
-            "id": "218050415202",
-            "type": "file",
-            "name": "bulbasaur",
-            "etag": "0"
-        },
-        {
-            "id": "217538428612",
-            "type": "file",
-            "name": "Learn Box Basics.pdf",
-            "etag": "0"
-        }],
-        "total_count": 2,
-        "order": [{
-            "by": "type",
-            "direction": "ASC"
-        },
-        {
-            "by": "name",
-            "direction": "ASC"
-        }],
-        "offset": 0,
-        "limit": 1000
-    },
-
-    "upload_metadata": {
-        "entries": [
+         ]
+      },
+      "created_by":{
+         "type":"user",
+         "id":"17738362",
+         "name":"sean rose",
+         "login":"sean@box.com"
+      },
+      "modified_by":{
+         "type":"user",
+         "id":"17738362",
+         "name":"sean rose",
+         "login":"sean@box.com"
+      },
+      "owned_by":{
+         "type":"user",
+         "id":"17738362",
+         "name":"sean rose",
+         "login":"sean@box.com"
+      },
+      "shared_link":{
+         "url":"https://www.box.com/s/vspke7y05sb214wjokpk",
+         "download_url":null,
+         "vanity_url":null,
+         "is_password_enabled":false,
+         "unshared_at":null,
+         "download_count":0,
+         "preview_count":0,
+         "access":"open",
+         "permissions":{
+            "can_download":true,
+            "can_preview":true
+         }
+      },
+      "folder_upload_email":{
+         "access":"open",
+         "email":"upload.Picture.k13sdz1@u.box.com"
+      },
+      "parent":{
+         "type":"folder",
+         "id":"0",
+         "sequence_id":null,
+         "etag":null,
+         "name":"All Files"
+      },
+      "item_status":"active",
+      "item_collection":{
+         "total_count":1,
+         "entries":[
             {
-                "type": "file",
-                "id": "5000948880",
-                "sequence_id": "3",
-                "etag": "3",
-                "sha1": "2ab21cd2c453e842f119cfe85f7859bda6e096d1",
-                "name": "newfile",
-                "description": "file_content from WB box tests",
-                "size": 39,
-                "path_collection": {
-                    "total_count": 2,
-                    "entries": [
-                        {
-                            "type": "folder",
-                            "id": "0",
-                            "sequence_id": null,
-                            "etag": null,
-                            "name": "All Files"
-                        },
-                        {
-                            "type": "folder",
-                            "id": "11446498",
-                            "sequence_id": "1",
-                            "etag": "1",
-                            "name": "Pictures"
-                        }
-                    ]
-                },
-                "created_at": "2012-12-12T10:55:30-08:00",
-                "modified_at": "2012-12-12T11:04:26-08:00",
-                "created_by": {
-                    "type": "user",
-                    "id": "17738362",
-                    "name": "sean rose",
-                    "login": "sean@box.com"
-                },
-                "modified_by": {
-                    "type": "user",
-                    "id": "17738362",
-                    "name": "sean rose",
-                    "login": "sean@box.com"
-                },
-                "owned_by": {
-                    "type": "user",
-                    "id": "17738362",
-                    "name": "sean rose",
-                    "login": "sean@box.com"
-                },
-                "shared_link": {
-                    "url": "https://www.box.com/s/rh935iit6ewrmw0unyul",
-                    "download_url": "https://www.box.com/shared/static/rh935iit6ewrmw0unyul.jpeg",
-                    "vanity_url": null,
-                    "is_password_enabled": false,
-                    "unshared_at": null,
-                    "download_count": 0,
-                    "preview_count": 0,
-                    "access": "open",
-                    "permissions": {
-                        "can_download": true,
-                        "can_preview": true
-                    }
-                },
-                "parent": {
-                    "type": "folder",
-                    "id": "11446498",
-                    "sequence_id": "1",
-                    "etag": "1",
-                    "name": "Pictures"
-                },
-                "item_status": "active"
+               "type":"file",
+               "id":"5000948880",
+               "sequence_id":"3",
+               "etag":"3",
+               "sha1":"134b65991ed521fcfe4724b7d814ab8ded5185dc",
+               "name":"tigers.jpeg"
             }
-        ]
-    },
-
-    "checksum_mismatch_metadata": {
-        "entries": [
-            {
-                "type": "file",
-                "id": "5000948880",
-                "sequence_id": "3",
-                "etag": "3",
-                "sha1": "9382285f95cceb31374efbe8ccc1ae881a29c1c1",
-                "name": "newfile",
-                "description": "file_content from WB box tests",
-                "size": 39,
-                "path_collection": {
-                    "total_count": 2,
-                    "entries": [
-                        {
-                            "type": "folder",
-                            "id": "0",
-                            "sequence_id": null,
-                            "etag": null,
-                            "name": "All Files"
-                        },
-                        {
-                            "type": "folder",
-                            "id": "11446498",
-                            "sequence_id": "1",
-                            "etag": "1",
-                            "name": "Pictures"
-                        }
-                    ]
-                },
-                "created_at": "2012-12-12T10:55:30-08:00",
-                "modified_at": "2012-12-12T11:04:26-08:00",
-                "created_by": {
-                    "type": "user",
-                    "id": "17738362",
-                    "name": "sean rose",
-                    "login": "sean@box.com"
-                },
-                "modified_by": {
-                    "type": "user",
-                    "id": "17738362",
-                    "name": "sean rose",
-                    "login": "sean@box.com"
-                },
-                "owned_by": {
-                    "type": "user",
-                    "id": "17738362",
-                    "name": "sean rose",
-                    "login": "sean@box.com"
-                },
-                "shared_link": {
-                    "url": "https://www.box.com/s/rh935iit6ewrmw0unyul",
-                    "download_url": "https://www.box.com/shared/static/rh935iit6ewrmw0unyul.jpeg",
-                    "vanity_url": null,
-                    "is_password_enabled": false,
-                    "unshared_at": null,
-                    "download_count": 0,
-                    "preview_count": 0,
-                    "access": "open",
-                    "permissions": {
-                        "can_download": true,
-                        "can_preview": true
-                    }
-                },
-                "parent": {
-                    "type": "folder",
-                    "id": "11446498",
-                    "sequence_id": "1",
-                    "etag": "1",
-                    "name": "Pictures"
-                },
-                "item_status": "active"
-            }
-        ]
-    }
-
+         ],
+         "offset":0,
+         "limit":100
+      },
+      "tags":[
+         "approved",
+         "ready to publish"
+      ]
+   },
+   "revalidate_metadata":{
+      "entries":[
+         {
+            "id":"218050415202",
+            "type":"file",
+            "name":"bulbasaur",
+            "etag":"0"
+         },
+         {
+            "id":"217538428612",
+            "type":"file",
+            "name":"Learn Box Basics.pdf",
+            "etag":"0"
+         }
+      ],
+      "total_count":2,
+      "order":[
+         {
+            "by":"type",
+            "direction":"ASC"
+         },
+         {
+            "by":"name",
+            "direction":"ASC"
+         }
+      ],
+      "offset":0,
+      "limit":1000
+   },
+   "upload_metadata":{
+      "entries":[
+         {
+            "type":"file",
+            "id":"5000948880",
+            "sequence_id":"3",
+            "etag":"3",
+            "sha1":"2ab21cd2c453e842f119cfe85f7859bda6e096d1",
+            "name":"newfile",
+            "description":"file_content from WB box tests",
+            "size":39,
+            "path_collection":{
+               "total_count":2,
+               "entries":[
+                  {
+                     "type":"folder",
+                     "id":"0",
+                     "sequence_id":null,
+                     "etag":null,
+                     "name":"All Files"
+                  },
+                  {
+                     "type":"folder",
+                     "id":"11446498",
+                     "sequence_id":"1",
+                     "etag":"1",
+                     "name":"Pictures"
+                  }
+               ]
+            },
+            "created_at":"2012-12-12T10:55:30-08:00",
+            "modified_at":"2012-12-12T11:04:26-08:00",
+            "created_by":{
+               "type":"user",
+               "id":"17738362",
+               "name":"sean rose",
+               "login":"sean@box.com"
+            },
+            "modified_by":{
+               "type":"user",
+               "id":"17738362",
+               "name":"sean rose",
+               "login":"sean@box.com"
+            },
+            "owned_by":{
+               "type":"user",
+               "id":"17738362",
+               "name":"sean rose",
+               "login":"sean@box.com"
+            },
+            "shared_link":{
+               "url":"https://www.box.com/s/rh935iit6ewrmw0unyul",
+               "download_url":"https://www.box.com/shared/static/rh935iit6ewrmw0unyul.jpeg",
+               "vanity_url":null,
+               "is_password_enabled":false,
+               "unshared_at":null,
+               "download_count":0,
+               "preview_count":0,
+               "access":"open",
+               "permissions":{
+                  "can_download":true,
+                  "can_preview":true
+               }
+            },
+            "parent":{
+               "type":"folder",
+               "id":"11446498",
+               "sequence_id":"1",
+               "etag":"1",
+               "name":"Pictures"
+            },
+            "item_status":"active"
+         }
+      ]
+   },
+   "create_session_metadata":{
+      "id":"fake_session_id",
+      "num_parts_processed":0,
+      "part_size":10,
+      "session_endpoints":{
+         "abort":"https://upload.box.com/api/2.0/files/upload_sessions/5BA29341D651FF4932FD78E9356B2A95",
+         "commit":"https://upload.box.com/api/2.0/files/upload_sessions/5BA29341D651FF4932FD78E9356B2A95/commit",
+         "list_parts":"https://upload.box.com/api/2.0/files/upload_sessions/5BA29341D651FF4932FD78E9356B2A95/parts",
+         "log_event":"https://upload.box.com/api/2.0/files/upload_sessions/5BA29341D651FF4932FD78E9356B2A95/log",
+         "status":"https://upload.box.com/api/2.0/files/upload_sessions/5BA29341D651FF4932FD78E9356B2A95",
+         "upload_part":"https://upload.box.com/api/2.0/files/upload_sessions/5BA29341D651FF4932FD78E9356B2A95"
+      },
+      "session_expires_at":"2017-11-06T14:11:57Z",
+      "total_parts":2,
+      "type":"upload_session"
+   },
+   "upload_part_one":{
+      "part":{
+         "offset":10,
+         "part_id":"37B0FB1B",
+         "sha1":"3ff00d99585b8da363f9f9955e791ed763e111c1",
+         "size":10
+      }
+   },
+   "upload_part_two":{
+      "part":{
+         "offset":20,
+         "part_id":"1872DEDA",
+         "sha1":"0ae5fc290c5c5414cdda245ab712a8440376284a",
+         "size":10
+      }
+   },
+   "formated_parts":{
+      "parts":[
+         {
+            "offset":10,
+            "part_id":"37B0FB1B",
+            "sha1":"3ff00d99585b8da363f9f9955e791ed763e111c1",
+            "size":10
+         },
+         {
+            "offset":20,
+            "part_id":"1872DEDA",
+            "sha1":"0ae5fc290c5c5414cdda245ab712a8440376284a",
+            "size":10
+         }
+      ]
+   },
+   "upload_commit_metadata":{
+      "entries":[
+         {
+            "content_created_at":"2017-10-30T09:57:54-07:00",
+            "content_modified_at":"2017-10-30T09:57:54-07:00",
+            "created_at":"2017-10-30T09:57:54-07:00",
+            "created_by":{
+               "id":"1536583404",
+               "login":"john@cos.io",
+               "name":"John Tordoff",
+               "type":"user"
+            },
+            "description":"",
+            "etag":"0",
+            "file_version":{
+               "id":"255645274323",
+               "sha1":"9a76558aeb129d42dc0ae40e02a7214059fa213a",
+               "type":"file_version"
+            },
+            "id":"242349416659",
+            "item_status":"active",
+            "modified_at":"2017-10-30T09:57:54-07:00",
+            "modified_by":{
+               "id":"1536583404",
+               "login":"john@cos.io",
+               "name":"John Tordoff",
+               "type":"user"
+            },
+            "name":"test.txt",
+            "owned_by":{
+               "id":"1536583404",
+               "login":"john@cos.io",
+               "name":"John Tordoff",
+               "type":"user"
+            },
+            "parent":{
+               "etag":"0",
+               "id":"25001149896",
+               "name":"test",
+               "sequence_id":"0",
+               "type":"folder"
+            },
+            "path_collection":{
+               "entries":[
+                  {
+                     "etag":null,
+                     "id":"0",
+                     "name":"All Files",
+                     "sequence_id":null,
+                     "type":"folder"
+                  },
+                  {
+                     "etag":"0",
+                     "id":"25001149896",
+                     "name":"test",
+                     "sequence_id":"0",
+                     "type":"folder"
+                  }
+               ],
+               "total_count":2
+            },
+            "purged_at":null,
+            "sequence_id":"0",
+            "sha1":"9a76558aeb129d42dc0ae40e02a7214059fa213a",
+            "shared_link":null,
+            "size":253105752,
+            "trashed_at":null,
+            "type":"file"
+         }
+      ],
+      "total_count":1
+   },
+   "checksum_mismatch_metadata":{
+      "entries":[
+         {
+            "type":"file",
+            "id":"5000948880",
+            "sequence_id":"3",
+            "etag":"3",
+            "sha1":"9382285f95cceb31374efbe8ccc1ae881a29c1c1",
+            "name":"newfile",
+            "description":"file_content from WB box tests",
+            "size":39,
+            "path_collection":{
+               "total_count":2,
+               "entries":[
+                  {
+                     "type":"folder",
+                     "id":"0",
+                     "sequence_id":null,
+                     "etag":null,
+                     "name":"All Files"
+                  },
+                  {
+                     "type":"folder",
+                     "id":"11446498",
+                     "sequence_id":"1",
+                     "etag":"1",
+                     "name":"Pictures"
+                  }
+               ]
+            },
+            "created_at":"2012-12-12T10:55:30-08:00",
+            "modified_at":"2012-12-12T11:04:26-08:00",
+            "created_by":{
+               "type":"user",
+               "id":"17738362",
+               "name":"sean rose",
+               "login":"sean@box.com"
+            },
+            "modified_by":{
+               "type":"user",
+               "id":"17738362",
+               "name":"sean rose",
+               "login":"sean@box.com"
+            },
+            "owned_by":{
+               "type":"user",
+               "id":"17738362",
+               "name":"sean rose",
+               "login":"sean@box.com"
+            },
+            "shared_link":{
+               "url":"https://www.box.com/s/rh935iit6ewrmw0unyul",
+               "download_url":"https://www.box.com/shared/static/rh935iit6ewrmw0unyul.jpeg",
+               "vanity_url":null,
+               "is_password_enabled":false,
+               "unshared_at":null,
+               "download_count":0,
+               "preview_count":0,
+               "access":"open",
+               "permissions":{
+                  "can_download":true,
+                  "can_preview":true
+               }
+            },
+            "parent":{
+               "type":"folder",
+               "id":"11446498",
+               "sequence_id":"1",
+               "etag":"1",
+               "name":"Pictures"
+            },
+            "item_status":"active"
+         }
+      ]
+   }
 }

--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -356,7 +356,9 @@ class TestUpload:
         assert len(aiohttpretty.calls) == 2
         for call in aiohttpretty.calls:
             assert call['method'] == 'PUT'
-            assert call['uri'] == provider._build_upload_url('files', 'upload_sessions', 'fake_session_id')
+            assert call['uri'] == provider._build_upload_url('files',
+                                                             'upload_sessions',
+                                                             'fake_session_id')
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty

--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -360,8 +360,7 @@ class TestUpload:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_upload_commit_upload(self, provider, root_provider_fixtures):
-        path = WaterButlerPath('/newfile', _ids=(provider.folder, None))
+    async def test_upload_complete_session(self, provider, root_provider_fixtures):
         commit_url = provider._build_upload_url('files', 'upload_sessions',
                                                               'fake_session_id', 'commit')
 
@@ -371,13 +370,11 @@ class TestUpload:
                                        body=root_provider_fixtures['upload_commit_metadata'])
 
         session_metadata = root_provider_fixtures['create_session_metadata']
-        metadata, created = await provider._commit_upload(path,
-                                                          session_metadata,
+        entry = await provider._complete_session(session_metadata,
                                                           root_provider_fixtures['formated_parts'],
                                                           'fake_sha')
 
-        assert created
-        assert metadata.name == 'test.txt'
+        assert root_provider_fixtures['upload_commit_metadata']['entries'][0] == entry
         assert aiohttpretty.has_call(method='POST', uri=commit_url)
 
 

--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -1,6 +1,7 @@
 import pytest
 
 import io
+import json
 from http import client
 
 import aiohttpretty
@@ -299,6 +300,86 @@ class TestUpload:
             await provider.upload(file_stream, path)
 
         assert aiohttpretty.has_call(method='POST', uri=upload_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_upload_create_upload_session(self, provider, root_provider_fixtures):
+        path = WaterButlerPath('/newfile', _ids=(provider.folder, None))
+        session_url = provider._build_upload_url('files', 'upload_sessions')
+
+        create_session_metadata = root_provider_fixtures['create_session_metadata']
+        aiohttpretty.register_json_uri('POST',
+                                       session_url,
+                                       status=201,
+                                       body=create_session_metadata)
+
+        session_data = await provider._create_upload_session(path, b'DATA')
+
+        assert root_provider_fixtures['create_session_metadata'] == session_data
+        assert aiohttpretty.has_call(method='POST', uri=session_url)
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_upload_parts(self, provider, root_provider_fixtures):
+
+        session_url = provider._build_upload_url('files', 'upload_sessions', 'fake_session_id')
+
+        responses = [{'body': json.dumps(root_provider_fixtures['upload_part_one']),
+                      'status' : 201},
+                     {'body': json.dumps(root_provider_fixtures['upload_part_two']),
+                      'status' : 201}]
+
+        aiohttpretty.register_json_uri('PUT',
+                                       session_url,
+                                       status=201,
+                                       responses=responses)
+
+        session_metadata = root_provider_fixtures['create_session_metadata']
+        parts_metadata = await provider._upload_parts('tenbytestr'.encode() * 2, session_metadata)
+
+        expected_response = {
+            'parts': [
+                {'offset': 10,
+                'part_id': '37B0FB1B',
+                'sha1': '3ff00d99585b8da363f9f9955e791ed763e111c1',
+                'size': 10
+                 },
+                {'offset': 20,
+                 'part_id': '1872DEDA',
+                 'sha1': '0ae5fc290c5c5414cdda245ab712a8440376284a',
+                 'size': 10}
+            ]
+        }
+
+
+        assert parts_metadata == expected_response
+
+        assert len(aiohttpretty.calls) == 2
+        for call in aiohttpretty.calls:
+            call['method'] == 'PUT'
+            call['uri'] == provider._build_upload_url('files', 'upload_sessions', 'fake_session_id')
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_upload_commit_upload(self, provider, root_provider_fixtures):
+        path = WaterButlerPath('/newfile', _ids=(provider.folder, None))
+        commit_url = provider._build_upload_url('files', 'upload_sessions',
+                                                              'fake_session_id', 'commit')
+
+        aiohttpretty.register_json_uri('POST',
+                                       commit_url,
+                                       status=201,
+                                       body=root_provider_fixtures['upload_commit_metadata'])
+
+        session_metadata = root_provider_fixtures['create_session_metadata']
+        metadata, created = await provider._commit_upload(path,
+                                                          session_metadata,
+                                                          root_provider_fixtures['formated_parts'],
+                                                          'fake_sha')
+
+        assert created
+        assert metadata.name == 'test.txt'
+        assert aiohttpretty.has_call(method='POST', uri=commit_url)
 
 
 class TestDelete:

--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -325,9 +325,9 @@ class TestUpload:
         session_url = provider._build_upload_url('files', 'upload_sessions', 'fake_session_id')
 
         responses = [{'body': json.dumps(root_provider_fixtures['upload_part_one']),
-                      'status' : 201},
+                      'status': 201},
                      {'body': json.dumps(root_provider_fixtures['upload_part_two']),
-                      'status' : 201}]
+                      'status': 201}]
 
         aiohttpretty.register_json_uri('PUT',
                                        session_url,
@@ -351,13 +351,12 @@ class TestUpload:
             ]
         }
 
-
         assert parts_metadata == expected_response
 
         assert len(aiohttpretty.calls) == 2
         for call in aiohttpretty.calls:
-            call['method'] == 'PUT'
-            call['uri'] == provider._build_upload_url('files', 'upload_sessions', 'fake_session_id')
+            assert call['method'] == 'PUT'
+            assert call['uri'] == provider._build_upload_url('files', 'upload_sessions', 'fake_session_id')
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -347,7 +347,7 @@ class BoxProvider(provider.BaseProvider):
         parts = await self._upload_parts(data, session_data)
 
         # Step 4 complete the session and return the upload file's metadata.
-        return await self._complete_session(path, session_data, parts, data_sha)
+        return await self._complete_session(session_data, parts, data_sha)
 
     async def _create_upload_session(self,
                                      path: wb_path.WaterButlerPath,
@@ -372,11 +372,11 @@ class BoxProvider(provider.BaseProvider):
                             session_data: dict):
 
         parts = {'parts': []}
-        upload_size = len(bytearray(data))
+        upload_size = len(data)
 
         for start_bytes in range(0, upload_size, session_data['part_size']):
             chunk = data[start_bytes: start_bytes + session_data['part_size']]
-            chunk_size = len(bytearray(chunk))  # Final chunk size != session_data['part_size']
+            chunk_size = len(chunk)  # Final chunk size != session_data['part_size']
             chunk_sha = base64.standard_b64encode(hashlib.sha1(chunk).digest()).decode()
 
             byte_range = self._build_range_header((start_bytes, start_bytes + chunk_size - 1))

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -293,7 +293,6 @@ class BoxProvider(provider.BaseProvider):
             path, _ = await self.handle_name_conflict(path, conflict=conflict, kind='folder')
             path._parts[-1]._id = None
 
-
         if stream.size > self.NONCHUNKED_UPLOAD_LIMIT:
             entry = await self._chunked_upload(stream, path)
         else:


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-545

## Purpose

This allows Box to upload very large files using their chunked upload endpoint.

## Changes

Adds several functions to start an upload session, upload the individual chunks and commit the upload into one file. Includes unittests.

## Side effects

None that I know of.

## QA Notes

A file must be over 50MB to trigger a chunked upload and the progress bar is not a good indicator of how much of the download has completed.

## Deployment Notes

Should probably correspond with removing upload limits for dropbox in Fangorn.js in osf.io