### PR TITLE
[SVCS-673] Use Context Manager to Release S3 Responses

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -64,7 +64,7 @@ def test(ctx, verbose=False, types=False):
     if types:
         mypy(ctx)
 
-    cmd = 'py.test --cov-report term-missing --cov waterbutler tests'
+    cmd = 'py.test --cov-report term-missing --cov waterbutler tests --pdb'
     if verbose:
         cmd += ' -v'
     ctx.run(cmd, pty=True)

--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -565,9 +565,11 @@ class TestCRUD:
     async def test_accepts_url(self, provider, mock_time):
         path = WaterButlerPath('/my-image')
         response_headers = {'response-content-disposition': 'attachment'}
-        url = provider.bucket.new_key(path.path).generate_url(100,
-                                                              'GET',
-                                                              response_headers=response_headers)
+        url = provider.bucket.new_key(path.path).generate_url(
+            100,
+            'GET',
+            response_headers=response_headers
+        )
 
         ret_url = await provider.download(path, accept_url=True)
 


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-672

## Purpose

In an effort to prepare waterbutler for a potential upgrade to a newer version of aiohttp, make sure that all requests are using a context manager to set up and break down requests.

The scope of this PR is constrained to only the s3 provider.

## Changes

Changes all instances where `aiohttp.ClientResponse.release` is called to use `async with`.

## Side effects

Shouldn't be any.