### PR TITLE
[SVCS-831] signal MFR render/export requests to the OSF

### DIFF
--- a/waterbutler/auth/osf/handler.py
+++ b/waterbutler/auth/osf/handler.py
@@ -105,6 +105,13 @@ class OsfAuthHandler(BaseAuthHandler):
                 osf_action = post_action_map[action.lower()]
             except KeyError:
                 raise exceptions.UnsupportedActionError(method, supported=post_action_map.keys())
+        elif method == 'head' and settings.MFR_ACTION_HEADER in request.headers:
+            mfr_action_map = {'render': 'render', 'export': 'export'}
+            mfr_action = request.headers[settings.MFR_ACTION_HEADER].lower()
+            try:
+                osf_action = mfr_action_map[mfr_action]
+            except KeyError:
+                raise exceptions.UnsupportedActionError(mfr_action, supported=mfr_action_map.keys())
         else:
             try:
                 osf_action = self.ACTION_MAP[method]

--- a/waterbutler/auth/osf/settings.py
+++ b/waterbutler/auth/osf/settings.py
@@ -19,3 +19,5 @@ if not settings.DEBUG:
 JWE_SALT = (JWE_SALT or 'yusaltydough')
 JWE_SECRET = (JWE_SECRET or 'CirclesAre4Squares')
 JWT_SECRET = (JWT_SECRET or 'ILiekTrianglesALot')
+
+MFR_ACTION_HEADER = config.get('MFR_ACTION_HEADER', 'X-Cos-Mfr-Request-Action')


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-831

## Purpose

Help OSF get more accurate MFR render/export statistics.

## Changes

When MFR requests metadata from WB, it sets a header identifying itself and indicating the type of MFR action being performed.  This PR will relay that information to the OSF in the authorization request.  This will allow the OSF to distinguish contributor vs. non-contributor views and also avoid missing views due to MFR caching.

## Side effects

None expected.  Will do nothing until SVCS-674 is merged into MFR.

## QA Notes

None.

## Deployment Notes

None.
