### PR TITLE
[SVCS-397] Copy `root` without the `rename` parameter raises 400 instead of 500

### DIFF
--- a/waterbutler/server/api/v1/provider/movecopy.py
+++ b/waterbutler/server/api/v1/provider/movecopy.py
@@ -107,13 +107,13 @@ class MoveCopyMixin:
             if path is None:
                 raise exceptions.InvalidParameters('"path" field is required for moves or copies')
             if not path.endswith('/'):
-                raise exceptions.InvalidParameters('"path" field requires a trailing slash to '
-                                                   'indicate it is a folder')
+                raise exceptions.InvalidParameters(
+                    '"path" field requires a trailing slash to indicate it is a folder'
+                )
 
-            # TODO optimize for same provider and resource
-
-            if action == 'copy' and not self.json.get('rename') and self.path.is_root:
-                raise exceptions.InvalidParameters('Rename is required for copying root')
+            # for copy action, `auth_action` is the same as `provider_action`
+            if auth_action == 'copy' and self.path.is_root and not self.json.get('rename'):
+                raise exceptions.InvalidParameters('"rename" field is required for copying root')
 
             # Note: attached to self so that _send_hook has access to these
             self.dest_resource = self.json.get('resource', self.resource)

--- a/waterbutler/server/api/v1/provider/movecopy.py
+++ b/waterbutler/server/api/v1/provider/movecopy.py
@@ -112,6 +112,9 @@ class MoveCopyMixin:
 
             # TODO optimize for same provider and resource
 
+            if action == 'copy' and not self.json.get('rename') and self.path.is_root:
+                raise exceptions.InvalidParameters('Rename is required for copying root')
+
             # Note: attached to self so that _send_hook has access to these
             self.dest_resource = self.json.get('resource', self.resource)
             self.dest_auth = await auth_handler.get(


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-397

## Purpose

This PR replaces https://github.com/CenterForOpenScience/waterbutler/pull/265 and credit goes to @AddisonSchiller 👍 👍 

Currently, if one tries to copy root, WB will throw `500`. Copying non-root files does not require rename. Code needs to be added so copying root without rename throws an appropriate error instead of `500`.

## Changes

Added a check so that if someone is attempting to copy `root`, the `rename` param needs to be set. Otherwise, throw an `InvalidParameters` error.

## Side effects

- [x] Verify/Update the code after https://github.com/CenterForOpenScience/waterbutler/pull/298 gets merged.

## QA Notes

Please refer to the QA Notes in the ticket.

## Deployment Notes

No
