### PR TITLE
[SVCS-499] Adding size_as_int property to BaseFileMetadata

### DIFF
--- a/tests/providers/bitbucket/test_metadata.py
+++ b/tests/providers/bitbucket/test_metadata.py
@@ -35,6 +35,7 @@ class TestBitbucketMetadata:
         assert metadata.created_utc is None
         assert metadata.content_type is None
         assert metadata.size == 13
+        assert metadata.size_as_int == 13
         assert metadata.etag == '{}::{}'.format(full_path,COMMIT_SHA)
         assert metadata.provider == 'bitbucket'
         assert metadata.last_commit_sha == '90c8f7eef948'

--- a/tests/providers/box/test_metadata.py
+++ b/tests/providers/box/test_metadata.py
@@ -20,6 +20,8 @@ class TestBoxMetadata:
         assert data.path == '/5000948880'
         assert data.provider == 'box'
         assert data.size == 629644
+        assert data.size_as_int == 629644
+        assert type(data.size_as_int) == int
         assert data.modified == '2012-12-12T11:04:26-08:00'
         assert data.created_utc == '2012-12-12T18:55:30+00:00'
         assert data.content_type is None

--- a/tests/providers/cloudfiles/test_metadata.py
+++ b/tests/providers/cloudfiles/test_metadata.py
@@ -43,6 +43,8 @@ class TestCloudfilesMetadata:
         assert data.path == '/file.txt'
         assert data.provider == 'cloudfiles'
         assert data.size == 216945
+        assert type(data.size_as_int) == int
+        assert data.size_as_int == 216945
         assert data.modified == 'Mon, 22 Dec 2014 19:01:02 GMT'
         assert data.created_utc is None
         assert data.content_type == 'text/plain'
@@ -117,6 +119,8 @@ class TestCloudfilesMetadata:
         assert data.provider == 'cloudfiles'
         assert data.path == '/similar.file'
         assert data.size == 190
+        assert data.size_as_int == 190
+        assert type(data.size_as_int) == int
         assert data.modified == '2014-12-19T23:22:14.728640'
         assert data.created_utc is None
         assert data.content_type == 'application/x-www-form-urlencoded;charset=utf-8'

--- a/tests/providers/dataverse/test_metadata.py
+++ b/tests/providers/dataverse/test_metadata.py
@@ -38,6 +38,8 @@ class TestFileMetadata:
         assert file_metadata_object.kind == 'file'
         assert file_metadata_object.file_id == '20'
         assert file_metadata_object.name == 'thefile.txt'
+        assert file_metadata_object.size is None
+        assert file_metadata_object.size_as_int is None
         assert file_metadata_object.path == '/20'
         assert file_metadata_object.materialized_path == '/thefile.txt'
         assert not file_metadata_object.size

--- a/tests/providers/dropbox/test_metadata.py
+++ b/tests/providers/dropbox/test_metadata.py
@@ -20,6 +20,9 @@ class TestDropboxMetadata:
         assert data.name == 'Getting_Started.pdf'
         assert data.path == '/Getting_Started.pdf'
         assert data.size == 124778
+        assert data.size_as_int == 124778
+        assert type(data.size_as_int) == int
+
         assert data.modified == '2016-06-13T19:08:17Z'
         assert data.created_utc is None
         assert data.content_type is None

--- a/tests/providers/figshare/test_metadata.py
+++ b/tests/providers/figshare/test_metadata.py
@@ -24,6 +24,9 @@ class TestFigshareFileMetadata:
         assert data.materialized_path == '/file_article/file'
         assert data.upload_path == '/4037952/6530715'
         assert data.size == 7
+        assert data.size_as_int == 7
+        assert type(data.size_as_int) == int
+
         assert data.content_type is None
         assert data.modified is None
         assert data.modified_utc is None

--- a/tests/providers/filesystem/test_metadata.py
+++ b/tests/providers/filesystem/test_metadata.py
@@ -36,6 +36,8 @@ class TestMetadata:
         assert data.content_type is None
         assert data.name == '77094244-aa24-48da-9437-d8ce6f7a94e9'
         assert data.size == 35981
+        assert data.size_as_int == 35981
+        assert type(data.size_as_int) == int
         assert data.etag == ('Wed, 20 Sep 2017 15:16:02 +0000::/'
             'code/website/osfstoragecache/77094244-aa24-48da-9437-d8ce6f7a94e9')
         assert data.kind == 'file'

--- a/tests/providers/filesystem/test_provider.py
+++ b/tests/providers/filesystem/test_provider.py
@@ -116,6 +116,7 @@ class TestCRUD:
         assert metadata.name == file_name
         assert metadata.path == file_path
         assert metadata.size == len(file_content)
+        assert metadata.size_as_int == len(file_content)
         assert created is True
 
     @pytest.mark.asyncio
@@ -132,6 +133,7 @@ class TestCRUD:
         assert metadata.name == file_name
         assert metadata.path == file_path
         assert metadata.size == len(file_content)
+        assert metadata.size_as_int == len(file_content)
         assert created is False
 
     @pytest.mark.asyncio
@@ -148,6 +150,7 @@ class TestCRUD:
         assert metadata.name == file_name
         assert metadata.path == file_path
         assert metadata.size == len(file_content)
+        assert metadata.size_as_int == len(file_content)
         assert created is True
 
     @pytest.mark.asyncio
@@ -164,6 +167,7 @@ class TestCRUD:
         assert metadata.name == file_name
         assert metadata.path == file_path
         assert metadata.size == len(file_content)
+        assert metadata.size_as_int == len(file_content)
         assert created is False
 
     @pytest.mark.asyncio

--- a/tests/providers/github/test_metadata.py
+++ b/tests/providers/github/test_metadata.py
@@ -25,6 +25,8 @@ class TestGitHubMetadata:
         assert metadata.modified is None
         assert metadata.content_type is None
         assert metadata.size == 38
+        assert metadata.size_as_int == 38
+        assert type(metadata.size_as_int) == int
         assert metadata.etag == '/README.md::d863d70539aa9fcb6b44b057221706f2ab18e341'
         assert metadata.extra == {
             'fileSha': 'd863d70539aa9fcb6b44b057221706f2ab18e341',
@@ -50,6 +52,8 @@ class TestGitHubMetadata:
         assert metadata.modified is None
         assert metadata.content_type is None
         assert metadata.size == 15
+        assert metadata.size_as_int == 15
+        assert type(metadata.size_as_int) == int
         assert metadata.etag == '/epsilon::bd4fb614678f544acb22bac6861a21108f1e5d10'
         assert metadata.extra == {
             'fileSha': 'bd4fb614678f544acb22bac6861a21108f1e5d10',
@@ -103,6 +107,8 @@ class TestGitHubMetadata:
         assert metadata.modified is None
         assert metadata.content_type is None
         assert metadata.size == 38
+        assert metadata.size_as_int == 38
+        assert type(metadata.size_as_int) == int
         assert metadata.etag == '/README.md::d863d70539aa9fcb6b44b057221706f2ab18e341'
         assert metadata.extra == {
             'fileSha': 'd863d70539aa9fcb6b44b057221706f2ab18e341',

--- a/tests/providers/googledrive/test_metadata.py
+++ b/tests/providers/googledrive/test_metadata.py
@@ -32,6 +32,8 @@ class TestMetadata:
         assert parsed.id == item['id']
         assert path.name == item['title']
         assert parsed.name == item['title']
+        assert parsed.size_as_int == 918668
+        assert type(parsed.size_as_int) == int
         assert parsed.size == item['fileSize']
         assert parsed.modified == item['modifiedDate']
         assert parsed.content_type == item['mimeType']
@@ -55,6 +57,8 @@ class TestMetadata:
         assert parsed.name == item['title']
         assert parsed.name == path.name
         assert parsed.size == item['fileSize']
+        assert parsed.size_as_int == 918668
+        assert type(parsed.size_as_int) == int
         assert parsed.modified == item['modifiedDate']
         assert parsed.content_type == item['mimeType']
         assert parsed.extra == {

--- a/tests/providers/owncloud/test_metadata.py
+++ b/tests/providers/owncloud/test_metadata.py
@@ -21,6 +21,8 @@ class TestFileMetadata:
         assert file_metadata_object.materialized_path == '/Documents/dissertation.aux'
         assert file_metadata_object.kind == 'file'
         assert file_metadata_object.size == '3011'
+        assert file_metadata_object.size_as_int == 3011
+        assert type(file_metadata_object.size_as_int) == int
         assert file_metadata_object.etag == '"a3c411808d58977a9ecd7485b5b7958e"'
         assert file_metadata_object.modified == 'Sun, 10 Jul 2016 23:28:31 GMT'
         assert file_metadata_object.modified_utc == '2016-07-10T23:28:31+00:00'
@@ -47,6 +49,7 @@ class TestFileMetadata:
         assert file_metadata_object_less_info.materialized_path == '/Documents/dissertation.aux'
         assert file_metadata_object_less_info.kind == 'file'
         assert file_metadata_object_less_info.size is None
+        assert file_metadata_object_less_info.size_as_int is None
         assert file_metadata_object_less_info.etag == '"a3c411808d58977a9ecd7485b5b7958e"'
         assert file_metadata_object_less_info.modified == 'Sun, 10 Jul 2016 23:28:31 GMT'
         assert file_metadata_object_less_info.modified_utc == '2016-07-10T23:28:31+00:00'

--- a/tests/providers/owncloud/test_provider.py
+++ b/tests/providers/owncloud/test_provider.py
@@ -177,6 +177,7 @@ class TestCRUD:
         assert created is True
         assert metadata.name == file_metadata_object.name
         assert metadata.size == file_metadata_object.size
+        assert metadata.size_as_int == int(file_metadata_object.size)
         assert aiohttpretty.has_call(method='PUT', uri=url)
 
     @pytest.mark.asyncio
@@ -200,6 +201,7 @@ class TestCRUD:
         assert created is True
         assert metadata.name == file_metadata_object.name
         assert metadata.size == file_metadata_object.size
+        assert metadata.size_as_int == int(file_metadata_object.size)
         assert aiohttpretty.has_call(method='PUT', uri=url)
 
     @pytest.mark.asyncio

--- a/tests/providers/s3/test_metadata.py
+++ b/tests/providers/s3/test_metadata.py
@@ -21,6 +21,8 @@ class TestFileMetadataHeaders:
         assert file_metadata_headers_object.kind == 'file'
         assert file_metadata_headers_object.provider == 's3'
         assert file_metadata_headers_object.size == 9001
+        assert file_metadata_headers_object.size_as_int == 9001
+        assert type(file_metadata_headers_object.size_as_int) == int
         assert file_metadata_headers_object.content_type == 'binary/octet-stream'
         assert file_metadata_headers_object.modified == 'SomeTime'
         assert not file_metadata_headers_object.created_utc
@@ -50,6 +52,8 @@ class TestFileMetadata:
         assert file_metadata_object.path == '/my-image.jpg'
         assert file_metadata_object.materialized_path == '/my-image.jpg'
         assert file_metadata_object.size == 434234
+        assert file_metadata_object.size_as_int == 434234
+        assert type(file_metadata_object.size_as_int) == int
         assert file_metadata_object.modified == '2009-10-12T17:50:30.000Z'
         assert file_metadata_object.etag == 'fba9dede5f27731c9771645a39863328'
         assert not file_metadata_object.created_utc

--- a/waterbutler/core/metadata.py
+++ b/waterbutler/core/metadata.py
@@ -271,10 +271,11 @@ class BaseFileMetadata(BaseMetadata):
         Some providers give metadata as an int. Both exist to maintain backwards
         compatibility.
         """
-        if self.size is not None:
-            return int(self.size)
-        else:
-            return None
+        try:
+            size_as_int = int(self.size)
+        except (TypeError, ValueError):
+            size_as_int = None
+        return size_as_int
 
 
 class BaseFileRevisionMetadata(metaclass=abc.ABCMeta):

--- a/waterbutler/core/metadata.py
+++ b/waterbutler/core/metadata.py
@@ -265,6 +265,17 @@ class BaseFileMetadata(BaseMetadata):
         """ Size of the file in bytes. """
         raise NotImplementedError
 
+    @property
+    def size_as_int(self) -> int:
+        """ Size of the file as an int.
+        Some providers give metadata as an int. Both exist to maintain backwards
+        compatibility.
+        """
+        if self.size is not None:
+            return int(self.size)
+        else:
+            return None
+
 
 class BaseFileRevisionMetadata(metaclass=abc.ABCMeta):
 


### PR DESCRIPTION
## Ticket

[SVCS-499](https://openscience.atlassian.net/browse/SVCS-499)

## Purpose
Some provider metadata returns size as a string, not an int. Add a property that returns size as an int.

## Changes
Added ```size_as_int``` field to ```BaseFileMetadata```.
Added explicit metadata tests for the new property

## Side effects
None

## QA Notes
This change is very minimal and should require little QA. It should be most notable in the tests for now.

## Deployment Notes
None