### PR TITLE
[SVCS-701] OSFStorage: Only Enable Intra Move/Copy For Same Region

### DIFF
--- a/tests/providers/osfstorage/fixtures.py
+++ b/tests/providers/osfstorage/fixtures.py
@@ -200,7 +200,23 @@ def provider_and_mock2(monkeypatch, auth, credentials, settings):
 
 @pytest.fixture
 def provider(auth, credentials, settings):
+    settings.update({
+        'storage': {
+            'bucket': 'mocke_bucket_1',
+        }
+    })
     return OSFStorageProvider(auth, credentials, settings)
+
+
+@pytest.fixture
+def provider_other(auth, credentials, settings):
+    settings_other = dict(settings)
+    settings_other.update({
+        'storage': {
+            'bucket': 'mocke_bucket_2',
+        }
+    })
+    return OSFStorageProvider(auth, credentials, settings_other)
 
 
 @pytest.fixture

--- a/tests/providers/osfstorage/test_provider.py
+++ b/tests/providers/osfstorage/test_provider.py
@@ -25,7 +25,7 @@ from tests.providers.osfstorage.fixtures import (auth, credentials, settings, pr
                                                  revisions_metadata, revision_metadata_object,
                                                  download_response, download_path,
                                                  upload_response, upload_path, root_path,
-                                                 mock_time)
+                                                 mock_time, provider_other, )
 
 
 def build_signed_url_without_auth(provider, method, *segments, **params):
@@ -481,14 +481,34 @@ class TestIntraMove:
 
 class TestUtils:
 
-    def test_intra_move_copy_utils(self, provider):
-        assert provider.can_duplicate_names()
+    def test_is_same_region_true(self, provider):
+        assert provider.is_same_region(provider)
+
+    def test_is_same_region_false(self, provider, provider_other):
+        assert not provider.is_same_region(provider_other)
+
+    def test_is_same_region_error(self, provider):
+
+        with pytest.raises(AssertionError) as exc:
+            provider.is_same_region(str())
+        assert str(exc.value) == 'Cannot compare region for providers of different provider ' \
+                                 'classes.'
+
+    def test_can_intra_move_copy_true(self, provider):
 
         assert provider.can_intra_copy(provider)
         assert provider.can_intra_move(provider)
 
+    def test_can_intra_move_copy_false_region_mismatch(self, provider, provider_other):
+        assert not provider.can_intra_copy(provider_other)
+        assert not provider.can_intra_move(provider_other)
+
+    def test_can_intra_move_copy_false_class_mismatch(self, provider):
         assert not provider.can_intra_copy(str())
         assert not provider.can_intra_move(str())
+
+    def test_can_duplicate_names(self, provider):
+        assert provider.can_duplicate_names()
 
     def test_make_provider(self, provider):
         pass

--- a/waterbutler/providers/googlecloud/provider.py
+++ b/waterbutler/providers/googlecloud/provider.py
@@ -70,7 +70,6 @@ class GoogleCloudProvider(BaseProvider):
         #         'storage': {
         #             'provider': 'change_me',
         #             'bucket': 'change_me',
-        #             'region': 'change_me',
         #         },
         #     }
         #

--- a/waterbutler/providers/osfstorage/provider.py
+++ b/waterbutler/providers/osfstorage/provider.py
@@ -145,11 +145,21 @@ class OSFStorageProvider(provider.BaseProvider):
     def can_duplicate_names(self):
         return True
 
+    def is_same_region(self, other):
+        assert isinstance(other, self.__class__), 'Cannot compare region for providers of ' \
+                                                  'different provider classes.'
+        # For 1-to-1 bucket-region mapping, bucket is the same if and only if region is the same
+        return self.settings['storage']['bucket'] == other.settings['storage']['bucket']
+
     def can_intra_copy(self, other, path=None):
-        return isinstance(other, self.__class__)
+        if not isinstance(other, self.__class__):
+            return False
+        return self.is_same_region(other)
 
     def can_intra_move(self, other, path=None):
-        return isinstance(other, self.__class__)
+        if not isinstance(other, self.__class__):
+            return False
+        return self.is_same_region(other)
 
     async def intra_move(self, dest_provider, src_path, dest_path):
         created = True


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-701

## Purpose

Only allow intra move/copy within the same region (for the same bucket) for OSFStorage.

## Changes

* Add a dedicated method `is_same_region()` to `core.provider` and `osfstorage.provider`. Currently implementation is based on the assumption that we use a 1-to-1 mapping between buckets and regions. If we change this assumption in the future, only `is_same_region()` needs to be updated.

* `can_intra_copy()` and `can_intra_move()` now calls the aforementioned `is_same_region()`

* Update provider tests for OSFStorage. (No refactor, just minimal changes that are necessary.)

* Update a comment in GCloud to reflect the latest change in OSFStorage settings. 

## Side effects

No

## QA Notes

This feature cannot be tested until the OSF has region.

## Deployment Notes

No
