### PR TITLE
Remove kwargs dict expansion

### DIFF
--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -201,7 +201,7 @@ class TestDownload:
         path = WaterButlerPath('/triangles.txt', _ids=(provider.folder, item['id']))
 
         metadata_url = provider.build_url('files', item['id'])
-        content_url = provider.build_url('files', item['id'], 'content', **{'version': revision})
+        content_url = provider.build_url('files', item['id'], 'content', version=revision)
 
         aiohttpretty.register_json_uri('GET', metadata_url, body=item)
         aiohttpretty.register_uri('GET', content_url, body=b'better', auto_length=True)


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/SVCS-1234 -->

## Purpose

`**` expands a dictionary as kwargs to a fn call. In this case it is completely unneccesary as the dict is a literal defined inside the call to the fn. Here it is simpler to assign the kwarg directly.
<!-- Describe the purpose of your changes -->

## Changes

<!-- Briefly describe or list your changes  -->

## Side effects

<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
