### PR TITLE
[] [] Ignore pyenv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .env
 .git
 .idea
+.python-version
 **/*.ipynb*
 **/*.pyc
 **/__pycache__


### PR DESCRIPTION
# Purpose

Adds .python-version to the gitignore file to allow people to use their own pyenv virtual environments without committing those changes.