### PR TITLE
[SVCS-334]Adding custom sentry sanitizer

### DIFF
--- a/tests/server/test_sanitize.py
+++ b/tests/server/test_sanitize.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest import mock
+
+import pytest
 
 from waterbutler.server.sanitize import WBSanitizer
 
@@ -71,12 +72,6 @@ class TestWBSanitizer:
             'okay_value': 'bears are awesome'
         }
         result = sanitizer.sanitize('sanitize_dict', sanitize_dict)
-
-        # Sanity check
-        assert result != {
-            'key': 'secret',
-            'okay_value': 'bears are awesome'
-        }
 
         assert result == {
             'key': self.MASK,

--- a/tests/server/test_sanitize.py
+++ b/tests/server/test_sanitize.py
@@ -1,0 +1,76 @@
+import pytest
+from unittest import mock
+
+from waterbutler.server.sanitize import WBSanitizer
+
+
+@pytest.fixture
+def sanitizer():
+    return WBSanitizer(mock.Mock())
+
+
+class TestWBSanitizer:
+    # The sanitize function changes some strings and dictionaries
+    # you put into it, so you need to explicitly test most things
+
+    MASK = '*' * 8
+
+    def test_no_sanitization(self, sanitizer):
+        assert sanitizer.sanitize('thing', 'ghost science') == 'ghost science'
+
+    def test_fields_sanitized(self, sanitizer):
+        fields = sanitizer.FIELDS
+        for field in fields:
+            assert sanitizer.sanitize(field, 'free speech') == self.MASK
+
+    def test_value_is_none(self, sanitizer):
+        assert sanitizer.sanitize('great hair', None) is None
+
+    def test_sanitize_credit_card(self, sanitizer):
+        assert sanitizer.sanitize('credit', '424242424242424') == self.MASK
+        assert sanitizer.sanitize('credit', '4242424242424243333333') != self.MASK
+
+    def test_sanitize_dictionary(self, sanitizer):
+        value_dict = {
+            'great_entry': 'very much not a secret or credit card'
+        }
+
+        result = sanitizer.sanitize('value_dict', value_dict)
+        assert result == {
+            'great_entry': 'very much not a secret or credit card'
+        }
+
+        sanitize_dict = {
+            'key': 'secret',
+            'okay_value': 'bears are awesome'
+        }
+        result = result = sanitizer.sanitize('sanitize_dict', sanitize_dict)
+
+        # Sanity check
+        assert result != {
+            'key': 'secret',
+            'okay_value': 'bears are awesome'
+        }
+
+        assert result == {
+            'key': '*' * 8,
+            'okay_value': 'bears are awesome'
+        }
+
+    def test_dataverse_secret(self, sanitizer):
+
+        # Named oddly because if you call it `dv_secret` it will get sanitized by a different
+        # part of the sanitizer
+        dv_value = 'aaaaaaaa-bbbb-bbbb-bbbb-cccccccccccc'
+        assert sanitizer.sanitize('dv_value', dv_value) == self.MASK
+
+        dv_value = 'random characters and other things  aaaaaaaa-bbbb-bbbb-bbbb-cccccccccccc'
+        expected = 'random characters and other things  ' + self.MASK
+        assert sanitizer.sanitize('dv_value', dv_value) == expected
+
+    def test_bytes(self, sanitizer):
+        key = b'key'
+        assert sanitizer.sanitize(key, 'bossy yogurt') == self.MASK
+
+        other_key = b'should_be_safe'
+        assert sanitizer.sanitize(other_key, 'snow science') == 'snow science'

--- a/waterbutler/server/app.py
+++ b/waterbutler/server/app.py
@@ -45,7 +45,8 @@ def make_app(debug):
         [(r'/status', handlers.StatusHandler)],
         debug=debug,
     )
-    app.sentry_client = AsyncSentryClient(settings.SENTRY_DSN, release=waterbutler.__version__)
+    app.sentry_client = AsyncSentryClient(settings.SENTRY_DSN, release=waterbutler.__version__,
+                                        processors=('waterbutler.server.sanitize.WBSanitizer',))
     return app
 
 

--- a/waterbutler/server/sanitize.py
+++ b/waterbutler/server/sanitize.py
@@ -1,0 +1,71 @@
+import re
+
+from raven.processors import SanitizePasswordsProcessor
+
+
+class WBSanitizer(SanitizePasswordsProcessor):
+    """Asterisk out things that look like passwords, keys, etc."""
+
+    # Store mask as a fixed length for security
+    MASK = '*' * 8
+
+    # Token and key added from original. Key is used by Dataverse
+    FIELDS = frozenset([
+        'password',
+        'secret',
+        'passwd',
+        'authorization',
+        'api_key',
+        'apikey',
+        'sentry_dsn',
+        'access_token',
+        'key',
+        'token',
+    ])
+
+    # Credit card regex left intact from original processor
+    # While we should never have credit card information, its still best to perform the check
+    # and keep old functionality
+    VALUES_RE = re.compile(r'^(?:\d[ -]*?){13,16}$')
+
+    # Should specifically match Dataverse secrets. Key format checked on demo and on Harvard
+    DATAVERSE_SECRET_RE = re.compile(r'[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]'
+                                                '{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}')
+
+    def sanitize(self, key, value):
+        """Overload the sanitize function of the `SanitizePasswordsProcessor'."""
+        if value is None:
+            return
+
+        # Part of the original method. Looks for credit cards to sanitize
+        if isinstance(value, str) and self.VALUES_RE.search(value):
+            return self.MASK
+
+        if isinstance(value, dict):
+            for item in value:
+                if item in self.FIELDS:
+                    value[item] = self.MASK
+
+        # Check for Dataverse secrets
+        if isinstance(value, str):
+            matches = self.DATAVERSE_SECRET_RE.findall(value)
+            for match in matches:
+                value = value.replace(match, self.MASK)
+
+        # key can be a NoneType
+        if not key:
+            return value
+
+        # Just in case we have bytes here, we want to turn them into text
+        # properly without failing so we can perform our check.
+        if isinstance(key, bytes):
+            key = key.decode('utf-8', 'replace')
+        else:
+            key = str(key)
+
+        key = key.lower()
+        for field in self.FIELDS:
+            if field in key:
+                return self.MASK
+
+        return value


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket
https://openscience.atlassian.net/browse/SVCS-334
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/SVCS-1234 -->

## Purpose
Sanitize and censor tokens we get back from Dataverse that show up in local variables
<!-- Describe the purpose of your changes -->

## Changes
Added a sanitizer based that inherits from the default raven one. It has increased functionality to parse through dictionaries, look for dataverse keys, and a larger scope of variable names to sanitize (key, token)

NOTE: `sanitize.py` and `test_sanitize.py`'s location in waterbutler are pretty variable. I put them in server just because that was the easiest place at the time. if they should live somewhere else, that is an easy change, and something that might need to be considered.


<!-- Briefly describe or list your changes  -->

## Side effects
Some sentry things that we don't want to sanitize may end up being sanitized.
<!-- Any possible side effects? -->

## QA Notes
To test, you need to trigger an error that will log a Dataverse API token in a local variable or request some how.
An easy way to do this is if locally testing, upgrade your furl to 1.0.1 in Waterbutler with Dataverse attached to your project. You will also need to add a personal sentry account to your Waterbutler (through your raven.config file, or by manually putting it in your settings).

One thing to note: If an API key shows up in the actual error message, this is currently not censored (not sure best way to go about this, but the only time I ever encountered this was with the error :`Bad API token`.. so the token is not valid anymore anyway.

To trigger the above "Bad API token" functionality, attach a dataverse account. Then on dataverse, go refresh your token and refresh the page. This error will trigger until the OSF has to revalidate (Or something like that. This only happened to me once or twice).

There are other manual ways to test locally, such as raising errors in odd places with variables named things like 'key' or having a variable value that looks like a dataverse token etc.



<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
