### PR TITLE
[PLAT-218] Change log callback so we can log file views

### DIFF
--- a/waterbutler/core/remote_logging.py
+++ b/waterbutler/core/remote_logging.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 
 import aiohttp
+from furl import furl
 # from geoip import geolite2
 
 from waterbutler import settings
@@ -41,6 +42,7 @@ async def log_to_callback(action, source=None, destination=None, start_time=None
         log_payload['provider'] = log_payload['metadata']['provider']
 
     if action in ['download_file', 'download_zip']:
+        log_payload['metadata']['version'] = furl(request['request']['url']).args['version']
         is_mfr_render = settings.MFR_IDENTIFYING_HEADER in request['request']['headers']
         log_payload['action_meta']['is_mfr_render'] = is_mfr_render
 

--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -150,7 +150,7 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
         if any((method in ('HEAD', 'OPTIONS'), status == 202, status > 302, status < 200)):
             return
 
-        if method == 'GET' and 'meta' in self.request.query_arguments:
+        if method == 'GET' and ('meta' in self.request.query_arguments or 'revisions' in self.request.query_arguments):
             return
 
         # Done here just because method is defined


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/PLAT-218
Plat PR:
https://github.com/CenterForOpenScience/osf.io/pull/8184

## Purpose

Recently we opened up the log_to_callback function to send back data on GET actions, this completes that behavior by sending the file's version info and not sending it when listing revisions.

## Changes

- Minor logic changes to handler.

## Side effects

None that I know of.

## QA Notes

Should be tested as part of PLAT-218 ticket follow notes on that PR.

## Deployment Notes

None that I know of.