### PR TITLE
[SVCS-595] Update Box and GoogleDrive to Pass `mypy`

### DIFF
--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -194,7 +194,7 @@ class BoxProvider(provider.BaseProvider):
                          dest_provider: provider.BaseProvider,
                          src_path: wb_path.WaterButlerPath,
                          dest_path: wb_path.WaterButlerPath) \
-            -> typing.Tuple[typing.Union[BoxFileMetadata, BoxFolderMetadata], bool]:
+            -> typing.Tuple[BaseBoxMetadata, bool]:
         if dest_path.identifier is not None:
             await dest_provider.delete(dest_path)
 
@@ -219,10 +219,12 @@ class BoxProvider(provider.BaseProvider):
 
         return await self._intra_move_copy_metadata(dest_path, data)
 
-    async def intra_move(self,  # type: ignore
-                         dest_provider: provider.BaseProvider,
-                         src_path: wb_path.WaterButlerPath,
-                         dest_path: wb_path.WaterButlerPath) -> typing.Tuple[BaseBoxMetadata, bool]:
+    async def intra_move(
+            self,
+            dest_provider: provider.BaseProvider,
+            src_path: wb_path.WaterButlerPath,
+            dest_path: wb_path.WaterButlerPath
+    ) -> typing.Tuple[BaseBoxMetadata, bool]:
         if dest_path.identifier is not None and str(dest_path).lower() != str(src_path).lower():
             await dest_provider.delete(dest_path)
 
@@ -449,8 +451,7 @@ class BoxProvider(provider.BaseProvider):
                 expects=(200, ), throws=exceptions.MetadataError,
             ) as resp:
                 data = await resp.json()
-                # FIXME: Usage does not match function call signature!  Dead code or bug?
-                return data if raw else self._serialize_item(data)
+                return data if raw else self._serialize_item(data, path)
 
         # Box maximum limit is 1000
         page_count, page_total, limit = 0, None, 1000
@@ -501,7 +502,11 @@ class BoxProvider(provider.BaseProvider):
             box_path = await self.validate_path(child.path)
             await self.delete(box_path)
 
-    async def _intra_move_copy_metadata(self, path, data: dict) -> BaseBoxMetadata:
+    async def _intra_move_copy_metadata(
+            self,
+            path: wb_path.WaterButlerPath,
+            data: dict
+    ) -> typing.Tuple[BaseBoxMetadata, bool]:
         """Return appropriate metadata from intra_copy/intra_move actions. If `data` respresents
         a folder, will fetch and include `data`'s children.
         """
@@ -511,5 +516,5 @@ class BoxProvider(provider.BaseProvider):
             return self._serialize_item(data, path), created
         else:
             folder = self._serialize_item(data, path)
-            folder._children = await self._get_folder_meta(path)
+            folder._children = await self._get_folder_meta(path)  # type: ignore
             return folder, created

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -377,7 +377,7 @@ class GoogleDriveProvider(provider.BaseProvider):
         metadata = await self.metadata(path, raw=True)
         return [GoogleDriveRevision({
             'modifiedDate': metadata['modifiedDate'],  # type: ignore
-            'id': metadata['etag'] + settings.DRIVE_IGNORE_VERSION,
+            'id': metadata['etag'] + settings.DRIVE_IGNORE_VERSION,  # type: ignore
         })]
 
     async def create_folder(self,


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-595
Replaces: https://github.com/CenterForOpenScience/waterbutler/pull/314

## Purpose

Credits goes to @TomBaxter 👍.

Fix (or ignore) the failed `mypy` tests:

```bash
waterbutler/providers/googledrive/provider.py:380: error: Value of type "Union[Dict[Any, Any], BaseGoogleDriveMetadata, List[Union[BaseGoogleDriveMetadata, Dict[Any, Any]]]]" is not indexable
waterbutler/providers/googledrive/provider.py:380: error: No overload variant of "__getitem__" of "list" matches argument types [builtins.str]
waterbutler/providers/box/provider.py:220: error: Incompatible return value type (got "BaseBoxMetadata", expected "Tuple[Union[BoxFileMetadata, BoxFolderMetadata], bool]")
waterbutler/providers/box/provider.py:247: error: Incompatible return value type (got "BaseBoxMetadata", expected "Tuple[BaseBoxMetadata, bool]")
waterbutler/providers/box/provider.py:453: error: Too few arguments for "_serialize_item" of "BoxProvider"
waterbutler/providers/box/provider.py:511: error: Incompatible return value type (got "Tuple[Union[BoxFileMetadata, BoxFolderMetadata], bool]", expected "BaseBoxMetadata")
waterbutler/providers/box/provider.py:514: error: Item "BoxFileMetadata" of "Union[BoxFileMetadata, BoxFolderMetadata]" has no attribute "_children"
waterbutler/providers/box/provider.py:515: error: Incompatible return value type (got "Tuple[Union[BoxFileMetadata, BoxFolderMetadata], bool]", expected "BaseBoxMetadata")
```

## Changes

TBD

## Side effects

TBD

## QA Notes

No QA

## Deployment Notes

No special deploy notes
