### PR TITLE
[No Ticket] Upgrade to `mypy==0.560`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ colorlog==2.5.0
 flake8==3.0.4
 ipdb
 ipython
-mypy==0.511
+mypy==0.560
 pydevd==0.0.6
 pyflakes
 pytest==2.8.2


### PR DESCRIPTION
## Ticket

No Ticket

## Purpose

* Update `mypy` to `0.560` (the latest)
  * `0.511` throws "Name 'builtins' is not defined". Upgrading to the latest version fix this bug.

## Changes

See Purpose

## Side effects

No

## QA Notes

No QA

## Deployment Notes

No special configuration
