### PR TITLE
 [PLAT-639] Send along the user ID when asking for children metadata from the osf

### DIFF
--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -493,7 +493,7 @@ class OSFStorageProvider(provider.BaseProvider):
     async def _children_metadata(self, path):
         async with self.signed_request(
             'GET',
-            self.build_url(path.identifier, 'children'),
+            self.build_url(path.identifier, 'children', user_id=self.auth['id']),
             expects=(200, )
         ) as resp:
             resp_json = await resp.json()


### PR DESCRIPTION



<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-639

## Purpose
When checking to see if a user has seen a file, it'd be lovely to have the requesting user's _id in the request itself -- this isn't usually necessary because the request has already been authorized and so shouldn't need to send any auth along. Now, since we're planning on highlighting files that a user hasn't yet seen, we need to know which user is asking for the file tree to do the appropriate query to find the files they haven't seen yet!

## Changes
Send the requesting user's id in the query params of the request for children metadata. This allows the user ID to be accessed OSF-side in `osfstorage_get_children` to use to see if the current user has seen the files yet or not!

## Side effects
None anticipated

## QA Notes
This is a small internal change, so should not need any QA!

## Deployment Notes
Nope!
