### PR TITLE
[SVCS-895] Upgrade tornado from 4.3 to 5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pytz==2017.2
 raven==5.27.0
 setuptools==37.0.0
 stevedore==1.2.0
-tornado==4.3
+tornado==5.1
 xmltodict==0.9.0
 
 # Issue: certifi-2015.9.6.1 and 2015.9.6.2 fail verification (https://github.com/certifi/python-certifi/issues/26)

--- a/tests/server/api/v1/fixtures.py
+++ b/tests/server/api/v1/fixtures.py
@@ -25,26 +25,6 @@ def app():
 
 
 @pytest.fixture
-def http_server_port():
-    """Port used by `http_server`.
-    """
-    return tornado.testing.bind_unused_port()
-
-
-@pytest.yield_fixture
-def io_loop():
-    """
-    Create a new `tornado.platform.asyncio.AsyncIOLoop` for each test case.
-    """
-    loop = tornado.platform.asyncio.AsyncIOLoop()
-    loop.make_current()
-    yield loop
-    loop.clear_current()
-    if not type(loop).initialized() or loop is not type(loop).instance():
-        loop.close(all_fds=True)
-
-
-@pytest.fixture
 def http_request():
     mocked_http_request = HTTPServerRequest(
         uri='/v1/resources/test/providers/test/path/mock',

--- a/tests/server/api/v1/test_core.py
+++ b/tests/server/api/v1/test_core.py
@@ -1,7 +1,13 @@
 from unittest import mock
 
-from tests.server.api.v1.fixtures import (http_request, handler, mock_exc_info, mock_exc_info_202,
-                                          mock_exc_info_http)
+from tests.server.api.v1.fixtures import (
+    app,
+    http_request,
+    handler,
+    mock_exc_info,
+    mock_exc_info_202,
+    mock_exc_info_http
+)
 
 
 class TestBaseHandler:

--- a/tests/server/api/v1/test_create_mixin.py
+++ b/tests/server/api/v1/test_create_mixin.py
@@ -6,8 +6,14 @@ import pytest
 from tests.utils import MockCoroutine
 from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
-from tests.server.api.v1.fixtures import (http_request, handler, handler_auth, mock_folder_metadata,
-                                          mock_file_metadata)
+from tests.server.api.v1.fixtures import (
+    app,
+    http_request,
+    handler,
+    handler_auth,
+    mock_folder_metadata,
+    mock_file_metadata
+)
 
 
 class TestValidatePut:

--- a/tests/server/api/v1/test_metadata_mixin.py
+++ b/tests/server/api/v1/test_metadata_mixin.py
@@ -4,9 +4,17 @@ import pytest
 
 from tests.utils import MockCoroutine
 from waterbutler.core.path import WaterButlerPath
-from tests.server.api.v1.fixtures import (http_request, handler, handler_auth, mock_stream,
-                                          mock_partial_stream, mock_file_metadata,
-                                          mock_folder_children, mock_revision_metadata)
+from tests.server.api.v1.fixtures import (
+    app,
+    http_request,
+    handler,
+    handler_auth,
+    mock_stream,
+    mock_partial_stream,
+    mock_file_metadata,
+    mock_folder_children,
+    mock_revision_metadata
+)
 
 
 class TestMetadataMixin:
@@ -19,11 +27,9 @@ class TestMetadataMixin:
         await handler.header_file_metadata()
 
         assert handler._headers['Content-Length'] == '1337'
-        assert handler._headers['Last-Modified'] == b'Wed, 25 Sep 1991 18:20:30 GMT'
-        assert handler._headers['Content-Type'] == b'application/octet-stream'
-        expected = bytes(json.dumps(mock_file_metadata.json_api_serialized(handler.resource)),
-                         'latin-1')
-        assert handler._headers['X-Waterbutler-Metadata'] == expected
+        assert handler._headers['Last-Modified'] == 'Wed, 25 Sep 1991 18:20:30 GMT'
+        assert handler._headers['Content-Type'] == 'application/octet-stream'
+        assert handler._headers['X-Waterbutler-Metadata'] == json.dumps(mock_file_metadata.json_api_serialized(handler.resource))
 
     @pytest.mark.asyncio
     async def test_get_folder(self, handler, mock_folder_children):
@@ -86,10 +92,9 @@ class TestMetadataMixin:
 
         await handler.download_file()
 
-        assert handler._headers['Content-Length'] == bytes(str(mock_stream.size), 'latin-1')
-        assert handler._headers['Content-Type'] == bytes(mock_stream.content_type, 'latin-1')
-        assert handler._headers['Content-Disposition'] == bytes('attachment;filename="{}"'.format(
-            handler.path.name), 'latin-1')
+        assert handler._headers['Content-Length'] == str(mock_stream.size)
+        assert handler._headers['Content-Type'] == mock_stream.content_type
+        assert handler._headers['Content-Disposition'] == 'attachment;filename="{}"'.format(handler.path.name)
 
         handler.write_stream.assert_awaited_once()
 
@@ -102,8 +107,7 @@ class TestMetadataMixin:
 
         await handler.download_file()
 
-        assert handler._headers['Content-Range'] == bytes(mock_partial_stream.content_range,
-                                                          'latin-1')
+        assert handler._headers['Content-Range'] == mock_partial_stream.content_range
         assert handler.get_status() == 206
         handler.write_stream.assert_called_once_with(mock_partial_stream)
 
@@ -130,7 +134,7 @@ class TestMetadataMixin:
         await handler.download_file()
 
         handler.write_stream.assert_called_once_with(mock_stream)
-        assert handler._headers['Content-Type'] == bytes(mimetype, 'latin-1')
+        assert handler._headers['Content-Type'] == mimetype
 
     @pytest.mark.asyncio
     async def test_file_metadata(self, handler, mock_file_metadata):
@@ -173,8 +177,8 @@ class TestMetadataMixin:
 
         await handler.download_folder_as_zip()
 
-        assert handler._headers['Content-Type'] == bytes('application/zip', 'latin-1')
-        expected = bytes('attachment;filename="{}"'.format(handler.path.name + '.zip'), 'latin-1')
+        assert handler._headers['Content-Type'] == 'application/zip'
+        expected = 'attachment;filename="{}"'.format(handler.path.name + '.zip')
         assert handler._headers['Content-Disposition'] == expected
 
         handler.write_stream.assert_called_once_with(mock_stream)

--- a/tests/server/api/v1/test_movecopy.py
+++ b/tests/server/api/v1/test_movecopy.py
@@ -2,12 +2,23 @@ import pytest
 
 from waterbutler.core import exceptions
 
-from tests.server.api.v1.fixtures import (http_request, handler, move_copy_args, handler_auth,
-                                          patch_auth_handler, serialized_request,
-                                          serialized_metadata, celery_src_copy_params,
-                                          celery_dest_copy_params, celery_dest_copy_params_root,
-                                          mock_intra, mock_inter, patch_make_provider_move_copy,
-                                          mock_file_metadata)
+from tests.server.api.v1.fixtures import (
+    app,
+    celery_dest_copy_params,
+    celery_dest_copy_params_root,
+    celery_src_copy_params,
+    handler,
+    handler_auth,
+    http_request,
+    mock_file_metadata,
+    mock_inter,
+    mock_intra,
+    move_copy_args,
+    patch_auth_handler,
+    patch_make_provider_move_copy,
+    serialized_metadata,
+    serialized_request
+)
 
 
 @pytest.mark.usefixtures('patch_auth_handler', 'patch_make_provider_move_copy')

--- a/tests/server/api/v1/test_provider.py
+++ b/tests/server/api/v1/test_provider.py
@@ -7,8 +7,14 @@ from waterbutler.core.path import WaterButlerPath
 from waterbutler.server.api.v1.provider import ProviderHandler, list_or_value
 
 from tests.utils import MockCoroutine, MockStream, MockWriter, MockProvider
-from tests.server.api.v1.fixtures import (http_request, handler, patch_auth_handler, handler_auth,
-                                          patch_make_provider_core)
+from tests.server.api.v1.fixtures import (
+    app,
+    handler,
+    handler_auth,
+    http_request,
+    patch_auth_handler,
+    patch_make_provider_core
+)
 
 
 class TestUtils:
@@ -29,7 +35,7 @@ class TestProviderHandler:
         await handler.prepare()
 
         # check that X-WATERBUTLER-REQUEST-ID is valid UUID
-        assert UUID(handler._headers['X-WATERBUTLER-REQUEST-ID'].decode('utf-8'), version=4)
+        assert UUID(handler._headers['X-WATERBUTLER-REQUEST-ID'], version=4)
 
     @pytest.mark.asyncio
     async def test_prepare_put(self, handler, patch_auth_handler, patch_make_provider_core,
@@ -43,7 +49,7 @@ class TestProviderHandler:
         assert handler.path == WaterButlerPath('/file', prepend=None)
 
         # check that X-WATERBUTLER-REQUEST-ID is valid UUID
-        assert UUID(handler._headers['X-WATERBUTLER-REQUEST-ID'].decode('utf-8'), version=4)
+        assert UUID(handler._headers['X-WATERBUTLER-REQUEST-ID'], version=4)
 
     @pytest.mark.asyncio
     async def test_prepare_stream(self, handler):

--- a/waterbutler/server/app.py
+++ b/waterbutler/server/app.py
@@ -49,8 +49,6 @@ def make_app(debug):
 
 
 def serve():
-    tornado.platform.asyncio.AsyncIOMainLoop().install()
-
     app = make_app(server_settings.DEBUG)
 
     ssl_options = None

--- a/waterbutler/server/app.py
+++ b/waterbutler/server/app.py
@@ -1,8 +1,8 @@
 import os
-# import signal
+import signal
 import asyncio
 import logging
-# from functools import partial
+from functools import partial
 
 import tornado.web
 import tornado.platform.asyncio
@@ -23,9 +23,11 @@ def sig_handler(sig, frame):
 
     def stop_loop():
         if len(asyncio.Task.all_tasks(io_loop)) == 0:
+            logger.info('Recieved signal {}. Stopping NOW...'.format(sig))
             io_loop.stop()
         else:
             io_loop.call_later(1, stop_loop)
+            logger.info('Recieved signal {}. Waiting for running tasks to finish...'.format(sig))
 
     io_loop.add_callback_from_signal(stop_loop)
 
@@ -68,7 +70,7 @@ def serve():
 
     logger.info("Listening on {0}:{1}".format(server_settings.ADDRESS, server_settings.PORT))
 
-    # signal.signal(signal.SIGTERM, partial(sig_handler))
+    signal.signal(signal.SIGTERM, partial(sig_handler))
     tornado.ioloop.IOLoop.current().start()
     # asyncio.get_event_loop().set_debug(server_settings.DEBUG)
     # asyncio.get_event_loop().run_forever()

--- a/waterbutler/server/app.py
+++ b/waterbutler/server/app.py
@@ -1,8 +1,8 @@
 import os
-import signal
+# import signal
 import asyncio
 import logging
-from functools import partial
+# from functools import partial
 
 import tornado.web
 import tornado.platform.asyncio
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 def sig_handler(sig, frame):
-    io_loop = tornado.ioloop.IOLoop.instance()
+    io_loop = tornado.ioloop.IOLoop.current()
 
     def stop_loop():
         if len(asyncio.Task.all_tasks(io_loop)) == 0:
@@ -68,6 +68,7 @@ def serve():
 
     logger.info("Listening on {0}:{1}".format(server_settings.ADDRESS, server_settings.PORT))
 
-    signal.signal(signal.SIGTERM, partial(sig_handler))
-    asyncio.get_event_loop().set_debug(server_settings.DEBUG)
-    asyncio.get_event_loop().run_forever()
+    # signal.signal(signal.SIGTERM, partial(sig_handler))
+    tornado.ioloop.IOLoop.current().start()
+    # asyncio.get_event_loop().set_debug(server_settings.DEBUG)
+    # asyncio.get_event_loop().run_forever()


### PR DESCRIPTION


<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

https://openscience.atlassian.net/browse/SVCS-895

## Purpose

The latest version of tornado has updates to use the event loop properly
that we need for aiohttp context managers to work properly. The version
of tornado that we use doesn't use the asyncio event loop, but its own
event loop, so other libraries that use the event loop sometimes don't
work properly. Like aiohttp.

## Changes

Tornado to 5.1

## Side effects

<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
