### PR TITLE
[SVCS-590] Improve WB Move and Copy

### DIFF
--- a/waterbutler/server/api/v1/provider/movecopy.py
+++ b/waterbutler/server/api/v1/provider/movecopy.py
@@ -1,4 +1,5 @@
 import json
+from http import HTTPStatus
 
 from waterbutler import tasks
 from waterbutler.sizes import MBs
@@ -51,43 +52,50 @@ class MoveCopyMixin:
         })
 
     async def move_or_copy(self):
+        """Copy, move and rename files and folders.
+        """
+
         # Force the json body to load into memory
         await self.request.body
 
-        if self.json.get('action') not in ('copy', 'move', 'rename'):
-            # Note: null is used as the default to avoid python specific error messages
-            raise exceptions.InvalidParameters('Action must be copy, move or rename, '
-                                               'not {}'.format(self.json.get('action', 'null')))
+        json_action = self.json.get('action', 'null')
+        if json_action not in ('copy', 'move', 'rename'):
+            raise exceptions.InvalidParameters('Action must be copy, move or rename, not {}'.format(json_action))
 
         # Setup of the provider was delayed so the json action could be retrieved from the request body.
-        provider = self.path_kwargs['provider']
-        action = self.json['action']
+        provider = self.path_kwargs.get('provider', '')
+        provider_action = json_action
+        if json_action == 'rename':
+            if not self.json.get('rename', ''):
+                raise exceptions.InvalidParameters('Rename is required for renaming')
+            provider_action = 'move'
 
         self.auth = await auth_handler.get(
-            self.resource, provider,
+            self.resource,
+            provider,
             self.request,
-            action=action,
+            action=json_action,
             auth_type=AuthType.SOURCE
         )
-        self.provider = make_provider(provider, self.auth['auth'], self.auth['credentials'], self.auth['settings'])
+        self.provider = make_provider(
+            provider,
+            self.auth['auth'],
+            self.auth['credentials'],
+            self.auth['settings']
+        )
         self.path = await self.provider.validate_v1_path(self.path, **self.arguments)
 
-        if action == 'rename':
-            if not self.json.get('rename'):
-                raise exceptions.InvalidParameters('Rename is required for renaming')
-
-            action = 'move'
+        if json_action == 'rename':
             self.dest_auth = self.auth
             self.dest_provider = self.provider
             self.dest_path = self.path.parent
             self.dest_resource = self.resource
         else:
-            if 'path' not in self.json:
+            path = self.json.get('path', '')
+            if not path:
                 raise exceptions.InvalidParameters('Path is required for moves or copies')
-
-            if not self.json['path'].endswith('/'):
-                raise exceptions.InvalidParameters('Path requires a trailing slash to indicate '
-                                                   'it is a folder')
+            if not path.endswith('/'):
+                raise exceptions.InvalidParameters('Path requires a trailing slash to indicate it is a folder')
 
             # TODO optimize for same provider and resource
 
@@ -97,7 +105,7 @@ class MoveCopyMixin:
                 self.dest_resource,
                 self.json.get('provider', self.provider.NAME),
                 self.request,
-                action=action,
+                action=json_action,
                 auth_type=AuthType.DESTINATION,
             )
             self.dest_provider = make_provider(
@@ -108,10 +116,10 @@ class MoveCopyMixin:
             )
             self.dest_path = await self.dest_provider.validate_path(**self.json)
 
-        if not getattr(self.provider, 'can_intra_' + action)(self.dest_provider, self.path):
+        if not getattr(self.provider, 'can_intra_' + provider_action)(self.dest_provider, self.path):
             # this weird signature syntax courtesy of py3.4 not liking trailing commas on kwargs
             conflict = self.json.get('conflict', DEFAULT_CONFLICT)
-            result = await getattr(tasks, action).adelay(
+            result = await getattr(tasks, provider_action).adelay(
                 rename=self.json.get('rename'),
                 conflict=conflict,
                 request=remote_logging._serialize_request(self.request),
@@ -121,7 +129,7 @@ class MoveCopyMixin:
         else:
             metadata, created = (
                 await tasks.backgrounded(
-                    getattr(self.provider, action),
+                    getattr(self.provider, provider_action),
                     self.dest_provider,
                     self.path,
                     self.dest_path,
@@ -133,8 +141,8 @@ class MoveCopyMixin:
         self.dest_meta = metadata
 
         if created:
-            self.set_status(201)
+            self.set_status(HTTPStatus.CREATED)
         else:
-            self.set_status(200)
+            self.set_status(HTTPStatus.OK)
 
         self.write({'data': metadata.json_api_serialized(self.dest_resource)})


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-590

## Purpose

"Actions"  are used in different places having different means. As requested by @icereval , this PR clean up the logic by using `provider_action` and `auth_action`. There is also an `osf_action` already introduced in https://github.com/CenterForOpenScience/waterbutler/pull/288.

## Changes

### Primary

Replace `action` with `provider_action` and `auth_action`. The former are native actions supported by providers: `move` and `copy`. The latter are actions requested in the API request and used by the auth handler: `move`, `rename` and `copy`. Both `move` and `copy` in `auth_action` are mapped to `move` in `provider_action`.

### Minor

* Use `.get('key', 'default_value') instead of `['key']` for dictionary access.
* Use `http.HTTPStatus` instead of number literals

## Side effects

No

## QA Notes

Backend follow-up update after https://github.com/CenterForOpenScience/waterbutler/pull/288. Everything should word as expected. Testing a few different providers is recommended.

* move/copy/rename within a project
* move/copy/rename between two projects you own
* move/copy/rename between a project you own and a linked public project

## Deployment Notes

No