### PR TITLE
[SVCS-281] Escape response headers

### DIFF
--- a/waterbutler/server/api/v1/provider/metadata.py
+++ b/waterbutler/server/api/v1/provider/metadata.py
@@ -97,7 +97,7 @@ class MetadataMixin:
         # Build `Content-Disposition` header from `displayName` override,
         # headers of provider response, or file path, whichever is truthy first
         name = self.get_query_argument('displayName', default=None) or getattr(stream, 'name', None) or self.path.name
-        self.set_header('Content-Disposition', utils.make_disposition(name))
+        self.set_header('Content-Disposition', utils.make_disposition(name).encode('unicode_escape'))
 
         _, ext = os.path.splitext(name)
         # If the file extention is in mime_types


### PR DESCRIPTION

<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

https://openscience.atlassian.net/browse/SVCS-281

## Purpose

Response headers should not have control characters in them because they
can mess up the headers returned in the response. 

## Changes

This change escapes them so they don't mess up the headers.

<!-- Briefly describe or list your changes  -->

## Side effects

<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
