### PR TITLE
[ENG-302] Handle GitHub Rate Limiting

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -332,3 +332,35 @@ OSF-specific parameter used to identify special "view-only" links that are used 
 * **Type**: string
 * **Expected on**: ``GET`` requests for files or folders
 * **Notes**: Only used internally for the Open Science Framework.
+
+
+GitHub Provider Params
+++++++++++++++++++++++
+
+Query parameters specific to the GitHub provider.
+
+
+*commit / branch identification*
+********************************
+
+Not a single parameter, but rather a class of parameters.  WaterButler has used many different parameters to identify the branch or commit a particular file should be found under.  These parameters can be either a commit SHA or a branch name.  These parameters are ``ref``, ``version``, ``branch``, ``sha``, ``revision``.  All will continue to be supported to maintain back-compatibility, but ``ref`` (for SHAs or branch names) and ``branch`` (branch names only) are preferred.
+
+If both a SHA and a branch name are provided in different parameters, the SHA will take precedence.  If multiple parameters are given with different SHAs, then the order of precedence will be: ``ref``, ``version``, ``sha``, ``revision``, ``branch``.  If multiple parameters are given with different branches, the order of precedence is: ``branch``, ``ref``, ``version``, ``sha``, ``revision``.
+
+* **Type**: str
+* **Expected on**: Any GitHub provider request
+* **Interactions**: None
+
+
+fileSha
+*******
+
+Identifies a specific revision of a file via its SHA.
+
+.. warning::
+
+   **PLEASE DON'T USE THIS!**  This was a mistake and should have never been added.  It will hopefully be removed or at the very least demoted in a future version.  File SHAs only identify the contents of a file.  They provide no information about the file name, path, commit, branch, etc.
+
+* **Type**: str
+* **Expected on**: Any GitHub provider request
+* **Interactions**: The ``fileSha`` is always assumed to be a file revision that is an ancestor of the imputed   commit or branch ref.  Providing a ``fileSha`` for a file version that was committed after the imputed ref will result in a 404.

--- a/tests/providers/github/fixtures/root_provider.json
+++ b/tests/providers/github/fixtures/root_provider.json
@@ -181,6 +181,39 @@
         "git_refs_url":"https://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
         "events_url":"https://api.github.com/repos/octocat/Hello-World/events"
     },
+    "commit_metadata": {
+        "sha" : "43798985fdb727843a49946b391409086a7021f2",
+        "url" : "https://api.github.com/repos/felliott/wb-testing/git/commits/43798985fdb727843a49946b391409086a7021f2",
+        "tree" : {
+            "sha" : "394164986adbe26c0c7605c6fe627e4fe3b13aa6",
+            "url" : "https://api.github.com/repos/felliott/wb-testing/git/trees/394164986adbe26c0c7605c6fe627e4fe3b13aa6"
+        },
+        "parents" : [
+            {
+                "url" : "https://api.github.com/repos/felliott/wb-testing/git/commits/189ee803576e85487afe4f6fa590e4ff9a791c6b",
+                "sha" : "189ee803576e85487afe4f6fa590e4ff9a791c6b",
+                "html_url" : "https://github.com/felliott/wb-testing/commit/189ee803576e85487afe4f6fa590e4ff9a791c6b"
+            }
+        ],
+        "committer" : {
+            "email" : "3rzwk@osf.io",
+            "name" : "Fitzfork",
+            "date" : "2017-03-14T19:18:51Z"
+        },
+        "author" : {
+            "date" : "2017-03-14T19:18:51Z",
+            "email" : "felliott@fiskur.org",
+            "name" : "Fitz Elliott"
+        },
+        "message" : "File updated on behalf of WaterButler",
+        "html_url" : "https://github.com/felliott/wb-testing/commit/43798985fdb727843a49946b391409086a7021f2",
+        "verification" : {
+            "payload" : null,
+            "verified" : false,
+            "signature" : null,
+            "reason" : "unsigned"
+        }
+    },
     "branch_metadata":{  
         "commit":{  
             "html_url":"https://github.com/octocat/Hello-World/commit/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",

--- a/tests/providers/github/test_exceptions.py
+++ b/tests/providers/github/test_exceptions.py
@@ -8,6 +8,7 @@ class TestExceptionSerialization:
 
     @pytest.mark.parametrize('exception_class', [
         (exceptions.GitHubUnsupportedRepoError),
+        (exceptions.GitHubRateLimitExceededError),
     ])
     def test_tolerate_dumb_signature(self, exception_class):
         """In order for WaterButlerError-inheriting exception classes to survive

--- a/tests/providers/github/test_exceptions.py
+++ b/tests/providers/github/test_exceptions.py
@@ -1,24 +1,29 @@
 import pytest
 
-from waterbutler.providers.github import exceptions
-
+from waterbutler.providers.github.exceptions import (GitHubUnsupportedRepoError,
+                                                     GitHubRateLimitExceededError, )
 
 
 class TestExceptionSerialization:
 
-    @pytest.mark.parametrize('exception_class', [
-        (exceptions.GitHubUnsupportedRepoError),
-        (exceptions.GitHubRateLimitExceededError),
-    ])
+    @pytest.mark.parametrize(
+        'exception_class',
+        [(GitHubUnsupportedRepoError), (GitHubRateLimitExceededError),]
+    )
     def test_tolerate_dumb_signature(self, exception_class):
-        """In order for WaterButlerError-inheriting exception classes to survive
-        pickling/unpickling, it is necessary for them to be able to be instatiated with
-         a single integer arg.  The reasons for this are described in the docstring for
-        `waterbutler.core.exceptions.WaterButlerError`.
+        """In order for WaterButlerError-inheriting exceptions to survive pickling/unpickling, it is
+        necessary for them to be able to be instantiated with a single integer arg.  The reasons for
+        this are described in the docstring for `waterbutler.core.exceptions.WaterButlerError`.
         """
+
         try:
             i_live_but_why = exception_class(616)
         except Exception as exc:
             pytest.fail(str(exc))
 
         assert isinstance(i_live_but_why, exception_class)
+
+    def test_date_formatting(self):
+        """Verify two-digit padding for month, day, hour, minute, second"""
+        exc = GitHubRateLimitExceededError(8)
+        assert '1970-01-01T00:00:08+00:00' in exc.message

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -102,7 +102,7 @@ def other_provider(other_auth, other_credentials, other_settings, provider_fixtu
 @pytest.fixture
 def rate_limit_provider(provider):
 
-    provider.task_id = 9876543210
+    provider.is_celery_task = True
     provider.rl_remaining = 500
     provider.rl_reset = 600
     provider.rl_available_tokens = 0
@@ -1465,7 +1465,7 @@ class TestRateLimit:
     async def test_make_request_not_celery(self, mock_time, rate_limit_provider):
 
         mock_provider = rate_limit_provider
-        del mock_provider.task_id
+        mock_provider.is_celery_task = False
 
         aiohttpretty.register_json_uri(
             'GET',
@@ -1549,7 +1549,7 @@ class TestRateLimit:
         """Test that non-celery requests throw rate limit exceeded error"""
 
         mock_provider = rate_limit_provider
-        del mock_provider.task_id
+        mock_provider.is_celery_task = False
 
         aiohttpretty.register_json_uri(
             'GET',
@@ -1579,7 +1579,7 @@ class TestRateLimit:
         """Test that non-celery requests re-throw non-limit exceeded errors"""
 
         mock_provider = rate_limit_provider
-        del mock_provider.task_id
+        mock_provider.is_celery_task = False
 
         aiohttpretty.register_json_uri(
             'GET',

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -1405,20 +1405,18 @@ class TestRateLimit:
 
         assert mock_provider.rl_req_rate == 0.6
         assert mock_provider.rl_req_rate_updated == 100
-        assert mock_provider.rl_available_tokens == 6.0
-        assert mock_provider.rl_tokens_updated == 100
+        assert mock_provider.rl_available_tokens == 0.6 * mock_provider.RL_TOKEN_ADD_DELAY
 
     # Test `_rl_add_more_tokens()` when new tokens exceeds maximum tokens
     def test_add_new_rate_limit_tokens_max_tokens_enforced(self, mock_time, rate_limit_provider):
 
         mock_provider = rate_limit_provider
-        mock_provider.rl_tokens_updated = 50
+        mock_provider.rl_available_tokens = 11
         mock_provider._rl_add_more_tokens()
 
         assert mock_provider.rl_req_rate == 0.6
         assert mock_provider.rl_req_rate_updated == 100
         assert mock_provider.rl_available_tokens == 10
-        assert mock_provider.rl_tokens_updated == 100
 
     # Test `_rl_add_more_tokens()` when it is not yet time to update `.rl_req_rate`
     def test_add_new_rate_limit_tokens_not_time_yet(self, mock_time, rate_limit_provider):
@@ -1438,10 +1436,10 @@ class TestRateLimit:
 
         await mock_provider._rl_check_available_tokens()
 
-        assert mock_provider.rl_available_tokens == 5
+        assert mock_provider.rl_available_tokens < 1
+        assert mock_provider.rl_available_tokens > 0
         assert mock_provider.rl_req_rate == 0.6
         assert mock_provider.rl_req_rate_updated == 100
-        assert mock_provider.rl_tokens_updated == 100
 
     # Test that celery requests update the `rl_remaining` and `rl_reset` with resp headers
     @pytest.mark.asyncio

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -976,8 +976,7 @@ class TestMetadata:
             '/file.txt', _ids=[("master", metadata[0]['sha']), ('master', metadata[0]['sha'])]
         )
 
-        url = provider.build_repo_url('commits', path=path.path, sha=path.file_sha)
-
+        url = provider.build_repo_url('commits', path=path.path, sha='master')
         aiohttpretty.register_json_uri('GET', url, body=metadata)
 
         result = await provider.revisions(path)

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -1402,6 +1402,11 @@ class TestRateLimit:
         mock_provider._rl_add_more_tokens()
         assert mock_provider.rl_available_tokens == 10
 
+    def test_add_tokens_reset_smaller_than_now(self, mock_time, rate_limit_provider):
+        mock_provider = rate_limit_provider
+        mock_provider.rl_reserved = 200
+        mock_provider.rl_reset = 50
+        mock_provider._rl_add_more_tokens()
         assert mock_provider.rl_available_tokens == 10
 
     @pytest.mark.asyncio

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -1608,7 +1608,7 @@ class TestRateLimit:
         """make_request should rethrow non-FORBIDDEN errors w/o any additional error-handling"""
 
         mock_provider = rate_limit_provider
-        mock_provider._rl_is_over_limit = utils.MockCoroutine()
+        mock_provider._rl_handle_forbidden_error = utils.MockCoroutine()
 
         aiohttpretty.register_json_uri(
             'GET',
@@ -1630,7 +1630,7 @@ class TestRateLimit:
             )
 
         assert exc.value.code == HTTPStatus.SERVICE_UNAVAILABLE
-        mock_provider._rl_is_over_limit.assert_not_called()
+        mock_provider._rl_handle_forbidden_error.assert_not_called()
 
 
 class TestOperations:

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -121,29 +121,30 @@ class TestValidatePath:
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_validate_v1_path_file(self, provider, provider_fixtures):
-        branch_url = provider.build_repo_url('branches', provider.default_branch)
-        tree_url = provider.build_repo_url(
-            'git', 'trees',
-            provider_fixtures['branch_metadata']['commit']['commit']['tree']['sha'],
-            recursive=1
-        )
 
-        aiohttpretty.register_json_uri('GET', branch_url, body=provider_fixtures['branch_metadata'])
-        aiohttpretty.register_json_uri(
-            'GET', tree_url, body=provider_fixtures['repo_tree_metadata_root']
-        )
+        branch_name = provider.default_branch
+        branch_metadata = provider_fixtures['branch_metadata']
+        tree_sha = branch_metadata['commit']['commit']['tree']['sha']
 
-        blob_path = 'file.txt'
+        branch_url = provider.build_repo_url('branches', branch_name)
+        tree_url = provider.build_repo_url('git', 'trees', tree_sha, recursive=1)
 
-        result = await provider.validate_v1_path('/' + blob_path)
+        aiohttpretty.register_json_uri('GET', branch_url, body=branch_metadata)
+        aiohttpretty.register_json_uri('GET', tree_url,
+                                       body=provider_fixtures['repo_tree_metadata_root'])
+
+        blob_name = 'file.txt'
+        blob_path = '/{}'.format(blob_name)
+
+        result = await provider.validate_v1_path(blob_path)
+        expected = GitHubPath(blob_path, _ids=[(branch_name, ''), (branch_name, '')])
+        assert result == expected
+        assert result.identifier[0] == expected.identifier[0]
 
         with pytest.raises(exceptions.NotFoundError) as exc:
-            await provider.validate_v1_path('/' + blob_path + '/')
-
-        expected = GitHubPath('/' + blob_path, _ids=[(provider.default_branch, '')])
+            await provider.validate_v1_path('/{}/'.format(blob_path))
 
         assert exc.value.code == client.NOT_FOUND
-        assert result == expected
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -161,35 +162,31 @@ class TestValidatePath:
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_validate_v1_path_folder(self, provider, provider_fixtures):
-        branch_url = provider.build_repo_url('branches', provider.default_branch)
-        tree_url = provider.build_repo_url(
-            'git', 'trees',
-            provider_fixtures['branch_metadata']['commit']['commit']['tree']['sha'],
-            recursive=1
-        )
 
-        aiohttpretty.register_json_uri(
-            'GET', branch_url, body=provider_fixtures['branch_metadata']
-        )
-        aiohttpretty.register_json_uri(
-            'GET', tree_url, body=provider_fixtures['repo_tree_metadata_root']
-        )
+        branch_name = provider.default_branch
+        branch_metadata = provider_fixtures['branch_metadata']
+        tree_sha = branch_metadata['commit']['commit']['tree']['sha']
 
-        tree_path = 'level1'
+        branch_url = provider.build_repo_url('branches', branch_name)
+        tree_url = provider.build_repo_url('git', 'trees', tree_sha, recursive=1)
 
-        expected = GitHubPath(
-            '/' + tree_path + '/', _ids=[(provider.default_branch, ''),
-            (provider.default_branch, None)]
-        )
+        aiohttpretty.register_json_uri('GET', branch_url, body=branch_metadata)
+        aiohttpretty.register_json_uri('GET', tree_url,
+                                       body=provider_fixtures['repo_tree_metadata_root'])
 
-        result = await provider.validate_v1_path('/' + tree_path + '/')
+        tree_name = 'level1'
+        tree_path = '/{}/'.format(tree_name)
+        result = await provider.validate_v1_path(tree_path)
+        expected = GitHubPath(tree_path, _ids=[(branch_name, ''), (branch_name, None)])
 
-        with pytest.raises(exceptions.NotFoundError) as exc:
-            await provider.validate_v1_path('/' + tree_path)
-
-        assert exc.value.code == client.NOT_FOUND
         assert result == expected
         assert result.extra == expected.extra
+        assert result.identifier[0] == expected.identifier[0]
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            await provider.validate_v1_path('/{}'.format(tree_name))
+
+        assert exc.value.code == client.NOT_FOUND
 
     @pytest.mark.asyncio
     async def test_reject_multiargs(self, provider):
@@ -1529,3 +1526,142 @@ class TestUtilities:
 
         assert len(pruned_tree) == 3  # alpha.txt, gamma.txt, epsilon.txt
         assert len([x for x in pruned_tree if x['type'] == 'tree']) == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    @pytest.mark.parametrize('param', [
+        ('branch'),
+        ('ref'),
+        ('version'),
+        ('sha'),
+        ('revision')
+    ])
+    async def test__interpret_query_parameters_branch(self, provider, provider_fixtures, param):
+
+        branch_name = 'develop'
+        branch_metadata = provider_fixtures['branch_metadata']
+        tree_sha = branch_metadata['commit']['commit']['tree']['sha']
+
+        branch_url = provider.build_repo_url('branches', branch_name)
+        tree_url = provider.build_repo_url('git', 'trees', tree_sha, recursive=1)
+
+        aiohttpretty.register_json_uri('GET', branch_url, body=branch_metadata)
+        aiohttpretty.register_json_uri('GET', tree_url,
+                                       body=provider_fixtures['repo_tree_metadata_root'])
+
+        blob_path = '/file.txt'
+        params = {param: branch_name}
+        result = await provider.validate_v1_path(blob_path, **params)
+        expected = GitHubPath(blob_path, _ids=[(branch_name, ''), (branch_name, '')])
+
+        assert result == expected
+        assert result.identifier[0] == expected.identifier[0]
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    @pytest.mark.parametrize('param', [
+        ('ref'),
+        ('version'),
+        ('sha'),
+        ('revision')
+    ])
+    async def test__interpret_query_parameters_sha(self, provider, provider_fixtures, param):
+
+        commit_sha = '6dcb09b5b57875f334f61aebed695e2e4193db5e'
+        commit_url = provider.build_repo_url('git', 'commits', commit_sha)
+
+        tree_sha = '394164986adbe26c0c7605c6fe627e4fe3b13aa6'
+        tree_url = provider.build_repo_url('git', 'trees', tree_sha, recursive=1)
+
+        aiohttpretty.register_json_uri('GET', commit_url,
+                                       body=provider_fixtures['commit_metadata'])
+        aiohttpretty.register_json_uri('GET', tree_url,
+                                       body=provider_fixtures['repo_tree_metadata_root'])
+
+        blob_path = '/file.txt'
+        params = {param: commit_sha}
+        result = await provider.validate_v1_path(blob_path, **params)
+        expected = GitHubPath(blob_path, _ids=[(commit_sha, ''), (commit_sha, '')])
+
+        assert result == expected
+        assert result.identifier[0] == expected.identifier[0]
+
+    def test__interpret_query_parameters_sha_priorities(self, provider):
+        params = {
+            'ref': 'b4eecafa9be2f2006ce1b709d6857b07069b4608',
+            'version': '7fd1a60b01f91b314f59955a4e4d4e80d8edf11d',
+            'sha': 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
+            'revision': 'bc1087ebfe8354a684bf9f8b75517784143dde86',
+        }
+
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'commit_sha'
+        assert ref == params['ref']
+
+        del params['ref']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'commit_sha'
+        assert ref == params['version']
+
+        del params['version']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'commit_sha'
+        assert ref == params['sha']
+
+        del params['sha']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'commit_sha'
+        assert ref == params['revision']
+
+        del params['revision']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == provider.default_branch
+
+    def test__interpret_query_parameters_branch_priorities(self, provider):
+        params = {
+            'branch': 'grr',
+            'ref': 'quack',
+            'version': 'woof',
+            'sha': 'moo',
+            'revision': 'meow',
+        }
+
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == params['branch']
+
+        del params['branch']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == params['ref']
+
+        del params['ref']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == params['version']
+
+        del params['version']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == params['sha']
+
+        del params['sha']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == params['revision']
+
+        del params['revision']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == provider.default_branch
+
+    def test__interpret_query_parameters_sha_vs_branch_priority(self, provider):
+        params = {
+            'ref': 'quack',
+            'version': 'ca39bcbf849231525ce9e775935fcb18ed477b5a',
+        }
+
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'commit_sha'
+        assert ref == params['version']

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -1714,3 +1714,13 @@ class TestUtilities:
             provider._interpret_query_parameters(**kwargs)
 
         assert exc.value.code == client.BAD_REQUEST
+
+    @pytest.mark.parametrize('ref,expected', [
+        ('ca39bcbf849231525ce9e775935fcb18ed477b5a', True),
+        ('ca39bcbf849231525ce9e775935fcb18ed477b5', False),  # one character short
+        ('bad', False),  # valid SHA, too short, must be branch
+        ('meow', False),  # not valid base 16, must be branch name
+        ('ca39bcbf849231525ce9e775935fcb18ed477b5x', False),  # 'x' not valid base16
+    ])
+    def test__looks_like_sha(self, provider, ref, expected):
+        assert provider._looks_like_sha(ref) == expected

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -286,7 +286,6 @@ class TestCRUD:
 
         url = provider.build_repo_url('git', 'blobs', file_sha)
         tree_url = provider.build_repo_url('git', 'trees', ref, recursive=1)
-        latest_sha_url = provider.build_repo_url('git', 'refs', 'heads', path.identifier[0])
         commit_url = provider.build_repo_url(
             'commits', path=path.path.lstrip('/'), sha=path.identifier[0]
         )
@@ -677,10 +676,7 @@ class TestCRUD:
             'git', 'trees',
             crud_fixtures['deleted_branch_metadata']['commit']['commit']['tree']['sha'])
         )
-
         create_tree_url = provider.build_repo_url('git', 'trees')
-        commit_url = provider.build_repo_url('git', 'commits')
-        patch_url = provider.build_repo_url('git', 'refs', 'heads', path.branch_ref)
 
         aiohttpretty.register_json_uri(
             'GET', branch_url, body=crud_fixtures['deleted_branch_metadata']
@@ -974,8 +970,6 @@ class TestMetadata:
         )
         url = furl.furl(provider.build_repo_url('contents', '/test/'))
         url.args.update({'ref': path.branch_ref})
-
-        message = 'This repository is empty.'
 
         aiohttpretty.register_json_uri('GET', url, body={})
 
@@ -1678,7 +1672,7 @@ class TestUtilities:
             GitHubPath('/beta/gam/', _ids=_ids)
         )
 
-        assert missing_file_tree == provider_fixtures['nested_tree_metadata']['tree']
+        assert missing_folder_tree == provider_fixtures['nested_tree_metadata']['tree']
 
     def test__reparent_blobs(self, provider, provider_fixtures):
         _ids = [('master', '')]

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -105,7 +105,6 @@ def rate_limit_provider(provider):
     provider.rl_req_rate = 1
     provider.rl_remaining = 500
     provider.rl_reset = 600
-    provider.rl_req_rate_updated = 10
     provider.rl_available_tokens = 0
     provider.rl_tokens_updated = 90
 
@@ -1383,9 +1382,7 @@ class TestRateLimit:
 
         mock_provider = rate_limit_provider
         mock_provider._rl_update_req_rate()
-
         assert mock_provider.rl_req_rate == 0.6
-        assert mock_provider.rl_req_rate_updated == 100
 
     # Test `_rl_update_req_rate()` when `.rl_remaining` is less then `rl_reserve`
     def test_update_rate_limit_under_reserve_limit(self, mock_time, rate_limit_provider):
@@ -1395,7 +1392,6 @@ class TestRateLimit:
         mock_provider._rl_update_req_rate()
 
         assert mock_provider.rl_req_rate == 0.01
-        assert mock_provider.rl_req_rate_updated == 100
 
     # Test `_rl_add_more_tokens()` with normal parameters
     def test_add_new_rate_limit_tokens(self, mock_time, rate_limit_provider):
@@ -1404,7 +1400,6 @@ class TestRateLimit:
         mock_provider._rl_add_more_tokens()
 
         assert mock_provider.rl_req_rate == 0.6
-        assert mock_provider.rl_req_rate_updated == 100
         assert mock_provider.rl_available_tokens == 0.6 * mock_provider.RL_TOKEN_ADD_DELAY
 
     # Test `_rl_add_more_tokens()` when new tokens exceeds maximum tokens
@@ -1415,18 +1410,7 @@ class TestRateLimit:
         mock_provider._rl_add_more_tokens()
 
         assert mock_provider.rl_req_rate == 0.6
-        assert mock_provider.rl_req_rate_updated == 100
         assert mock_provider.rl_available_tokens == 10
-
-    # Test `_rl_add_more_tokens()` when it is not yet time to update `.rl_req_rate`
-    def test_add_new_rate_limit_tokens_not_time_yet(self, mock_time, rate_limit_provider):
-
-        mock_provider = rate_limit_provider
-        mock_provider.rl_req_rate_updated = 90
-        mock_provider.rl_req_rate = 1
-        mock_provider._rl_add_more_tokens()
-
-        assert mock_provider.rl_req_rate == 1
 
     # Test `_rl_check_available_tokens()` with normal parameters
     @pytest.mark.asyncio
@@ -1439,7 +1423,6 @@ class TestRateLimit:
         assert mock_provider.rl_available_tokens < 1
         assert mock_provider.rl_available_tokens > 0
         assert mock_provider.rl_req_rate == 0.6
-        assert mock_provider.rl_req_rate_updated == 100
 
     # Test that celery requests update the `rl_remaining` and `rl_reset` with resp headers
     @pytest.mark.asyncio

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -1592,6 +1592,7 @@ class TestUtilities:
             'version': '7fd1a60b01f91b314f59955a4e4d4e80d8edf11d',
             'sha': 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
             'revision': 'bc1087ebfe8354a684bf9f8b75517784143dde86',
+            'branch': '71a892a5cd479bc73ae750b121c0d47a33028e66',
         }
 
         ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
@@ -1614,6 +1615,11 @@ class TestUtilities:
         assert ref == params['revision']
 
         del params['revision']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'commit_sha'
+        assert ref == params['branch']
+
+        del params['branch']
         ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
         assert ref_type == 'branch_name'
         assert ref == provider.default_branch
@@ -1660,8 +1666,14 @@ class TestUtilities:
         params = {
             'ref': 'quack',
             'version': 'ca39bcbf849231525ce9e775935fcb18ed477b5a',
+            'branch': 'tooth',
         }
 
         ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
         assert ref_type == 'commit_sha'
         assert ref == params['version']
+
+        del params['version']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == params['branch']

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -87,18 +87,21 @@ class BaseProvider(metaclass=abc.ABCMeta):
     def __init__(self, auth: dict,
                  credentials: dict,
                  settings: dict,
-                 retry_on: typing.Set[int]={408, 502, 503, 504}) -> None:
+                 retry_on: typing.Set[int]={408, 502, 503, 504},
+                 is_celery_task: bool=False) -> None:
         """
         :param auth: ( :class:`dict` ) Information about the user this provider will act on the behalf of
         :param credentials: ( :class:`dict` ) The credentials used to authenticate with the provider,
             ofter an OAuth 2 token
         :param settings: ( :class:`dict` ) Configuration settings for this provider,
             often folder or repo
+        :param is_celery_task: ( :class:`bool` ) Was this provider built inside a celery task?
         """
         self._retry_on = retry_on
         self.auth = auth
         self.credentials = credentials
         self.settings = settings
+        self.is_celery_task = is_celery_task
 
         self.provider_metrics = MetricsRecord('provider')
         self.provider_metrics.add('auth', auth)

--- a/waterbutler/core/utils.py
+++ b/waterbutler/core/utils.py
@@ -45,6 +45,7 @@ def make_provider(name: str, auth: dict, credentials: dict, settings: dict, **kw
             name=name,
             invoke_on_load=True,
             invoke_args=(auth, credentials, settings),
+            invoke_kwds=kwargs,
         )
     except RuntimeError:
         raise exceptions.ProviderNotFound(name)

--- a/waterbutler/providers/bitbucket/provider.py
+++ b/waterbutler/providers/bitbucket/provider.py
@@ -38,8 +38,8 @@ class BitbucketProvider(provider.BaseProvider):
     VIEW_URL = pd_settings.VIEW_URL
     RESP_PAGE_LEN = pd_settings.RESP_PAGE_LEN
 
-    def __init__(self, auth, credentials, settings):
-        super().__init__(auth, credentials, settings)
+    def __init__(self, auth, credentials, settings, **kwargs):
+        super().__init__(auth, credentials, settings, **kwargs)
         self.name = self.auth.get('name', None)
         self.email = self.auth.get('email', None)
         self.token = self.credentials['token']

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -33,7 +33,7 @@ class BoxProvider(provider.BaseProvider):
     TEMP_CHUNK_SIZE = pd_settings.TEMP_CHUNK_SIZE  # 32KiB default
     UPLOAD_COMMIT_RETRIES = pd_settings.UPLOAD_COMMIT_RETRIES
 
-    def __init__(self, auth, credentials, settings):
+    def __init__(self, auth, credentials, settings, **kwargs):
         """Initialize a `BoxProvider` instance
         Credentials::
 
@@ -44,7 +44,7 @@ class BoxProvider(provider.BaseProvider):
             * ``folder``: id of the folder to use as root.  Box account root is always 0.
 
         """
-        super().__init__(auth, credentials, settings)
+        super().__init__(auth, credentials, settings, **kwargs)
         self.token = self.credentials['token']  # type: str
         self.folder = self.settings['folder']  # type: str
 

--- a/waterbutler/providers/cloudfiles/provider.py
+++ b/waterbutler/providers/cloudfiles/provider.py
@@ -36,8 +36,8 @@ class CloudFilesProvider(provider.BaseProvider):
     """
     NAME = 'cloudfiles'
 
-    def __init__(self, auth, credentials, settings):
-        super().__init__(auth, credentials, settings)
+    def __init__(self, auth, credentials, settings, **kwargs):
+        super().__init__(auth, credentials, settings, **kwargs)
         self.token = None
         self.endpoint = None
         self.public_endpoint = None

--- a/waterbutler/providers/dataverse/provider.py
+++ b/waterbutler/providers/dataverse/provider.py
@@ -28,7 +28,7 @@ class DataverseProvider(provider.BaseProvider):
 
     NAME = 'dataverse'
 
-    def __init__(self, auth, credentials, settings):
+    def __init__(self, auth, credentials, settings, **kwargs):
         """
         :param dict auth: Not used
         :param dict credentials: Contains `token`
@@ -38,7 +38,7 @@ class DataverseProvider(provider.BaseProvider):
             - 'dataverse.harvard.edu': Dataverse Production Server **(NO TEST DATA)**
             - Other
         """
-        super().__init__(auth, credentials, settings)
+        super().__init__(auth, credentials, settings, **kwargs)
         self.BASE_URL = 'https://{0}'.format(self.settings['host'])
 
         self.token = self.credentials['token']

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -61,8 +61,8 @@ class DropboxProvider(provider.BaseProvider):
     CONTIGUOUS_UPLOAD_SIZE_LIMIT = pd_settings.CONTIGUOUS_UPLOAD_SIZE_LIMIT
     CHUNK_SIZE = pd_settings.CHUNK_SIZE
 
-    def __init__(self, auth, credentials, settings):
-        super().__init__(auth, credentials, settings)
+    def __init__(self, auth, credentials, settings, **kwargs):
+        super().__init__(auth, credentials, settings, **kwargs)
         self.token = self.credentials['token']
         self.folder = self.settings['folder']
         self.metrics.add('folder_is_root', self.folder == '/')

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -801,7 +801,7 @@ class FigshareProjectProvider(BaseFigshareProvider):
 
 class FigshareArticleProvider(BaseFigshareProvider):
 
-    def __init__(self, auth, credentials, settings, child=False, **kwargs):
+    def __init__(self, auth, credentials, settings, **kwargs):
         super().__init__(auth, credentials, settings, **kwargs)
 
     async def validate_v1_path(self, path, **kwargs):

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -100,8 +100,8 @@ class BaseFigshareProvider(provider.BaseProvider):
     DOWNLOAD_URL = pd_settings.DOWNLOAD_URL
     VALID_CONTAINER_TYPES = pd_settings.VALID_CONTAINER_TYPES
 
-    def __init__(self, auth, credentials, settings):
-        super().__init__(auth, credentials, settings)
+    def __init__(self, auth, credentials, settings, **kwargs):
+        super().__init__(auth, credentials, settings, **kwargs)
         self.token = self.credentials['token']
         self.container_type = self.settings['container_type']
         if self.container_type not in self.VALID_CONTAINER_TYPES:
@@ -801,8 +801,8 @@ class FigshareProjectProvider(BaseFigshareProvider):
 
 class FigshareArticleProvider(BaseFigshareProvider):
 
-    def __init__(self, auth, credentials, settings, child=False):
-        super().__init__(auth, credentials, settings)
+    def __init__(self, auth, credentials, settings, child=False, **kwargs):
+        super().__init__(auth, credentials, settings, **kwargs)
 
     async def validate_v1_path(self, path, **kwargs):
         """Take a string path from the url and attempt to map it to an entity within this article.

--- a/waterbutler/providers/filesystem/provider.py
+++ b/waterbutler/providers/filesystem/provider.py
@@ -24,8 +24,8 @@ class FileSystemProvider(provider.BaseProvider):
     """
     NAME = 'filesystem'
 
-    def __init__(self, auth, credentials, settings):
-        super().__init__(auth, credentials, settings)
+    def __init__(self, auth, credentials, settings, **kwargs):
+        super().__init__(auth, credentials, settings, **kwargs)
         self.folder = self.settings['folder']
         os.makedirs(self.folder, exist_ok=True)
 

--- a/waterbutler/providers/github/exceptions.py
+++ b/waterbutler/providers/github/exceptions.py
@@ -1,3 +1,4 @@
+import time
 from http import HTTPStatus
 
 from waterbutler.core.exceptions import ProviderError
@@ -13,3 +14,12 @@ class GitHubUnsupportedRepoError(ProviderError):
                          'without data loss.  To carry out this operation, please perform it in a '
                          'local git repository, then push to the target repository on GitHub.',
                          code=HTTPStatus.NOT_IMPLEMENTED)
+
+
+class GitHubRateLimitExceededError(ProviderError):
+    def __init__(self, retry: int):
+        retry_date = time.gmtime(retry)
+        iso_date = '{}-{}-{}T{}:{}:{}+00:00'.format(retry_date.tm_year, retry_date.tm_mon,
+                                                    retry_date.tm_mday, retry_date.tm_hour,
+                                                    retry_date.tm_min, retry_date.tm_sec)
+        super().__init__('Rate limit exceeded. New quota will be available after {}.'.format(iso_date), code=HTTPStatus.SERVICE_UNAVAILABLE, is_user_error=True)

--- a/waterbutler/providers/github/exceptions.py
+++ b/waterbutler/providers/github/exceptions.py
@@ -5,11 +5,13 @@ from waterbutler.core.exceptions import ProviderError
 
 
 class GitHubUnsupportedRepoError(ProviderError):
-    def __init__(self, dummy):
+
+    def __init__(self, dummy) -> None:
         """``dummy`` argument is because children of ``WaterButlerError`` must be instantiable with
-        a single integer argument.  See :class:`waterbutler.core.exceptions.WaterButlerError`
-        for details.
+        a single integer argument.  See :class:`waterbutler.core.exceptions.WaterButlerError` for
+        details.
         """
+
         super().__init__('Some folder operations on large GitHub repositories cannot be supported '
                          'without data loss.  To carry out this operation, please perform it in a '
                          'local git repository, then push to the target repository on GitHub.',
@@ -17,9 +19,13 @@ class GitHubUnsupportedRepoError(ProviderError):
 
 
 class GitHubRateLimitExceededError(ProviderError):
-    def __init__(self, retry: int):
+
+    def __init__(self, retry: int) -> None:
+
+        # TODO: should we add more information to this exception, e.g. which OSF user or GH account?
         retry_date = time.gmtime(retry)
-        iso_date = '{}-{}-{}T{}:{}:{}+00:00'.format(retry_date.tm_year, retry_date.tm_mon,
-                                                    retry_date.tm_mday, retry_date.tm_hour,
-                                                    retry_date.tm_min, retry_date.tm_sec)
-        super().__init__('Rate limit exceeded. New quota will be available after {}.'.format(iso_date), code=HTTPStatus.SERVICE_UNAVAILABLE, is_user_error=True)
+        iso_date = time.strftime('%Y-%m-%dT%H:%M:%S+00:00', retry_date)
+
+        super().__init__('WB has exceeded GitHub\'s rate limit for this user.  New quota will be '
+                         'available after the limit gets reset at {}.'.format(iso_date),
+                         code=HTTPStatus.SERVICE_UNAVAILABLE, is_user_error=True)

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -1228,15 +1228,8 @@ class GitHubProvider(provider.BaseProvider):
         # OSF. In addition, this should support at least 3 concurrent large move/copy actions.
         #
         rl_reserved = self.rl_remaining * self.RL_RESERVE_RATIO + self.RL_RESERVE_BASE
+
         now = time.time()
-
-        if self.rl_reset < now:
-            # When GH reset the limit and start a new hour window, WB does not know instantly since
-            # self.rl_reset is only updated when a response is received for a new request. However,
-            # when reaching the limit and the reset time, the request rate is about one request per
-            # second, which is quite long to wait. Add one hour when WB detects the time has passed.
-            self.rl_reset = now + 3600
-
         if rl_reserved > self.rl_remaining:
             # With the default setting, the number of reserved requests is greater or equal to the
             # number of remaining requests when the latter is 125 or less. Set the reference request

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -1,16 +1,20 @@
 import copy
 import json
+import time
+import asyncio
 import hashlib
 import logging
 from typing import Tuple
 
 import furl
+import aiohttp
 
 from waterbutler.core import exceptions, provider, streams
 
 from waterbutler.providers.github.path import GitHubPath
 from waterbutler.providers.github import settings as pd_settings
-from waterbutler.providers.github.exceptions import GitHubUnsupportedRepoError
+from waterbutler.providers.github.exceptions import (GitHubUnsupportedRepoError,
+                                                     GitHubRateLimitExceededError, )
 from waterbutler.providers.github.metadata import (GitHubRevision,
                                                    GitHubFileContentMetadata,
                                                    GitHubFolderContentMetadata,
@@ -56,6 +60,8 @@ class GitHubProvider(provider.BaseProvider):
     NAME = 'github'
     BASE_URL = pd_settings.BASE_URL
     VIEW_URL = pd_settings.VIEW_URL
+    MAX_RATE_LIMIT_TOKENS = 10
+    UPDATE_RATE_LIMIT_INTERVAL = 60
 
     def __init__(self, auth, credentials, settings):
         super().__init__(auth, credentials, settings)
@@ -65,6 +71,91 @@ class GitHubProvider(provider.BaseProvider):
         self.owner = self.settings['owner']
         self.repo = self.settings['repo']
         self.metrics.add('repo', {'repo': self.repo, 'owner': self.owner})
+        # self.rate_limit must be set to an integer
+        # If set to 0, will be recalculated without waiting for UPDATE_RATE_LIMIT_INTERVAL
+        self.rate_limit = 0
+        # Start with a full bag of tokens and set tokens_updated to current time
+        self.rate_limit_tokens = self.MAX_RATE_LIMIT_TOKENS
+        self.rate_limit_tokens_updated = time.time()
+        # Will be set during first call to GitHub
+        self.rate_limit_remaining = 0
+        # Will be set during first call to GitHub
+        self.rate_limit_reset = 0
+        # Will be set during initial rate limit update
+        self.rate_limit_updated = 0
+
+    # TODO: No testing has been done to find optimal sleep time.
+    # In practice, rate limit usually is set between 1 and 2 calls per second.
+    # Therefore it seems like 1 second sleep is optimal for fastest throughput.
+    # However, there may be other considerations.
+    async def wait_for_token(self) -> None:
+        while self.rate_limit_tokens <= 1:
+            self.add_new_rate_limit_tokens()
+            await asyncio.sleep(1)
+        self.rate_limit_tokens -= 1
+
+    def add_new_rate_limit_tokens(self) -> None:
+        now = time.time()
+        if self.rate_limit_updated == 0 or \
+                now - self.rate_limit_updated > self.UPDATE_RATE_LIMIT_INTERVAL:
+            self.update_rate_limit()
+        new_tokens = (now - self.rate_limit_tokens_updated) * self.rate_limit
+        if new_tokens > 1:
+            self.rate_limit_tokens = min(self.rate_limit_tokens + new_tokens,
+                                         self.MAX_RATE_LIMIT_TOKENS)
+            self.rate_limit_tokens_updated = now
+
+    # TODO: No testing has been done to find optimal rate_limit_reserve.
+    # 10% of remaining plus 10 results, in practice, in a rate limit that usually starts
+    # at just over 1 call per second and gradually increases to around 2.
+    # At the very end of the reset period rate limit can get a little larger than 2.
+    # In testing this reserve setting prevents running out of tokens even when additional
+    # calls are being made through osf.io .
+    # In the very unlikely event that the limit remaining falls lower then the reserve limit,
+    # The rate limit is set to 0.01 or 1 call every 100 seconds.
+    def update_rate_limit(self) -> None:
+        now = time.time()
+        rate_limit_reserve = self.rate_limit_remaining // 10 + 10
+        seconds_till_reset = self.rate_limit_reset - now
+        if rate_limit_reserve > self.rate_limit_remaining:
+            self.rate_limit = 0.01
+        else:
+            self.rate_limit = (self.rate_limit_remaining - rate_limit_reserve) / seconds_till_reset
+        self.rate_limit_updated = now
+
+    async def make_request(self, method: str, url: str, *args, **kwargs) -> aiohttp.client.ClientResponse:
+        if 'expects' in kwargs.keys():
+            expects = list(kwargs['expects'])
+            expects.append(403)
+            kwargs['expects'] = tuple(expects)
+
+        if not getattr(self, 'task_id', None):
+            response = await super().make_request(method, url, **kwargs)
+            if response.status == 403:
+                await self.check_rate_limit_exceeded(response, **kwargs)
+            return response
+
+        await self.wait_for_token()
+
+        response = await super().make_request(method, url, *args, **kwargs)
+
+        self.rate_limit_remaining = int(response.headers['X-RateLimit-Remaining'])
+        self.rate_limit_reset = int(response.headers['X-RateLimit-Reset'])
+
+        if response.status == 403:
+            await self.check_rate_limit_exceeded(response, **kwargs)
+
+        return response
+
+    async def check_rate_limit_exceeded(self, response: aiohttp.client.ClientResponse,
+                                        **kwargs) -> None:
+        response_json = await response.json()
+        if 'API rate limit exceeded' in response_json['message']:
+            rate_limit_reset = int(response.headers['X-RateLimit-Reset'])
+            raise GitHubRateLimitExceededError(rate_limit_reset)
+        else:
+            throws = kwargs.get('throws', exceptions.UnhandledProviderError)
+            raise (await exceptions.exception_from_response(response, error=throws, **kwargs))
 
     async def validate_v1_path(self, path, **kwargs):
         """Validate the path part of the request url, asserting that the path exists, and

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -203,7 +203,8 @@ class GitHubProvider(provider.BaseProvider):
         """Build a path from a parent path and a metadata object.  Will correctly set the _id
         Used for building zip archives."""
         file_sha = metadata.extra.get('fileSha', None)
-        return parent_path.child(metadata.name, _id=(metadata.ref, file_sha), folder=metadata.is_folder, )
+        return parent_path.child(metadata.name, _id=(metadata.ref, file_sha),
+                                 folder=metadata.is_folder, )
 
     def can_duplicate_names(self):
         return False
@@ -314,7 +315,8 @@ class GitHubProvider(provider.BaseProvider):
             'tree': tree['sha'],
             'parents': [latest_sha],
             'committer': self.committer,
-            'message': message or (pd_settings.UPDATE_FILE_MESSAGE if exists else pd_settings.UPLOAD_FILE_MESSAGE),
+            'message': message or (pd_settings.UPDATE_FILE_MESSAGE
+                                   if exists else pd_settings.UPLOAD_FILE_MESSAGE),
         })
 
         # Doesn't return anything useful
@@ -405,14 +407,18 @@ class GitHubProvider(provider.BaseProvider):
         data = await resp.json()
 
         if resp.status in (422, 409):
-            if resp.status == 409 or data.get('message') == 'Invalid request.\n\n"sha" wasn\'t supplied.':
+            if (
+                    resp.status == 409 or
+                    data.get('message') == 'Invalid request.\n\n"sha" wasn\'t supplied.'
+            ):
                 raise exceptions.FolderNamingConflict(path.name)
             raise exceptions.CreateFolderError(data, code=resp.status)
 
         data['content']['name'] = path.name
         data['content']['path'] = data['content']['path'].replace('.gitkeep', '')
 
-        return GitHubFolderContentMetadata(data['content'], commit=data['commit'], ref=path.branch_ref)
+        return GitHubFolderContentMetadata(data['content'], commit=data['commit'],
+                                           ref=path.branch_ref)
 
     async def _delete_file(self, path, message=None, **kwargs):
         if path.file_sha:
@@ -836,8 +842,8 @@ class GitHubProvider(provider.BaseProvider):
             if dest_path.is_dir:
                 src_tree['tree'] = self._remove_path_from_tree(src_tree['tree'], dest_path)
 
-            # if this is a copy, duplicate and append our source blobs. The originals will be updated
-            # with the new destination path.
+            # if this is a copy, duplicate and append our source blobs. The originals will be
+            # updated with the new destination path.
             if is_copy:
                 src_tree['tree'].extend(copy.deepcopy(blobs))
 
@@ -1017,7 +1023,7 @@ class GitHubProvider(provider.BaseProvider):
         line.  Returns the new commit.
 
         :param list old_tree: A list of blobs representing the new file tree.
-        :param dict old_head: The commit object will be the parent of the new commit. Must have 'sha' key.
+        :param dict old_head: The commit that's the parent of the new commit. Must have 'sha' key.
         :param str commit_msg: The commit message for the new commit.
         :param str branch_ref: The branch that will be advanced to the new commit.
         :returns dict new_head: The commit object returned by GitHub.

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -301,10 +301,10 @@ class GitHubProvider(provider.BaseProvider):
         else:
             return (await self._metadata_file(path, **kwargs))
 
-    async def revisions(self, path, sha=None, **kwargs):
+    async def revisions(self, path, **kwargs):
         resp = await self.make_request(
             'GET',
-            self.build_repo_url('commits', path=path.path, sha=sha or path.file_sha),
+            self.build_repo_url('commits', path=path.path, sha=path.branch_ref),
             expects=(200, ),
             throws=exceptions.RevisionsError
         )

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -1030,9 +1030,9 @@ class GitHubProvider(provider.BaseProvider):
             if possible_values[param] == '':
                 possible_values[param] = None
 
-        # look for commit SHA likes
+        # look for commit SHA likes ('branch' is least likely to be a sha)
         inferred_ref, ref_from = None, None
-        for param in possible_params:
+        for param in possible_params + ['branch']:
             v = possible_values[param]
             if v is not None and self._looks_like_sha(v):
                 inferred_ref = v
@@ -1042,7 +1042,7 @@ class GitHubProvider(provider.BaseProvider):
         if inferred_ref is not None:
             return inferred_ref, 'commit_sha', ref_from  # found a SHA!
 
-        # look for branch names
+        # look for branch names ('branch' is most likely to be a branchname)
         for param in ['branch'] + possible_params:
             v = possible_values[param]
             if v is not None:

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -1075,7 +1075,10 @@ class GitHubProvider(provider.BaseProvider):
         return inferred_ref, 'branch_name', ref_from
 
     def _looks_like_sha(self, ref):
-        """Returns `True` if ``ref`` could be a valid SHA (i.e. is a valid hex number).
+        """Returns `True` if ``ref`` could be a valid SHA (i.e. is a valid hex number).  If ``True``
+        also checks to make sure ``ref`` is a valid number of characters, as GH doesn't like
+        abbreviated refs.  Currently only check for 40 characters (length of a sha1-name), but a
+        future git release will add support for 64-character sha256-names.
 
         :param str ref: the string to test
         :rtype: `bool`
@@ -1086,4 +1089,5 @@ class GitHubProvider(provider.BaseProvider):
         except (TypeError, ValueError):
             return False
 
-        return True
+        # 'in' instead of '==' b/c git shas will be changing in future git release.
+        return len(ref) in pd_settings.GITHUB_SHA_LENGTHS

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -1021,18 +1021,20 @@ class GitHubProvider(provider.BaseProvider):
         query during validation.  The latter is used for analytics.
         """
 
-        possible_params = ['ref', 'version', 'sha', 'revision']
+        all_possible_params = ['ref', 'version', 'sha', 'revision', 'branch']
 
         # empty string values should be made None
         possible_values = {}
-        for param in possible_params + ['branch']:
+        for param in all_possible_params:
             possible_values[param] = kwargs.get(param, '')
             if possible_values[param] == '':
                 possible_values[param] = None
 
-        # look for commit SHA likes ('branch' is least likely to be a sha)
         inferred_ref, ref_from = None, None
-        for param in possible_params + ['branch']:
+
+        # look for commit SHA likes ('branch' is least likely to be a sha)
+        sha_priority_order = ['ref', 'version', 'sha', 'revision', 'branch']
+        for param in sha_priority_order:
             v = possible_values[param]
             if v is not None and self._looks_like_sha(v):
                 inferred_ref = v
@@ -1043,7 +1045,8 @@ class GitHubProvider(provider.BaseProvider):
             return inferred_ref, 'commit_sha', ref_from  # found a SHA!
 
         # look for branch names ('branch' is most likely to be a branchname)
-        for param in ['branch'] + possible_params:
+        branch_priority_order = ['branch', 'ref', 'version', 'sha', 'revision']
+        for param in branch_priority_order:
             v = possible_values[param]
             if v is not None:
                 inferred_ref = v

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -64,7 +64,6 @@ class GitHubProvider(provider.BaseProvider):
     # Load settings for GitHub rate limiting
     RL_TOKEN_ADD_DELAY = pd_settings.RL_TOKEN_ADD_DELAY
     RL_MAX_AVAILABLE_TOKENS = pd_settings.RL_MAX_AVAILABLE_TOKENS
-    RL_REQ_RATE_UPDATE_INTERVAL = pd_settings.RL_REQ_RATE_UPDATE_INTERVAL
     RL_RESERVE_RATIO = pd_settings.RL_RESERVE_RATIO
     RL_RESERVE_BASE = pd_settings.RL_RESERVE_BASE
     RL_MIN_REQ_RATE = pd_settings.RL_MIN_REQ_RATE
@@ -82,9 +81,6 @@ class GitHubProvider(provider.BaseProvider):
         # `.rl_req_rate` denotes the number of requests allowed per second. It will be updated if
         # it is the initial run (value is 0) or if `.RL_REQ_RATE_UPDATE_INTERVAL` has elapsed.
         self.rl_req_rate = 0
-
-        # `.rl_req_rate_updated` denotes the last time `.rl_req_rate` was updated.
-        self.rl_req_rate_updated = 0
 
         # `.rl_available_tokens` determines if a request should wait or proceed. Each provider
         # instance starts with a full bag (`.RL_MAX_AVAILABLE_TOKENS`) of tokens.
@@ -1196,12 +1192,7 @@ class GitHubProvider(provider.BaseProvider):
         at `self.RL_MAX_AVAILABLE_TOKENS`.
         """
 
-        now = time.time()
-
-        # Update `.rl_req_rate` if initial run or if `.RL_REQ_RATE_UPDATE_INTERVAL` has passed.
-        time_since_last_rate = now - self.rl_req_rate_updated
-        if self.rl_req_rate_updated == 0 or time_since_last_rate > self.RL_REQ_RATE_UPDATE_INTERVAL:
-            self._rl_update_req_rate()
+        self._rl_update_req_rate()
 
         # Add a number of tokens equal to: seconds since we last added tokens (which is
         # approximately RL_TOKEN_ADD_DELAY) times the rate at which we should add tokens
@@ -1253,5 +1244,3 @@ class GitHubProvider(provider.BaseProvider):
             # requests (i.e. another copy/move) are being made at the same time, this reference
             # request rate keeps increasing slightly.
             self.rl_req_rate = (self.rl_remaining - rl_reserved) / (self.rl_reset - now)
-
-        self.rl_req_rate_updated = now

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -102,9 +102,9 @@ class GitHubProvider(provider.BaseProvider):
     RL_RESERVE_BASE = pd_settings.RL_RESERVE_BASE
     RL_MIN_REQ_RATE = pd_settings.RL_MIN_REQ_RATE
 
-    def __init__(self, auth, credentials, settings):
+    def __init__(self, auth, credentials, settings, **kwargs):
 
-        super().__init__(auth, credentials, settings)
+        super().__init__(auth, credentials, settings, **kwargs)
         self.name = self.auth.get('name', None)
         self.email = self.auth.get('email', None)
         self.token = self.credentials['token']
@@ -156,7 +156,7 @@ class GitHubProvider(provider.BaseProvider):
             kwargs.update({'expects': expects + (int(HTTPStatus.FORBIDDEN), )})
 
         # If not a celery task, default to regular behavior (but inform about rate limits)
-        if not getattr(self, 'task_id', None):
+        if not self.is_celery_task:
             logger.debug('P({}):{}:make_request: NOT a celery task, bypassing '
                          'limits'.format(self._my_id, self._request_count))
             resp = await super().make_request(method, url, **kwargs)

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -1311,7 +1311,8 @@ class GitHubProvider(provider.BaseProvider):
             # remaining requests and the time between now and next limit reset. If no other major
             # requests (i.e. another copy/move) are being made at the same time, this reference
             # request rate keeps increasing slightly.
-            rl_req_rate = (self.rl_remaining - self.rl_reserved) / (self.rl_reset - time.time())
+            seconds_until_reset = max((self.rl_reset - time.time()), 1)
+            rl_req_rate = (self.rl_remaining - self.rl_reserved) / seconds_until_reset
 
         logger.debug('P({}):{}:adding_tokens: current_tokens:({}) '
                      'request_rate:({})'.format(self._my_id, self._request_count,

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -1246,6 +1246,13 @@ class GitHubProvider(provider.BaseProvider):
         rl_reserved = self.rl_remaining * self.RL_RESERVE_RATIO + self.RL_RESERVE_BASE
         now = time.time()
 
+        if self.rl_reset < now:
+            # When GH reset the limit and start a new hour window, WB does not know instantly since
+            # self.rl_reset is only updated when a response is received for a new request. However,
+            # when reaching the limit and the reset time, the request rate is about one request per
+            # second, which is quite long to wait. Add one hour when WB detects the time has passed.
+            self.rl_reset = now + 3600
+
         if rl_reserved > self.rl_remaining:
             # With the default setting, the number of reserved requests is greater or equal to the
             # number of remaining requests when the latter is 125 or less. Set the reference request

--- a/waterbutler/providers/github/settings.py
+++ b/waterbutler/providers/github/settings.py
@@ -13,7 +13,6 @@ UPDATE_FILE_MESSAGE = config.get('UPDATE_FILE_MESSAGE', 'File updated on behalf 
 UPLOAD_FILE_MESSAGE = config.get('UPLOAD_FILE_MESSAGE', 'File uploaded on behalf of WaterButler')
 DELETE_FOLDER_MESSAGE = config.get('DELETE_FOLDER_MESSAGE', 'Folder deleted on behalf of WaterButler')
 
-
 # At some point in the near(?) future git will be changing its internal hash function from SHA-1
 # to SHA-256.  sha1-names are 40 hexdigits long and sha256-names are 64 hexdigits long.  At that
 # point, it seems probable that GitHub will update its API to accept both sha types. When that
@@ -26,3 +25,12 @@ DELETE_FOLDER_MESSAGE = config.get('DELETE_FOLDER_MESSAGE', 'Folder deleted on b
 #   GITHUB_PROVIDER_GITHUB_SHA_LENGTHS=40 64
 #
 GITHUB_SHA_LENGTHS = [int(x) for x in config.get('GITHUB_SHA_LENGTHS', '40').split(' ')]
+
+# The time in seconds to wait before making another attempt to add more tokens
+RL_TOKEN_ADD_DELAY = int(config.get('RL_TOKEN_ADD_DELAY', 1))
+
+# The maximum number of available tokens allowed
+RL_MAX_AVAILABLE_TOKENS = int(config.get('RL_MAX_AVAILABLE_TOKENS', 10))
+
+# The minimum interval in seconds between each request rate update.
+RL_REQ_RATE_UPDATE_INTERVAL = int(config.get('RL_REQ_RATE_UPDATE_INTERVAL', 60))

--- a/waterbutler/providers/github/settings.py
+++ b/waterbutler/providers/github/settings.py
@@ -13,6 +13,7 @@ UPDATE_FILE_MESSAGE = config.get('UPDATE_FILE_MESSAGE', 'File updated on behalf 
 UPLOAD_FILE_MESSAGE = config.get('UPLOAD_FILE_MESSAGE', 'File uploaded on behalf of WaterButler')
 DELETE_FOLDER_MESSAGE = config.get('DELETE_FOLDER_MESSAGE', 'Folder deleted on behalf of WaterButler')
 
+
 # At some point in the near(?) future git will be changing its internal hash function from SHA-1
 # to SHA-256.  sha1-names are 40 hexdigits long and sha256-names are 64 hexdigits long.  At that
 # point, it seems probable that GitHub will update its API to accept both sha types. When that
@@ -26,11 +27,18 @@ DELETE_FOLDER_MESSAGE = config.get('DELETE_FOLDER_MESSAGE', 'Folder deleted on b
 #
 GITHUB_SHA_LENGTHS = [int(x) for x in config.get('GITHUB_SHA_LENGTHS', '40').split(' ')]
 
+
+# Config For GitHub Rate Limiting
+#
 # The time in seconds to wait before making another attempt to add more tokens
 RL_TOKEN_ADD_DELAY = int(config.get('RL_TOKEN_ADD_DELAY', 1))
-
-# The maximum number of available tokens allowed
-RL_MAX_AVAILABLE_TOKENS = int(config.get('RL_MAX_AVAILABLE_TOKENS', 10))
-
+# The maximum number of available tokens (requests) allowed
+RL_MAX_AVAILABLE_TOKENS = float(config.get('RL_MAX_AVAILABLE_TOKENS', 10.0))
 # The minimum interval in seconds between each request rate update.
-RL_REQ_RATE_UPDATE_INTERVAL = int(config.get('RL_REQ_RATE_UPDATE_INTERVAL', 60))
+RL_REQ_RATE_UPDATE_INTERVAL = int(config.get('RL_REQ_RATE_UPDATE_INTERVAL', 10))
+# The percentage of remaining requests to be reserved.
+RL_RESERVE_RATIO = float(config.get('RL_RESERVE_RATIO', 0.2))
+# The base number of requests to be reserved.
+RL_RESERVE_BASE = int(config.get('RL_RESERVE_BASE', 100))
+# The minimum request rate allowed.  Applies when the provider is near the reserve base.
+RL_MIN_REQ_RATE = float(config.get('RL_MIN_REQ_RATE', 0.01))

--- a/waterbutler/providers/github/settings.py
+++ b/waterbutler/providers/github/settings.py
@@ -12,3 +12,17 @@ DELETE_FILE_MESSAGE = config.get('DELETE_FILE_MESSAGE', 'File deleted on behalf 
 UPDATE_FILE_MESSAGE = config.get('UPDATE_FILE_MESSAGE', 'File updated on behalf of WaterButler')
 UPLOAD_FILE_MESSAGE = config.get('UPLOAD_FILE_MESSAGE', 'File uploaded on behalf of WaterButler')
 DELETE_FOLDER_MESSAGE = config.get('DELETE_FOLDER_MESSAGE', 'Folder deleted on behalf of WaterButler')
+
+
+# At some point in the near(?) future git will be changing its internal hash function from SHA-1
+# to SHA-256.  sha1-names are 40 hexdigits long and sha256-names are 64 hexdigits long.  At that
+# point, it seems probable that GitHub will update its API to accept both sha types. When that
+# happens, the following config var will need to be updated to include both sizes.
+#
+# Example for passing multiple length values via an envvar on the command line:
+#   $ GITHUB_PROVIDER_GITHUB_SHA_LENGTHS="40 64" invoke server
+#
+# Example setting in a .docker-compose.env (no quotes):
+#   GITHUB_PROVIDER_GITHUB_SHA_LENGTHS=40 64
+#
+GITHUB_SHA_LENGTHS = [int(x) for x in config.get('GITHUB_SHA_LENGTHS', '40').split(' ')]

--- a/waterbutler/providers/github/settings.py
+++ b/waterbutler/providers/github/settings.py
@@ -34,8 +34,6 @@ GITHUB_SHA_LENGTHS = [int(x) for x in config.get('GITHUB_SHA_LENGTHS', '40').spl
 RL_TOKEN_ADD_DELAY = int(config.get('RL_TOKEN_ADD_DELAY', 1))
 # The maximum number of available tokens (requests) allowed
 RL_MAX_AVAILABLE_TOKENS = float(config.get('RL_MAX_AVAILABLE_TOKENS', 10.0))
-# The minimum interval in seconds between each request rate update.
-RL_REQ_RATE_UPDATE_INTERVAL = int(config.get('RL_REQ_RATE_UPDATE_INTERVAL', 10))
 # The percentage of remaining requests to be reserved.
 RL_RESERVE_RATIO = float(config.get('RL_RESERVE_RATIO', 0.2))
 # The base number of requests to be reserved.

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -54,8 +54,8 @@ class GitLabProvider(provider.BaseProvider):
 
     MAX_PAGE_SIZE = 100
 
-    def __init__(self, auth, credentials, settings):
-        super().__init__(auth, credentials, settings)
+    def __init__(self, auth, credentials, settings, **kwargs):
+        super().__init__(auth, credentials, settings, **kwargs)
         self.name = self.auth.get('name', None)
         self.email = self.auth.get('email', None)
         self.token = self.credentials['token']

--- a/waterbutler/providers/googlecloud/provider.py
+++ b/waterbutler/providers/googlecloud/provider.py
@@ -51,7 +51,7 @@ class GoogleCloudProvider(BaseProvider):
     # EXPIRATION for Signed Request/URL for XML API
     SIGNATURE_EXPIRATION = pd_settings.SIGNATURE_EXPIRATION
 
-    def __init__(self, auth: dict, credentials: dict, settings: dict) -> None:
+    def __init__(self, auth: dict, credentials: dict, settings: dict, **kwargs) -> None:
         """Initialize a provider instance with the given parameters.
 
         :param dict auth: the auth dictionary
@@ -76,7 +76,7 @@ class GoogleCloudProvider(BaseProvider):
         #
         #     WATERBUTLER_RESOURCE = 'bucket'
 
-        super().__init__(auth, credentials, settings)
+        super().__init__(auth, credentials, settings, **kwargs)
 
         self.bucket = settings.get('bucket')
         if not self.bucket:

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -78,8 +78,8 @@ class GoogleDriveProvider(provider.BaseProvider):
     # 'reader' and 'commenter' are not authorized to access the revisions list
     ROLES_ALLOWING_REVISIONS = ['owner', 'organizer', 'writer']
 
-    def __init__(self, auth: dict, credentials: dict, settings: dict) -> None:
-        super().__init__(auth, credentials, settings)
+    def __init__(self, auth: dict, credentials: dict, settings: dict, **kwargs) -> None:
+        super().__init__(auth, credentials, settings, **kwargs)
         self.token = self.credentials['token']
         self.folder = self.settings['folder']
 

--- a/waterbutler/providers/onedrive/provider.py
+++ b/waterbutler/providers/onedrive/provider.py
@@ -63,9 +63,9 @@ class OneDriveProvider(provider.BaseProvider):
 
     # ========== __init__ ==========
 
-    def __init__(self, auth, credentials, settings):
+    def __init__(self, auth, credentials, settings, **kwargs):
         logger.debug('__init__ auth::{} settings::{}'.format(auth, settings))
-        super().__init__(auth, credentials, settings)
+        super().__init__(auth, credentials, settings, **kwargs)
         self.token = self.credentials['token']
         self.folder = self.settings['folder']
 

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -39,8 +39,8 @@ class OSFStorageProvider(provider.BaseProvider):
 
     NAME = 'osfstorage'
 
-    def __init__(self, auth, credentials, settings):
-        super().__init__(auth, credentials, settings)
+    def __init__(self, auth, credentials, settings, **kwargs):
+        super().__init__(auth, credentials, settings, **kwargs)
         self.nid = settings['nid']
         self.root_id = settings['rootId']
         self.BASE_URL = settings['baseUrl']
@@ -128,6 +128,7 @@ class OSFStorageProvider(provider.BaseProvider):
                 self.auth,
                 self.credentials['storage'],
                 self.settings['storage'],
+                is_celery_task=self.is_celery_task,
             )
         return self._inner_provider
 

--- a/waterbutler/providers/owncloud/provider.py
+++ b/waterbutler/providers/owncloud/provider.py
@@ -37,8 +37,8 @@ class OwnCloudProvider(provider.BaseProvider):
     """
     NAME = 'owncloud'
 
-    def __init__(self, auth, credentials, settings):
-        super().__init__(auth, credentials, settings)
+    def __init__(self, auth, credentials, settings, **kwargs):
+        super().__init__(auth, credentials, settings, **kwargs)
 
         self.folder = settings['folder']
         if not self.folder.endswith('/'):

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -46,7 +46,7 @@ class S3Provider(provider.BaseProvider):
     CHUNK_SIZE = settings.CHUNK_SIZE
     CONTIGUOUS_UPLOAD_SIZE_LIMIT = settings.CONTIGUOUS_UPLOAD_SIZE_LIMIT
 
-    def __init__(self, auth, credentials, settings):
+    def __init__(self, auth, credentials, settings, **kwargs):
         """
         .. note::
 
@@ -57,7 +57,7 @@ class S3Provider(provider.BaseProvider):
         :param dict credentials: Dict containing `access_key` and `secret_key`
         :param dict settings: Dict containing `bucket`
         """
-        super().__init__(auth, credentials, settings)
+        super().__init__(auth, credentials, settings, **kwargs)
 
         self.connection = S3Connection(credentials['access_key'],
                 credentials['secret_key'], calling_format=OrdinaryCallingFormat())

--- a/waterbutler/tasks/copy.py
+++ b/waterbutler/tasks/copy.py
@@ -18,6 +18,10 @@ async def copy(src_bundle, dest_bundle, request={}, start_time=None, **kwargs):
     src_path, src_provider = src_bundle.pop('path'), utils.make_provider(**src_bundle.pop('provider'))
     dest_path, dest_provider = dest_bundle.pop('path'), utils.make_provider(**dest_bundle.pop('provider'))
 
+    # Save celery task ID. Used to identify provider object running in celery
+    src_provider.task_id = copy.request.id
+    dest_path.task_id = copy.request.id
+
     logger.info('Starting copying {!r}, {!r} to {!r}, {!r}'
                 .format(src_path, src_provider, dest_path, dest_provider))
 

--- a/waterbutler/tasks/copy.py
+++ b/waterbutler/tasks/copy.py
@@ -1,26 +1,29 @@
 import time
 import logging
 
-from waterbutler.core import utils
 from waterbutler.tasks import core
-from waterbutler.core import remote_logging
 from waterbutler.core.path import WaterButlerPath
+from waterbutler.core import utils, remote_logging
 from waterbutler.core.log_payload import LogPayload
-
 
 logger = logging.getLogger(__name__)
 
 
 @core.celery_task
-async def copy(src_bundle, dest_bundle, request={}, start_time=None, **kwargs):
+async def copy(src_bundle, dest_bundle, request=None, start_time=None, **kwargs):
+
+    request = request or {}
     start_time = start_time or time.time()
 
-    src_path, src_provider = src_bundle.pop('path'), utils.make_provider(**src_bundle.pop('provider'))
-    dest_path, dest_provider = dest_bundle.pop('path'), utils.make_provider(**dest_bundle.pop('provider'))
+    src_path = src_bundle.pop('path')
+    src_provider = utils.make_provider(**src_bundle.pop('provider'))
+    dest_path = dest_bundle.pop('path')
+    dest_provider = utils.make_provider(**dest_bundle.pop('provider'))
 
+    # TODO: should we add `task_id` explicitly as a property for core provider?
     # Save celery task ID. Used to identify provider object running in celery
     src_provider.task_id = copy.request.id
-    dest_path.task_id = copy.request.id
+    dest_provider.task_id = copy.request.id
 
     logger.info('Starting copying {!r}, {!r} to {!r}, {!r}'
                 .format(src_path, src_provider, dest_path, dest_provider))

--- a/waterbutler/tasks/copy.py
+++ b/waterbutler/tasks/copy.py
@@ -16,14 +16,10 @@ async def copy(src_bundle, dest_bundle, request=None, start_time=None, **kwargs)
     start_time = start_time or time.time()
 
     src_path = src_bundle.pop('path')
-    src_provider = utils.make_provider(**src_bundle.pop('provider'))
-    dest_path = dest_bundle.pop('path')
-    dest_provider = utils.make_provider(**dest_bundle.pop('provider'))
+    src_provider = utils.make_provider(**src_bundle.pop('provider'), is_celery_task=True)
 
-    # TODO: should we add `task_id` explicitly as a property for core provider?
-    # Save celery task ID. Used to identify provider object running in celery
-    src_provider.task_id = copy.request.id
-    dest_provider.task_id = copy.request.id
+    dest_path = dest_bundle.pop('path')
+    dest_provider = utils.make_provider(**dest_bundle.pop('provider'), is_celery_task=True)
 
     logger.info('Starting copying {!r}, {!r} to {!r}, {!r}'
                 .format(src_path, src_provider, dest_path, dest_provider))

--- a/waterbutler/tasks/move.py
+++ b/waterbutler/tasks/move.py
@@ -1,32 +1,34 @@
 import time
 import logging
 
-from waterbutler.core import utils
 from waterbutler.tasks import core
-from waterbutler.core import remote_logging
 from waterbutler.core.path import WaterButlerPath
+from waterbutler.core import utils, remote_logging
 from waterbutler.core.log_payload import LogPayload
-
 
 logger = logging.getLogger(__name__)
 
 
 @core.celery_task
-async def move(src_bundle, dest_bundle, request: dict=None, start_time=None, **kwargs):
+async def move(src_bundle, dest_bundle, request=None, start_time=None, **kwargs):
+
     request = request or {}
     start_time = start_time or time.time()
 
-    src_path, src_provider = src_bundle.pop('path'), utils.make_provider(**src_bundle.pop('provider'))
-    dest_path, dest_provider = dest_bundle.pop('path'), utils.make_provider(**dest_bundle.pop('provider'))
+    src_path = src_bundle.pop('path')
+    src_provider = utils.make_provider(**src_bundle.pop('provider'))
+    dest_path = dest_bundle.pop('path')
+    dest_provider = utils.make_provider(**dest_bundle.pop('provider'))
 
+    # TODO: should we add `task_id` explicitly as a property for core provider?
     # Save celery task ID. Used to identify provider object running in celery
     src_provider.task_id = move.request.id
-    dest_path.task_id = move.request.id
+    dest_provider.task_id = move.request.id
 
     logger.info('Starting moving {!r}, {!r} to {!r}, {!r}'
                 .format(src_path, src_provider, dest_path, dest_provider))
 
-    metadata, errors = None, []  # type: ignore
+    metadata, errors = None, []
     try:
         metadata, created = await src_provider.move(dest_provider, src_path, dest_path, **kwargs)
     except Exception as e:

--- a/waterbutler/tasks/move.py
+++ b/waterbutler/tasks/move.py
@@ -16,14 +16,10 @@ async def move(src_bundle, dest_bundle, request=None, start_time=None, **kwargs)
     start_time = start_time or time.time()
 
     src_path = src_bundle.pop('path')
-    src_provider = utils.make_provider(**src_bundle.pop('provider'))
-    dest_path = dest_bundle.pop('path')
-    dest_provider = utils.make_provider(**dest_bundle.pop('provider'))
+    src_provider = utils.make_provider(**src_bundle.pop('provider'), is_celery_task=True)
 
-    # TODO: should we add `task_id` explicitly as a property for core provider?
-    # Save celery task ID. Used to identify provider object running in celery
-    src_provider.task_id = move.request.id
-    dest_provider.task_id = move.request.id
+    dest_path = dest_bundle.pop('path')
+    dest_provider = utils.make_provider(**dest_bundle.pop('provider'), is_celery_task=True)
 
     logger.info('Starting moving {!r}, {!r} to {!r}, {!r}'
                 .format(src_path, src_provider, dest_path, dest_provider))

--- a/waterbutler/tasks/move.py
+++ b/waterbutler/tasks/move.py
@@ -19,6 +19,10 @@ async def move(src_bundle, dest_bundle, request: dict=None, start_time=None, **k
     src_path, src_provider = src_bundle.pop('path'), utils.make_provider(**src_bundle.pop('provider'))
     dest_path, dest_provider = dest_bundle.pop('path'), utils.make_provider(**dest_bundle.pop('provider'))
 
+    # Save celery task ID. Used to identify provider object running in celery
+    src_provider.task_id = move.request.id
+    dest_path.task_id = move.request.id
+
     logger.info('Starting moving {!r}, {!r} to {!r}, {!r}'
                 .format(src_path, src_provider, dest_path, dest_provider))
 


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-302

## Purpose

This PR replaces https://github.com/CenterForOpenScience/waterbutler/pull/292

h/t to @TomBaxter for the core part implement which is fully functional, I just polished the code

GitHub API has a [rate-limiting](https://developer.github.com/v3/#rate-limiting) feature that only allow 5000 requests per hour. The limit is not a **rate** but a **count**.  To handle this limitation, this PR enables WB to rate-limiting GitHub move/copy requests by allowing 1-2 requests per second.

### GitHub VS WB

* GitHub rate-limiting is enforced per user. For example, API requests made to GitHub by non-OSF products users have authorized **count** against the quota.

```
For API requests using Basic Authentication or OAuth, you can make up to 5000 requests
per hour. Authenticated requests are associated with the authenticated user, regardless
of whether Basic Authentication or an OAuth token was used. This means that all OAuth
applications authorized by a user share the same quota of 5000 requests per hour when
they authenticate with different tokens owned by the same user.
```

* WB rate-limiting is enforced per provider instance. However, there are a few features that actively preventing it from hitting the rate-limit cap when multiple instances are present and when users are making a reasonable amount of requests using GitHub API outside OSF and WB.
  * Reserve a portion (default is 10%) of the pool for requests that does not go through WB's rate-limiting and for multiple instances scenario mentioned below.
  * Actively (default is 1 minute) updates the request rate based the response headers GitHub returns.
  * Slow down the request rate to 1 per 100 seconds if reaching the limit.

### What Will Work

If user tries to copy two or more repos of more than 2000 files at the same time, WB rate-limit can still work because none of them can make all the requests at the same time. The request rate limit gets refreshed every minute to reflect the most updated info from GitHub.

### What Will Not Work

As mentioned the request rate limit gets updated every minute. Within in that limit each instance makes request on their own pace assuming they are the only one using the quota. However, if users have other non-OSF apps that suddenly used up the quota within that minute, WB will fail.

## Changes

This is the original commit message (slightly modified) by Tom.

This PR only rate limits the GitHub provider's `.make_requests()` that run in celery tasks. Currently, the only tasks are "move" and "copy". The distinction is made by adding a `task_id` to the providers after they are instantiated in the task definition.

This PR uses the rate limit information returned in **all** GitHub response headers to limit the number of `.make_requests()` calls in such a way that the GitHub rate limit is never reached. In practice this usually results in a rate limit between 1-2 calls a second.

As a bonus, this PR adds a `GitHubRateLimitExceeded` exception, that will be checked for with each `.make_request()`. This exception ~~should never~~ is not expected to be raised during a move/copy celery task unless users suddenly use up the quota outside OSF or WB. This also helps non-celery requests as well.

## Side effects

GitHub move/copy request are rate-limited to 1-2 per second, no matter how many/few files are there. 

## QA Notes

Here is a dedicated [repo](https://github.com/cslzchen/OSF-Addon-Folder/tree/develop/feature-tasks/rate-limit) I created for test. Pease fork it for testing purpose. It has folders containing a variety number of files.

* Stage one, use the first 4 folders (files-[00128|00256|00512|01024]) to test and feel the side effect of speed decrease because of the rate limit.
* Stage two, [files-16384](https://github.com/cslzchen/OSF-Addon-Folder/tree/develop/feature-tasks/rate-limit/files-16384) contains 4 folders, each with 4096 files. Any of them should fail on `Prod` but  should succeed on `Staging`. Locally, it takes 2.5 hours to finish each one.
* Final stage, try copy 2 or more folders at the same time, each with a `different` OSF user. Please expect around 6 - 12 hours and it needs a stable `Staging`. You may want to skip this one.

## Deployment Notes

TBD
