### PR TITLE
[SVCS-693] Fix `resp.json()` throwing warnings about `mimetype`

### DIFF
--- a/waterbutler/providers/googlecloud/provider.py
+++ b/waterbutler/providers/googlecloud/provider.py
@@ -44,7 +44,7 @@ class GoogleCloudProvider(BaseProvider):
     # Provider Name
     NAME = 'googlecloud'
 
-    # BASE URL for JSON API
+    # BASE URL for XML API
     BASE_URL = pd_settings.BASE_URL
 
     # EXPIRATION for Signed Request/URL for XML API


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-693

## Purpose

`resp.json()` will throw the warning "Attempt to decode JSON with unexpected mimetype: `%s`" if the "Content-Type" is not of a `json` type.  This is a correct and expected warning.

However, providers (such as S3 and GoogleCloud) using XML API endpoint will pollute the WB celery log with this warning when checking file existences before each copy/move.  In addition, some 404s responses have a `str` or `bytes` body regardless of the "Content-Type".

Current fix is to skip parsing the response body for HTTP HEAD requests.  We cannot simply rely on the header "Content-Type" to decide whether to call `.json()` or `.read()`.  The warning should be still logged at a level that it is useful but not annoying.

## Changes

Skip parsing response body for HTTP HEAD requests.

## Side effects

Fix an issue where response are not released.
Update an outdated comments for Google Cloud when moving from JSON to XML.

## QA Notes

QA is not needed.

## Deployment Notes

No
