### PR TITLE
[SVCS-30] Allow delete folder that creates empty GitHub repo

### DIFF
--- a/tests/providers/github/fixtures/root_provider.json
+++ b/tests/providers/github/fixtures/root_provider.json
@@ -263,6 +263,24 @@
         },
         "name":"master"
     },
+    "content_repo_metadata_root_one_folder":[
+        {
+            "path":"deletedfolder",
+            "type":"dir",
+            "html_url":"https://github.com/icereval/test/tree/master/deletedfolder",
+            "git_url":"https://api.github.com/repos/icereval/test/git/trees/bc1087ebfe8354a684bf9f8b75517784143dde86",
+            "url":"https://api.github.com/repos/icereval/test/contents/deletedfolder?ref=master",
+            "sha":"bc1087ebfe8354a684bf9f8b75517784143dde86",
+            "_links":{
+                "git":"https://api.github.com/repos/icereval/test/git/trees/bc1087ebfe8354a684bf9f8b75517784143dde86",
+                "self":"https://api.github.com/repos/icereval/test/contents/deletedfolder?ref=master",
+                "html":"https://github.com/icereval/test/tree/master/deletedfolder"
+            },
+            "name":"deletedfolder",
+            "size":0,
+            "download_url":null
+        }
+    ],
     "content_repo_metadata_root":[  
         {  
             "path":"file.txt",

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -365,6 +365,16 @@ class GitHubProvider(provider.BaseProvider):
         await resp.release()
 
     async def _delete_folder(self, path, message=None, **kwargs):
+        message = message or settings.DELETE_FOLDER_MESSAGE
+        # _create_tree fails with empty tree (422 Invalid tree info), so catch it if this folder
+        # is the last contents of this repository and use _delete_root_folder_contents instead.
+        if path.parent.is_root:
+            root_metadata = await self.metadata(path.parent)
+            if len(root_metadata) == 1:
+                if root_metadata[0].path == path.materialized_path:
+                    await self._delete_root_folder_contents(path, message=message, **kwargs)
+                    return
+
         branch_data = await self._fetch_branch(path.branch_ref)
 
         old_commit_sha = branch_data['commit']['sha']
@@ -429,7 +439,6 @@ class GitHubProvider(provider.BaseProvider):
             tree_sha = tree_data['sha']
 
         # Create a new commit which references our top most tree change.
-        message = message or settings.DELETE_FOLDER_MESSAGE
         commit_resp = await self.make_request(
             'POST',
             self.build_repo_url('git', 'commits'),


### PR DESCRIPTION
## Ticket
[SVCS-30](https://openscience.atlassian.net/browse/SVCS-30)

## Purpose
Allow delete folder that creates empty GitHub repo

## Changes
During "def _folder_delete" check to see if folder is the last contents
of the repository. If so, execute a "def _delete_root_folder_contents".

## Side effects
Slight additional overhead when deleting a folder from repository root.
Deletion of last folder in repo will be much faster then other folder deletions.

## QA Notes
Test deleting folders from repository root. with/without contents and with/without other repo contents. This can be tested with postman and/or through osf.io .
