### PR TITLE
[SVCS-617] Remove Region From Google Cloud Provider 

### DIFF
--- a/tests/providers/googlecloud/fixtures/providers.py
+++ b/tests/providers/googlecloud/fixtures/providers.py
@@ -53,9 +53,9 @@ def mock_creds_2():
 
 @pytest.fixture()
 def mock_settings():
-    return {'bucket': 'gcloud-test.longzechen.com', 'region': 'US-EAST1'}
+    return {'bucket': 'gcloud-test.longzechen.com'}
 
 
 @pytest.fixture()
 def mock_settings_2():
-    return {'bucket': 'gcloud-test-2.longzechen.com', 'region': 'US-EAST1'}
+    return {'bucket': 'gcloud-test-2.longzechen.com'}

--- a/tests/providers/googlecloud/test_provider.py
+++ b/tests/providers/googlecloud/test_provider.py
@@ -70,7 +70,6 @@ class TestProviderInit:
         assert mock_provider.NAME == 'googlecloud'
         assert mock_provider.BASE_URL == pd_settings.BASE_URL
         assert mock_provider.bucket == mock_settings.get('bucket')
-        assert mock_provider.region == mock_settings.get('region')
 
         json_creds = mock_creds.get('json_creds')
         assert mock_provider.creds is not None

--- a/waterbutler/providers/googlecloud/provider.py
+++ b/waterbutler/providers/googlecloud/provider.py
@@ -62,7 +62,6 @@ class GoogleCloudProvider(BaseProvider):
                 'storage': {
                     'provider': 'change_me',
                     'bucket': 'change_me',
-                    'region': 'change_me',
                 },
             }
 
@@ -91,9 +90,6 @@ class GoogleCloudProvider(BaseProvider):
                 self.NAME,
                 message='Invalid or mal-formed service account credentials: {}'.format(str(exc))
             )
-
-        # `self.region` has no functional usage or impact
-        self.region = settings.get('region')
 
     async def validate_v1_path(self, path: str, **kwargs) -> WaterButlerPath:
         return await self.validate_path(path)


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-617

## Purpose

Google Cloud Storage API (XML and JSON) only needs the bucket name (and the object name). **Region** is set to the bucket during creation.

For WB, only needs to know which bucket to work on, OSF handles the region and select the correct bucket for WB.

## Changes

Remove `region` from the provider, tests, docstr and comments.

## Side effects

No

## QA Notes

No

## Deployment Notes

No
