### PR TITLE
Remove cute trick to deal with bufffer size

### DIFF
--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -130,7 +130,15 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
 
     async def prepare_stream(self):
         """Sets up an asyncio pipe from client to server
-        Only called on PUT when path is to a file
+        Only called on PUT when path is to a file.
+        
+        Creating a StreamWriter, StreamReader pair gives access to the 
+        StreamWriter.drain method which will pause writing until the in memory buffer
+        is below a certain threshold. This prevents entire files to be pulled into memory
+        when the client's connection to waterbutler was faster than
+        waterbutler's connection to the provider
+
+        https://github.com/CenterForOpenScience/waterbutler/commit/bb77d790284d8f575178c51d09991ae898a8e152
         """
         self.rsock, self.wsock = socket.socketpair()
 


### PR DESCRIPTION

<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/SVCS-1234 -->

## Purpose

Wrapping around a socket is cute, but it's not really the right way to
do it. Put an actual limit on the buffer size and wait for it to get
written.

## Changes

<!-- Briefly describe or list your changes  -->

## Side effects

<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
