### PR TITLE
[SVCS-319] Fix Range-header handling (enables MFR video support on Safari)

### DIFF
--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -8,6 +8,7 @@ class TestExceptionSerialization:
     @pytest.mark.parametrize('exception_class', [
         (exceptions.WaterButlerError),
         (exceptions.InvalidParameters),
+        (exceptions.InvalidHeaderError),
         (exceptions.UnsupportedHTTPMethodError),
         (exceptions.UnsupportedActionError),
         (exceptions.PluginError),

--- a/tests/providers/filesystem/test_provider.py
+++ b/tests/providers/filesystem/test_provider.py
@@ -96,6 +96,30 @@ class TestCRUD:
         assert content == b'I am a file'
 
     @pytest.mark.asyncio
+    async def test_download_range(self, provider):
+        path = await provider.validate_path('/flower.jpg')
+
+        result = await provider.download(path, range=(0, 1))
+        assert result.partial
+        content = await result.read()
+        assert content == b'I '
+
+        result = await provider.download(path, range=(2, 5))
+        assert result.partial
+        content = await result.read()
+        assert content == b'am a'
+
+    @pytest.mark.asyncio
+    async def test_download_range_open_ended(self, provider):
+        path = await provider.validate_path('/flower.jpg')
+
+        result = await provider.download(path, range=(0, None))
+        assert hasattr('result', 'partial') == False
+        content = await result.read()
+
+        assert content == b'I am a file'
+
+    @pytest.mark.asyncio
     async def test_download_not_found(self, provider):
         path = await provider.validate_path('/missing.txt')
 

--- a/tests/providers/gitlab/test_provider.py
+++ b/tests/providers/gitlab/test_provider.py
@@ -497,6 +497,22 @@ class TestDownload:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
+    async def test_download_range(self, provider):
+        path = '/folder1/file.py'
+        gl_path = GitLabPath(path, _ids=([('a1b2c3d4', 'master')] * 3))
+
+        url = ('http://base.url/api/v4/projects/123/repository/files'
+               '/folder1%2Ffile.py?ref=a1b2c3d4')
+        aiohttpretty.register_json_uri('GET', url, body={'content': 'aGVsbG8='})
+
+        result = await provider.download(gl_path, branch='master', range=(0, 1))
+        assert result.partial
+        assert await result.read() == b'he'  # body content after base64 decoding and slice
+        assert aiohttpretty.has_call(method='GET', uri=url,
+                                     headers={'Range': 'bytes=0-1', 'PRIVATE-TOKEN': 'naps'})
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
     async def test_download_file_ruby_response(self, provider):
         """See: https://gitlab.com/gitlab-org/gitlab-ce/issues/31790"""
         path = '/folder1/folder2/file'
@@ -508,6 +524,23 @@ class TestDownload:
 
         result = await provider.download(gl_path)
         assert await result.read() == b'rolf\n'
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    async def test_download_file_ruby_response_range(self, provider):
+        """See: https://gitlab.com/gitlab-org/gitlab-ce/issues/31790"""
+        path = '/folder1/folder2/file'
+        gl_path = GitLabPath(path, _ids=([(None, 'my-branch')] * 4))
+
+        url = ('http://base.url/api/v4/projects/123/repository/files/'
+               'folder1%2Ffolder2%2Ffile?ref=my-branch')
+        aiohttpretty.register_uri('GET', url, body=fixtures.weird_ruby_response())
+
+        result = await provider.download(gl_path, range=(0, 1))
+        assert result.partial
+        assert await result.read() == b'ro'
+        assert aiohttpretty.has_call(method='GET', uri=url,
+                                     headers={'Range': 'bytes=0-1', 'PRIVATE-TOKEN': 'naps'})
 
 
 class TestReadOnlyProvider:

--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -253,6 +253,21 @@ class TestCRUD:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
+    async def test_download_range(self, provider, mock_time):
+        path = WaterButlerPath('/muhtriangle')
+        response_headers = {'response-content-disposition': 'attachment'}
+        url = provider.bucket.new_key(path.path).generate_url(100,
+                                                              response_headers=response_headers)
+        aiohttpretty.register_uri('GET', url, body=b'de', auto_length=True, status=206)
+
+        result = await provider.download(path, range=(0, 1))
+        assert result.partial
+        content = await result.read()
+        assert content == b'de'
+        assert aiohttpretty.has_call(method='GET', uri=url, headers={'Range': 'bytes=0-1'})
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
     async def test_download_version(self, provider, mock_time):
         path = WaterButlerPath('/muhtriangle')
         url = provider.bucket.new_key(path.path).generate_url(

--- a/tests/server/test_utils.py
+++ b/tests/server/test_utils.py
@@ -1,11 +1,13 @@
-import pytest
 from unittest import mock
 
+import pytest
 from tornado import testing
 
 from tests.server.api.v1.utils import ServerTestCase
 
-from waterbutler.server.utils import CORsMixin
+from waterbutler.core.exceptions import InvalidHeaderError
+from waterbutler.server.utils import CORsMixin, parse_request_range
+
 
 class MockHandler(CORsMixin):
 
@@ -166,3 +168,28 @@ class TestCORsMixin(ServerTestCase):
             assert 'Access-Control-Allow-Credentials' not in self.handler.headers
             assert 'Access-Control-Allow-Headers' not in self.handler.headers
             assert 'Access-Control-Expose-Headers' not in self.handler.headers
+
+
+class TestRangeParsing():
+
+    @pytest.mark.parametrize("range_header,expected", [
+        ('bytes=0-1',      (0, 1)),
+        ('bytes=28-45',    (28, 45)),
+        ('bytes=0-',       (0, None)),
+        ('bytes=6-',       (6, None)),
+        ('bytes=',         None),
+        ('foo=42',         None),
+        ('bytes=1-2,6-10', None),
+    ])
+    def test_range_parsing(self, range_header, expected):
+        result = parse_request_range(range_header)
+        assert result == expected
+
+    @pytest.mark.parametrize("range_header", [
+        ('bytes=-6'),
+        ('bytes=-0'),
+    ])
+    def test_range_parsing_errors(self, range_header):
+        with pytest.raises(InvalidHeaderError) as exc:
+            parse_request_range(range_header)
+

--- a/waterbutler/core/exceptions.py
+++ b/waterbutler/core/exceptions.py
@@ -61,6 +61,13 @@ class InvalidParameters(WaterButlerError):
         super().__init__(message, code=code)
 
 
+class InvalidHeaderError(WaterButlerError):
+    """An invalid value for an HTTP header was given.
+    """
+    def __init__(self, message, is_user_error=True):
+        super().__init__(message, code=HTTPStatus.BAD_REQUEST, is_user_error=is_user_error)
+
+
 class UnsupportedHTTPMethodError(WaterButlerError):
     """An unsupported HTTP method was used.
     """

--- a/waterbutler/core/streams/__init__.py
+++ b/waterbutler/core/streams/__init__.py
@@ -5,6 +5,7 @@ from waterbutler.core.streams.base import StringStream  # noqa
 from waterbutler.core.streams.base import EmptyStream  # noqa
 
 from waterbutler.core.streams.file import FileStreamReader  # noqa
+from waterbutler.core.streams.file import PartialFileStreamReader  # noqa
 
 from waterbutler.core.streams.http import FormDataStream  # noqa
 from waterbutler.core.streams.http import RequestStreamReader  # noqa

--- a/waterbutler/core/streams/file.py
+++ b/waterbutler/core/streams/file.py
@@ -46,3 +46,55 @@ class FileStreamReader(BaseStream):
         await asyncio.sleep(0.001)
         async for chunk in self.file_gen:
             return chunk
+
+
+class PartialFileStreamReader(FileStreamReader):
+    """Awful class, used to avoid messing with FileStreamReader"""
+
+    def __init__(self, file_pointer, byte_range):
+        super().__init__(file_pointer)
+        self.start = byte_range[0]
+        self.end = byte_range[1]
+        self.bytes_read = 0
+
+    @property
+    def size(self):
+        return self.end - self.start + 1
+
+    @property
+    def total_size(self):
+        cursor = self.file_pointer.tell()
+        self.file_pointer.seek(0, os.SEEK_END)
+        ret = self.file_pointer.tell()
+        self.file_pointer.seek(cursor)
+        return ret
+
+    @property
+    def partial(self):
+        return self.size < self.total_size
+
+    @property
+    def content_range(self):
+        return 'bytes {}-{}/{}'.format(self.start, self.end, self.total_size)
+
+    @agent.async_generator
+    def chunk_reader(self):
+        self.file_pointer.seek(self.start)
+        while True:
+            chunk = self.file_pointer.read(self.read_size)
+            self.bytes_read += self.read_size
+            if not chunk:
+                self.feed_eof()
+                yield b''
+
+            yield chunk
+
+    async def _read(self, size):
+        self.file_gen = self.file_gen or self.chunk_reader()
+        bytes_remaining = self.size - self.bytes_read
+        self.read_size = bytes_remaining if size == -1 else min(size, bytes_remaining)
+        # add sleep of 0 so read will yield and continue in next io loop iteration
+        # asyncio.sleep(0) yields None by default, which displeases tornado
+        await asyncio.sleep(0.001)
+        async for chunk in self.file_gen:
+            return chunk

--- a/waterbutler/providers/bitbucket/provider.py
+++ b/waterbutler/providers/bitbucket/provider.py
@@ -1,4 +1,6 @@
 import typing
+import logging
+
 from waterbutler.core import streams
 from waterbutler.core import provider
 from waterbutler.core import exceptions
@@ -8,6 +10,8 @@ from waterbutler.providers.bitbucket.path import BitbucketPath
 from waterbutler.providers.bitbucket.metadata import BitbucketFileMetadata
 from waterbutler.providers.bitbucket.metadata import BitbucketFolderMetadata
 from waterbutler.providers.bitbucket.metadata import BitbucketRevisionMetadata
+
+logger = logging.getLogger(__name__)
 
 
 class BitbucketProvider(provider.BaseProvider):
@@ -186,6 +190,7 @@ class BitbucketProvider(provider.BaseProvider):
         '''
         metadata = await self.metadata(path)
 
+        logger.debug('requested-range:: {}'.format(range))
         resp = await self.make_request(
             'GET',
             self._build_v1_repo_url('raw', path.commit_sha, *path.path_tuple()),
@@ -193,6 +198,7 @@ class BitbucketProvider(provider.BaseProvider):
             expects=(200, ),
             throws=exceptions.DownloadError,
         )
+        logger.debug('download-headers:: {}'.format([(x, resp.headers[x]) for x in resp.headers]))
 
         return streams.ResponseStreamReader(resp, size=metadata.size)
 

--- a/waterbutler/providers/bitbucket/provider.py
+++ b/waterbutler/providers/bitbucket/provider.py
@@ -1,3 +1,4 @@
+import typing
 from waterbutler.core import streams
 from waterbutler.core import provider
 from waterbutler.core import exceptions
@@ -25,6 +26,8 @@ class BitbucketProvider(provider.BaseProvider):
       error.
 
     * I think bitbucket lets you name branches the same as commits.  Then how does it resolve them?
+
+    * Bitbucket doesn't respect Range header on downloads for either v1.0 or v2.0 API
     """
 
     NAME = 'bitbucket'
@@ -176,7 +179,8 @@ class BitbucketProvider(provider.BaseProvider):
             for item in valid_revisions
         ]
 
-    async def download(self, path: BitbucketPath, **kwargs):  # type: ignore
+    async def download(self, path: BitbucketPath, range: typing.Tuple[int, int]=None,
+                       **kwargs):  # type: ignore
         '''Get the stream to the specified file on bitbucket
         :param str path: The path to the file on bitbucket
         '''
@@ -185,6 +189,7 @@ class BitbucketProvider(provider.BaseProvider):
         resp = await self.make_request(
             'GET',
             self._build_v1_repo_url('raw', path.commit_sha, *path.path_tuple()),
+            range=range,
             expects=(200, ),
             throws=exceptions.DownloadError,
         )

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -1,8 +1,10 @@
 import json
 import typing
-import aiohttp
 import hashlib
+import logging
 from http import HTTPStatus
+
+import aiohttp
 
 from waterbutler.core import streams
 from waterbutler.core import provider
@@ -13,6 +15,8 @@ from waterbutler.providers.box.metadata import (BaseBoxMetadata,
                                                 BoxFileMetadata,
                                                 BoxFolderMetadata,
                                                 BoxRevision)
+
+logger = logging.getLogger(__name__)
 
 
 class BoxProvider(provider.BaseProvider):
@@ -270,6 +274,7 @@ class BoxProvider(provider.BaseProvider):
         if revision and revision != path.identifier:
             query['version'] = revision
 
+        logger.debug('request-range:: {}'.format(range))
         resp = await self.make_request(
             'GET',
             self.build_url('files', path.identifier, 'content', **query),
@@ -278,6 +283,7 @@ class BoxProvider(provider.BaseProvider):
             expects=(200, 206),
             throws=exceptions.DownloadError,
         )
+        logger.debug('download-headers:: {}'.format([(x, resp.headers[x]) for x in resp.headers]))
 
         return streams.ResponseStreamReader(resp)
 

--- a/waterbutler/providers/dataverse/provider.py
+++ b/waterbutler/providers/dataverse/provider.py
@@ -1,5 +1,6 @@
 import typing
 import hashlib
+import logging
 import tempfile
 from http import HTTPStatus
 
@@ -12,6 +13,8 @@ from waterbutler.core.utils import AsyncIterator
 from waterbutler.providers.dataverse import settings
 from waterbutler.providers.dataverse.metadata import DataverseRevision
 from waterbutler.providers.dataverse.metadata import DataverseDatasetMetadata
+
+logger = logging.getLogger(__name__)
 
 
 class DataverseProvider(provider.BaseProvider):
@@ -127,6 +130,7 @@ class DataverseProvider(provider.BaseProvider):
         if path.identifier is None:
             raise exceptions.NotFoundError(str(path))
 
+        logger.debug('request-range:: {}'.format(range))
         resp = await self.make_request(
             'GET',
             self.build_url(settings.DOWN_BASE_URL, path.identifier, key=self.token),

--- a/waterbutler/providers/dataverse/provider.py
+++ b/waterbutler/providers/dataverse/provider.py
@@ -1,3 +1,4 @@
+import typing
 import hashlib
 import tempfile
 from http import HTTPStatus
@@ -17,6 +18,10 @@ class DataverseProvider(provider.BaseProvider):
     """Provider for Dataverse
 
     API Docs: http://guides.dataverse.org/en/4.5/api/
+
+    Quirks:
+
+    * Dataverse doesn't respect Range header on downloads
 
     """
 
@@ -105,7 +110,7 @@ class DataverseProvider(provider.BaseProvider):
             return self._metadata_cache[version]
         return sum(self._metadata_cache.values(), [])
 
-    async def download(self, path, revision=None, range=None, **kwargs):
+    async def download(self, path, revision=None, range: typing.Tuple[int, int]=None, **kwargs):
         """Returns a ResponseWrapper (Stream) for the specified path
         raises FileNotFoundError if the status from Dataverse is not 200
 

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -2,6 +2,7 @@ import json
 import typing
 import asyncio
 import hashlib
+import logging
 from http import HTTPStatus
 
 from waterbutler.core import streams
@@ -10,6 +11,8 @@ from waterbutler.core import exceptions
 
 from waterbutler.providers.figshare.path import FigsharePath
 from waterbutler.providers.figshare import metadata, settings
+
+logger = logging.getLogger(__name__)
 
 
 class FigshareProvider:
@@ -177,6 +180,7 @@ class BaseFigshareProvider(provider.BaseProvider):
         if download_url is None:
             raise exceptions.DownloadError('Download not available', code=HTTPStatus.FORBIDDEN)
 
+        logger.debug('requested-range:: {}'.format(range))
         params = {} if file_metadata.is_public else {'token': self.token}
         resp = await self.make_request(
             'GET',

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -1,9 +1,8 @@
 import json
+import typing
 import asyncio
 import hashlib
 from http import HTTPStatus
-
-import aiohttp
 
 from waterbutler.core import streams
 from waterbutler.core import provider
@@ -164,7 +163,7 @@ class BaseFigshareProvider(provider.BaseProvider):
         """
         return path.rstrip('/').split('/')
 
-    async def download(self, path, **kwargs):
+    async def download(self, path, range: typing.Tuple[int, int]=None, **kwargs):
         """Download the file identified by ``path`` from this project.
 
         :param FigsharePath path: FigsharePath to file you want to download
@@ -179,7 +178,12 @@ class BaseFigshareProvider(provider.BaseProvider):
             raise exceptions.DownloadError('Download not available', code=HTTPStatus.FORBIDDEN)
 
         params = {} if file_metadata.is_public else {'token': self.token}
-        resp = await aiohttp.request('GET', download_url, params=params)
+        resp = await self.make_request(
+            'GET',
+            download_url,
+            range=range,
+            params=params,
+        )
         if resp.status == 404:
             await resp.release()
             raise exceptions.DownloadError('Download not available', code=HTTPStatus.FORBIDDEN)

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -2,6 +2,7 @@ import copy
 import json
 import typing
 import hashlib
+import logging
 
 import furl
 
@@ -17,6 +18,8 @@ from waterbutler.providers.github.metadata import GitHubFolderContentMetadata
 from waterbutler.providers.github.metadata import GitHubFileTreeMetadata
 from waterbutler.providers.github.metadata import GitHubFolderTreeMetadata
 from waterbutler.providers.github.exceptions import GitHubUnsupportedRepoError
+
+logger = logging.getLogger(__name__)
 
 
 GIT_EMPTY_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
@@ -185,6 +188,7 @@ class GitHubProvider(provider.BaseProvider):
         data = await self.metadata(path, revision=revision)
         file_sha = path.file_sha or data.extra['fileSha']
 
+        logger.debug('requested-range:: {}'.format(range))
         resp = await self.make_request(
             'GET',
             self.build_repo_url('git', 'blobs', file_sha),

--- a/waterbutler/server/api/v0/crud.py
+++ b/waterbutler/server/api/v0/crud.py
@@ -5,7 +5,6 @@ from http import HTTPStatus
 
 import tornado.web
 import tornado.gen
-import tornado.httputil
 import tornado.platform.asyncio
 
 from waterbutler.core import mime_types
@@ -63,7 +62,7 @@ class CRUDHandler(core.BaseProviderHandler):
             raise tornado.web.HTTPError(status_code=400)
 
         if 'Range' in self.request.headers:
-            request_range = tornado.httputil._parse_request_range(self.request.headers['Range'])
+            request_range = utils.parse_request_range(self.request.headers['Range'])
         else:
             request_range = None
 

--- a/waterbutler/server/api/v1/provider/metadata.py
+++ b/waterbutler/server/api/v1/provider/metadata.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 
 import pytz
-import tornado.httputil
 from dateutil.parser import parse as datetime_parser
 
 from waterbutler.core import mime_types
@@ -66,7 +65,7 @@ class MetadataMixin:
             request_range = None
         else:
             logger.debug('Range header is: {}'.format(self.request.headers['Range']))
-            request_range = tornado.httputil._parse_request_range(self.request.headers['Range'])
+            request_range = utils.parse_request_range(self.request.headers['Range'])
             logger.debug('Range header parsed as: {}'.format(request_range))
 
         version = self.get_query_argument('version', default=None) or self.get_query_argument('revision', default=None)

--- a/waterbutler/server/api/v1/provider/metadata.py
+++ b/waterbutler/server/api/v1/provider/metadata.py
@@ -6,8 +6,9 @@ import logging
 import pytz
 from dateutil.parser import parse as datetime_parser
 
-from waterbutler.core import mime_types
 from waterbutler.server import utils
+from waterbutler.core import mime_types
+from waterbutler.core.streams import ResponseStreamReader
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +106,10 @@ class MetadataMixin:
             self.set_header('Content-Type', mime_types[ext])
 
         await self.write_stream(stream)
+
+        if getattr(stream, 'partial', False) and isinstance(stream, ResponseStreamReader):
+            await stream.response.release()
+
         logger.debug('bytes received is: {}'.format(self.bytes_downloaded))
 
     async def file_metadata(self):

--- a/waterbutler/server/utils.py
+++ b/waterbutler/server/utils.py
@@ -1,6 +1,7 @@
 import tornado.iostream
-from waterbutler.server import settings
 
+from waterbutler.core.exceptions import InvalidHeaderError
+from waterbutler.server import settings
 
 CORS_ACCEPT_HEADERS = [
     'Range',
@@ -26,6 +27,37 @@ HTTP_REASONS = {
 
 def make_disposition(filename):
     return 'attachment;filename="{}"'.format(filename.replace('"', '\\"'))
+
+
+def parse_request_range(range_header):
+    """WB uses tornado's httputil._parse_request_range function to parse the Range HTTP header and
+    return a tuple representing the range.  Tornado's version returns a tuple suitable for slicing
+    arrays, meaning that a range of 0-1 will be returned as ``(0, 2)``.  WB had been assuming that
+    the tuple would represent the first and last byte positions and was consistenly returning one
+    more byte than requested. Since WB doesn't ever use ranges to do list slicing of byte streams,
+    this function wraps tornado's version and returns the actual byte indices.
+
+    Ex. ``Range: bytes=0-1`` will be returned as ``(0, 1)``.
+
+    :param str range_header: a string containing the value of the Range header
+    :rtype: `tuple` or `None`
+    :return: a `tuple` representing the inclusive range of byte positions or `None`.
+    """
+    request_range = tornado.httputil._parse_request_range(range_header)
+
+    if request_range is None:
+        return request_range
+
+    start, end = request_range
+    if start is None and end is None:
+        return None
+    elif start is None or start < 0:
+        raise InvalidHeaderError('Unsupported Range header format: {}'.format(range_header))
+
+    if end is not None:
+        end -= 1
+
+    return (start, end)
 
 
 class CORsMixin:


### PR DESCRIPTION
## Ticket

[SVCS-319](https://openscience.atlassian.net/browse/SVCS-319)

This PR replaces #234 

## Purpose

Fix WB's broken Range header support, incidentally fixing video rendering on Safari.

WB was using an external library for parsing HTTP Range headers.  WB assumed that the tuple returned represented the first and last byte positions requested.  It was actually a list-slice compatible tuple, meaning that the end index was one byte greater than expected.  Given `Range: bytes=0-1`, the library would return `(0, 2)`, which WB would treat as `Range: bytes=0-2`.  This patch series fixes this error, adds code to ensure partial responses are properly closed, and adds Range header support to several providers that did not have it already.

This issue was unearthed by Detective @Johnetordoff in PR #234.  His fix would have worked, but was working around WB's incorrect behavior.  Instead, let's teach WB to DTRT.  This exposed other issues in WB's Range handling, which have been addressed.

## Changes

* Add a new utility method, `waterbutler.server.utils.parse_request_range`, that wraps the tornado version but returns an inclusive range instead of a list-slicing range.
* Manually close partial responses after download.  Partial responses did not exhaust their stream (they read exactly the number of bytes they contain), so the provider-originating response was not being released in `ResponseStreamReader`.  Unreleased aiohttp responses warn loudly on destruction.
* Document the three providers that don't currently support Range headers: Bitbucket, Dataverse, and GitHub.  Pass the Range header anyway, in hopes that they'll turn it on one day, and it will Just Work™.
* Manually implement Range header support for GitLab. We have to buffer the entire response into memory anyway, so we may as well trim it while we got it.
* Start sending the Range header to Figshare.  Figshare supports it, we just weren't passing it on.
* Implement Range header support for the filesystem provider by creating a new version of FileStreamReader that can return only the requested byte range from a file.
* Add tests for all supporting providers to ensure the Range Header is getting set and the returned response is a partial response.  The second part is a bit artificial for all but the GitLab and filesystem providers, since we mock the response.

## Side effects

* Positive: most (all?) providers now have a logger object available in them!  Logging defaults to `debug` level to not clog the terminal. 
* WB now rejects Range headers of the format `bytes=-6` with a 400 error.  Some providers do support this, so we may want to reconsider in the future.

## QA Notes

1. Upload videos (mp4 has good cross-browser support) to all WB-supported providers.
2. Attempt to view each on Safari.  Only Bitbucket, Dataverse, and GitHub should fail to render.
3. Attempt to download the file from each provider.  The file should download successfully for all providers and be playable locally (i.e. not corrupted)
4. *Bonus round*: Upload a plain text file containing the English alphabet to each provider. For each provider, send a WB download request with the header `Range: bytes=5-9`.  You should receive the string `fghij` from all but Bitbucket, Dataverse, and Github.  From those three, you should receive the entire original file.

## Deployment Notes

None needed.