### PR TITLE
[SVCS-334] Sentry captures dataverse API tokens on certain error types

### DIFF
--- a/tests/server/test_sanitize.py
+++ b/tests/server/test_sanitize.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest import mock
+
+import pytest
 
 from waterbutler.server.sanitize import WBSanitizer
 
@@ -71,12 +72,6 @@ class TestWBSanitizer:
             'okay_value': 'bears are awesome'
         }
         result = sanitizer.sanitize('sanitize_dict', sanitize_dict)
-
-        # Sanity check
-        assert result != {
-            'key': 'secret',
-            'okay_value': 'bears are awesome'
-        }
 
         assert result == {
             'key': self.MASK,

--- a/tests/server/test_sanitize.py
+++ b/tests/server/test_sanitize.py
@@ -7,7 +7,7 @@ from waterbutler.server.sanitize import WBSanitizer
 
 @pytest.fixture
 def sanitizer():
-    return WBSanitizer(mock.Mock())
+    return WBSanitizer()
 
 
 class TestWBSanitizer:

--- a/tests/server/test_sanitize.py
+++ b/tests/server/test_sanitize.py
@@ -1,0 +1,76 @@
+import pytest
+from unittest import mock
+
+from waterbutler.server.sanitize import WBSanitizer
+
+
+@pytest.fixture
+def sanitizer():
+    return WBSanitizer(mock.Mock())
+
+
+class TestWBSanitizer:
+    # The sanitize function changes some strings and dictionaries
+    # you put into it, so you need to explicitly test most things
+
+    MASK = '*' * 8
+
+    def test_no_sanitization(self, sanitizer):
+        assert sanitizer.sanitize('thing', 'ghost science') == 'ghost science'
+
+    def test_fields_sanitized(self, sanitizer):
+        fields = sanitizer.FIELDS
+        for field in fields:
+            assert sanitizer.sanitize(field, 'free speech') == self.MASK
+
+    def test_value_is_none(self, sanitizer):
+        assert sanitizer.sanitize('great hair', None) is None
+
+    def test_sanitize_credit_card(self, sanitizer):
+        assert sanitizer.sanitize('credit', '424242424242424') == self.MASK
+        assert sanitizer.sanitize('credit', '4242424242424243333333') != self.MASK
+
+    def test_sanitize_dictionary(self, sanitizer):
+        value_dict = {
+            'great_entry': 'very much not a secret or credit card'
+        }
+
+        result = sanitizer.sanitize('value_dict', value_dict)
+        assert result == {
+            'great_entry': 'very much not a secret or credit card'
+        }
+
+        sanitize_dict = {
+            'key': 'secret',
+            'okay_value': 'bears are awesome'
+        }
+        result = result = sanitizer.sanitize('sanitize_dict', sanitize_dict)
+
+        # Sanity check
+        assert result != {
+            'key': 'secret',
+            'okay_value': 'bears are awesome'
+        }
+
+        assert result == {
+            'key': '*' * 8,
+            'okay_value': 'bears are awesome'
+        }
+
+    def test_dataverse_secret(self, sanitizer):
+
+        # Named oddly because if you call it `dv_secret` it will get sanitized by a different
+        # part of the sanitizer
+        dv_value = 'aaaaaaaa-bbbb-bbbb-bbbb-cccccccccccc'
+        assert sanitizer.sanitize('dv_value', dv_value) == self.MASK
+
+        dv_value = 'random characters and other things  aaaaaaaa-bbbb-bbbb-bbbb-cccccccccccc'
+        expected = 'random characters and other things  ' + self.MASK
+        assert sanitizer.sanitize('dv_value', dv_value) == expected
+
+    def test_bytes(self, sanitizer):
+        key = b'key'
+        assert sanitizer.sanitize(key, 'bossy yogurt') == self.MASK
+
+        other_key = b'should_be_safe'
+        assert sanitizer.sanitize(other_key, 'snow science') == 'snow science'

--- a/waterbutler/server/app.py
+++ b/waterbutler/server/app.py
@@ -44,7 +44,8 @@ def make_app(debug):
         [(r'/status', handlers.StatusHandler)],
         debug=debug,
     )
-    app.sentry_client = AsyncSentryClient(settings.SENTRY_DSN, release=__version__)
+    app.sentry_client = AsyncSentryClient(settings.SENTRY_DSN, release=__version__,
+                                        processors=('waterbutler.server.sanitize.WBSanitizer',))
     return app
 
 

--- a/waterbutler/server/sanitize.py
+++ b/waterbutler/server/sanitize.py
@@ -1,0 +1,71 @@
+import re
+
+from raven.processors import SanitizePasswordsProcessor
+
+
+class WBSanitizer(SanitizePasswordsProcessor):
+    """Asterisk out things that look like passwords, keys, etc."""
+
+    # Store mask as a fixed length for security
+    MASK = '*' * 8
+
+    # Token and key added from original. Key is used by Dataverse
+    FIELDS = frozenset([
+        'password',
+        'secret',
+        'passwd',
+        'authorization',
+        'api_key',
+        'apikey',
+        'sentry_dsn',
+        'access_token',
+        'key',
+        'token',
+    ])
+
+    # Credit card regex left intact from original processor
+    # While we should never have credit card information, its still best to perform the check
+    # and keep old functionality
+    VALUES_RE = re.compile(r'^(?:\d[ -]*?){13,16}$')
+
+    # Should specifically match Dataverse secrets. Key format checked on demo and on Harvard
+    DATAVERSE_SECRET_RE = re.compile(r'[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]'
+                                                '{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}')
+
+    def sanitize(self, key, value):
+        """Overload the sanitize function of the `SanitizePasswordsProcessor'."""
+        if value is None:
+            return
+
+        # Part of the original method. Looks for credit cards to sanitize
+        if isinstance(value, str) and self.VALUES_RE.search(value):
+            return self.MASK
+
+        if isinstance(value, dict):
+            for item in value:
+                if item in self.FIELDS:
+                    value[item] = self.MASK
+
+        # Check for Dataverse secrets
+        if isinstance(value, str):
+            matches = self.DATAVERSE_SECRET_RE.findall(value)
+            for match in matches:
+                value = value.replace(match, self.MASK)
+
+        # key can be a NoneType
+        if not key:
+            return value
+
+        # Just in case we have bytes here, we want to turn them into text
+        # properly without failing so we can perform our check.
+        if isinstance(key, bytes):
+            key = key.decode('utf-8', 'replace')
+        else:
+            key = str(key)
+
+        key = key.lower()
+        for field in self.FIELDS:
+            if field in key:
+                return self.MASK
+
+        return value

--- a/waterbutler/server/sanitize.py
+++ b/waterbutler/server/sanitize.py
@@ -4,43 +4,26 @@ from raven.processors import SanitizePasswordsProcessor
 
 
 class WBSanitizer(SanitizePasswordsProcessor):
-    """Asterisk out things that look like passwords, keys, etc."""
+    """
+    Use parent class to asterisk out things that look like passwords, credit card numbers,
+    and API keys in frames, http, and basic extra data.
 
-    # Store mask as a fixed length for security
-    MASK = '*' * 8
-
-    # Token and key added from original. Key is used by Dataverse
-    FIELDS = frozenset([
-        'password',
-        'secret',
-        'passwd',
-        'authorization',
-        'api_key',
-        'apikey',
-        'sentry_dsn',
-        'access_token',
-        'key',
-        'token',
-    ])
-
-    # Credit card regex left intact from original processor
-    # While we should never have credit card information, its still best to perform the check
-    # and keep old functionality
-    VALUES_RE = re.compile(r'^(?:\d[ -]*?){13,16}$')
+    In addition, asterisk out Dataverse formatted ouath tokens.
+    """
 
     # Should specifically match Dataverse secrets. Key format checked on demo and on Harvard
     DATAVERSE_SECRET_RE = re.compile(r'[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]'
                                                 '{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}')
 
+    def __init__(self):
+        # As of raven version 6.4 this attribute name has been changed from FIELDS to KEYS.
+        # Will need to be updated when we upgrade.
+        self.FIELDS = self.FIELDS.union(['key', 'token', 'refresh_token'])
+
     def sanitize(self, key, value):
-        """Overload the sanitize function of the `SanitizePasswordsProcessor'."""
+        """Subclass the sanitize function of the `SanitizePasswordsProcessor'."""
 
-        if value is None:
-            return
-
-        # Part of the original method. Looks for credit cards to sanitize
-        if isinstance(value, str) and self.VALUES_RE.search(value):
-            return self.MASK
+        value = SanitizePasswordsProcessor.sanitize(self, key, value)
 
         if isinstance(value, dict):
             for item in value:
@@ -50,7 +33,6 @@ class WBSanitizer(SanitizePasswordsProcessor):
             new_list = []
             for item in value:
                 new_list.append(self.sanitize(key, item))
-
             value = new_list
 
         # Check for Dataverse secrets
@@ -58,23 +40,5 @@ class WBSanitizer(SanitizePasswordsProcessor):
             matches = self.DATAVERSE_SECRET_RE.findall(value)
             for match in matches:
                 value = value.replace(match, self.MASK)
-
-        # key can be a NoneType
-        # This sould be after the regex checks incase a `None` key is a token
-        if not key:
-            return value
-
-        # Just in case we have bytes here, we want to turn them into text
-        # properly without failing so we can perform our check.
-        if isinstance(key, bytes):
-            # May want a try/except block around this, but for now it should be okay
-            key = key.decode('utf-8', 'replace')
-        else:
-            key = str(key)
-
-        key = key.lower()
-        for field in self.FIELDS:
-            if field in key:
-                return self.MASK
 
         return value


### PR DESCRIPTION
This PR includes merge of https://github.com/CenterForOpenScience/waterbutler/pull/297 plus refactor of sub-classed raven processor.

## TODO
- [x] Move self.FIELDS.union to WBSanitizer __init__

## Ticket
[SVCS-334](https://openscience.atlassian.net/browse/SVCS-334)

## Purpose
Sanitize and censor tokens we get back from Dataverse that show up in local variables

## Changes
Added a sanitizer based that inherits from the default raven one. It has increased functionality to parse through dictionaries, look for dataverse keys, and a larger scope of variable names to sanitize (key, token)

NOTE: sanitize.py and test_sanitize.py's location in waterbutler are pretty variable. I put them in server just because that was the easiest place at the time. if they should live somewhere else, that is an easy change, and something that might need to be considered.

## Side effects
Some sentry things that we don't want to sanitize may end up being sanitized.

## QA Notes
To test, you need to trigger an error that will log a Dataverse API token in a local variable or request some how.
An easy way to do this is if locally testing, upgrade your furl to 1.0.1 in Waterbutler with Dataverse attached to your project. You will also need to add a personal sentry account to your Waterbutler (through your raven.config file, or by manually putting it in your settings).

One thing to note: If an API key shows up in the actual error message, this is currently not censored (not sure best way to go about this, but the only time I ever encountered this was with the error :Bad API token.. so the token is not valid anymore anyway.

To trigger the above "Bad API token" functionality, attach a dataverse account. Then on dataverse, go refresh your token and refresh the page. This error will trigger until the OSF has to revalidate (Or something like that. This only happened to me once or twice).

There are other manual ways to test locally, such as raising errors in odd places with variables named things like 'key' or having a variable value that looks like a dataverse token etc.
  