### PR TITLE
[hotfix] osfstorage parity metadata

### DIFF
--- a/tests/providers/osfstorage/test_provider.py
+++ b/tests/providers/osfstorage/test_provider.py
@@ -732,8 +732,9 @@ class TestUploads:
         inner_provider.upload.assert_called_once_with(file_stream, WaterButlerPath('/uniquepath'),
                                                       check_created=False, fetch_metadata=False)
         complete_path = os.path.join(FILE_PATH_COMPLETE, file_stream.writers['sha256'].hexdigest)
-        mock_parity.assert_called_once_with(complete_path, credentials['parity'],
-                                            settings['parity'])
+        mock_parity.assert_called_once_with(complete_path, upload_response['version'],
+                                            'https://waterbutler.io/hooks/metadata/',
+                                            credentials['parity'], settings['parity'])
         mock_backup.assert_called_once_with(complete_path, upload_response['version'],
                                             'https://waterbutler.io/hooks/metadata/',
                                             credentials['archive'], settings['parity'])

--- a/waterbutler/core/metadata.py
+++ b/waterbutler/core/metadata.py
@@ -188,7 +188,7 @@ class BaseMetadata(metaclass=abc.ABCMeta):
 
     @property
     def extra(self) -> dict:
-        """A dict of optional metdata from the provider.  Non-mandatory metadata should be stored
+        """A dict of optional metadata from the provider.  Non-mandatory metadata should be stored
         in this property.
 
         While this field is not explicitly structured, the `hashes` key should be reserved for the

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -368,6 +368,8 @@ class OSFStorageProvider(provider.BaseProvider):
         if settings.RUN_TASKS and data.pop('archive', True):
             parity.main(
                 local_complete_path,
+                data['version'],
+                self.build_url('hooks', 'metadata') + '/',
                 self.parity_credentials,
                 self.parity_settings,
             )

--- a/waterbutler/providers/osfstorage/tasks/parity.py
+++ b/waterbutler/providers/osfstorage/tasks/parity.py
@@ -1,16 +1,22 @@
 import os
+import json
 import asyncio
+import hashlib
+from http import HTTPStatus
 
-from waterbutler.core import streams
+import aiohttp
+
+from waterbutler.core import streams, signing
 from waterbutler.core.utils import async_retry
 from waterbutler.core.utils import make_provider
 
+from waterbutler.providers.osfstorage import settings
 from waterbutler.providers.osfstorage.tasks import utils
 from waterbutler.providers.osfstorage import settings as osf_settings
 
 
 @utils.task
-def _parity_create_files(self, name, credentials, settings):
+def _parity_create_files(self, name, version_id, callback_url, credentials, settings):
     path = os.path.join(osf_settings.FILE_PATH_COMPLETE, name)
     loop = asyncio.get_event_loop()
     with utils.RetryUpload(self):
@@ -29,6 +35,15 @@ def _parity_create_files(self, name, credentials, settings):
             error = each.exception()
             if error:
                 raise error
+    metadata = {
+        'parity': {
+            'redundancy': osf_settings.PARITY_REDUNDANCY,
+            'files': [
+                (lambda r: {'name': r[0], 'sha256': r[1]})(r.result()) for r in results
+            ],
+        },
+    }
+    _push_parity_complete.delay(version_id, callback_url, metadata)
 
 
 async def _upload_parity(path, credentials, settings):
@@ -37,12 +52,38 @@ async def _upload_parity(path, credentials, settings):
     provider = make_provider(provider_name, {}, credentials, settings)
     with open(path, 'rb') as file_pointer:
         stream = streams.FileStreamReader(file_pointer)
+        stream.add_writer('sha256', streams.HashStreamWriter(hashlib.sha256))
         await provider.upload(
             stream,
             (await provider.validate_path('/' + name))
         )
+    return (name, stream.writers['sha256'].hexdigest)
+
+
+@utils.task
+def _push_parity_complete(self, version_id, callback_url, metadata):
+    signer = signing.Signer(settings.HMAC_SECRET, settings.HMAC_ALGORITHM)
+    with utils.RetryHook(self):
+        data = signing.sign_data(
+            signer,
+            {
+                'version': version_id,
+                'metadata': metadata,
+            },
+        )
+        future = aiohttp.request(
+            'PUT',
+            callback_url,
+            data=json.dumps(data),
+            headers={'Content-Type': 'application/json'},
+        )
+        loop = asyncio.get_event_loop()
+        response = loop.run_until_complete(future)
+
+        if response.status != HTTPStatus.OK:
+            raise Exception('Failed to report parity completion, got status code {}'.format(response.status))
 
 
 @async_retry(retries=5, backoff=5)
-def main(name, credentials, settings):
-    return _parity_create_files.delay(name, credentials, settings)
+def main(name, version_id, callback_url, credentials, settings):
+    return _parity_create_files.delay(name, version_id, callback_url, credentials, settings)

--- a/waterbutler/providers/osfstorage/tasks/utils.py
+++ b/waterbutler/providers/osfstorage/tasks/utils.py
@@ -1,13 +1,18 @@
 import os
 import glob
+import json
 import errno
 import logging
 import functools
 import contextlib
 import subprocess
+from http import HTTPStatus
+
+import aiohttp
 
 from celery.utils.log import get_task_logger
 
+from waterbutler.core import signing
 from waterbutler.tasks.app import app, client
 from waterbutler.providers.osfstorage import settings
 from waterbutler.providers.osfstorage.tasks import exceptions
@@ -64,6 +69,26 @@ def create_parity_files(file_path, redundancy=5):
             for fpath in
             glob.glob(os.path.join(path, '{0}*.par2'.format(name)))
         ]
+
+
+async def push_metadata(version_id, callback_url, metadata):
+    signer = signing.Signer(settings.HMAC_SECRET, settings.HMAC_ALGORITHM)
+    data = signing.sign_data(
+        signer,
+        {
+            'version': version_id,
+            'metadata': metadata,
+        },
+    )
+    response = await aiohttp.request(
+        'PUT',
+        callback_url,
+        data=json.dumps(data),
+        headers={'Content-Type': 'application/json'},
+    )
+
+    if response.status != HTTPStatus.OK:
+        raise Exception('Failed to report archive completion, got status code {}'.format(response.status))
 
 
 def sanitize_request(request):


### PR DESCRIPTION
Adds parity metadata for osfstorage provider hook callback.

Depends on https://github.com/CenterForOpenScience/osf.io/pull/8075