### PR TITLE
[No Ticket] Disable editable install for aiohttpretty

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
--e git+https://github.com/centerforopenscience/aiohttpretty.git@0.0.2#egg=aiohttpretty
+git+https://github.com/centerforopenscience/aiohttpretty.git@0.0.2#egg=aiohttpretty
 colorlog==2.5.0
 flake8==3.0.4
 ipdb

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-git+https://github.com/centerforopenscience/aiohttpretty.git@0.0.2#egg=aiohttpretty
+git+https://github.com/centerforopenscience/aiohttpretty.git@0.1.0#egg=aiohttpretty
 colorlog==2.5.0
 flake8==3.0.4
 ipdb


### PR DESCRIPTION
## Ticket

No ticket or ticket to be created

## Purpose

Fix requirement installation by disabling editable install for aiohttpretty. This is the WB counterpart for MFR: https://github.com/CenterForOpenScience/modular-file-renderer/pull/312.

## Changes

- Remove `-e` from dev requirements, similar to the MFR PR, we don't need such editable install
- Editable install creates a temporary folder which may cause future installation to hang when
  `docker-compose up wb_requirements` finds out that the folder already exists and decide to wait for user input. Using `docker-compose up`, no instructions is provided to inform the user what's happening and installation just hangs
- Error message by installing directly inside the container using `invoke install -d`
  ```bash
  Obtaining aiohttpretty from 
  git+https://github.com/centerforopenscience/aiohttpretty.git@0.0.2#egg=aiohttpretty (from -r dev-
  requirements.txt (line 3))
    Directory /code/src/aiohttpretty already exists, and is not a git clone.
    The plan is to install the git repository https://github.com/centerforopenscience/aiohttpretty.git
  What to do?  (i)gnore, (w)ipe, (b)ackup
  ```

## Side effects

No. If you need to modify the code on the fly, enable `-e` locally.

## QA Notes

No. This is an update for local docker development.

## Deployment Notes

No. Make sure that travis pass.
