### PR TITLE
[WIP][SVCS-892] Support cross-region moves in osfstorage.

### DIFF
--- a/tests/auth/osf/test_handler.py
+++ b/tests/auth/osf/test_handler.py
@@ -48,7 +48,7 @@ class TestOsfAuthHandler(ServerTestCase):
             for action in post_actions:
                 self.request.method = 'post'
                 await self.handler.get(resource, provider,
-                                            self.request, action=action, auth_type=auth_type)
+                                       self.request, action=action, auth_type=auth_type)
 
         for method in supported_methods:
             self.request.method = method
@@ -80,11 +80,15 @@ class TestOsfAuthHandler(ServerTestCase):
                 self.handler.build_payload.assert_called_with({
                     'nid': resource,
                     'provider': provider,
-                    'action': 'download'
+                    'action': 'download',
+                    'path': '',
+                    'version': None,
                 }, cookie=None, view_only=None)
             else:
                 self.handler.build_payload.assert_called_with({
                     'nid': resource,
                     'provider': provider,
-                    'action': 'upload'
+                    'action': 'upload',
+                    'path': '',
+                    'version': None,
                 }, cookie=None, view_only=None)

--- a/tests/providers/osfstorage/fixtures.py
+++ b/tests/providers/osfstorage/fixtures.py
@@ -166,6 +166,8 @@ def file_stream(file_like):
 
 @pytest.fixture
 def provider_and_mock(monkeypatch, auth, credentials, settings):
+    """Returns an OSFStorageProvider and a mock object representing the inner storage provider."""
+
     mock_provider = utils.MockProvider1({}, {}, {})
 
     mock_provider.copy = utils.MockCoroutine()
@@ -184,6 +186,8 @@ def provider_and_mock(monkeypatch, auth, credentials, settings):
 
 @pytest.fixture
 def provider_and_mock2(monkeypatch, auth, credentials, settings):
+    """Returns an OSFStorageProvider and a mock object representing the inner storage provider."""
+
     mock_provider = utils.MockProvider1({}, {}, {})
 
     mock_provider.copy = utils.MockCoroutine()

--- a/tests/providers/osfstorage/test_provider.py
+++ b/tests/providers/osfstorage/test_provider.py
@@ -9,6 +9,7 @@ import aiohttpretty
 from waterbutler.core import metadata
 from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
+from waterbutler.providers.osfstorage.provider import OSFStorageProvider
 from waterbutler.providers.osfstorage.metadata import (OsfStorageFileMetadata,
                                                        OsfStorageFolderMetadata,
                                                        OsfStorageRevisionMetadata)
@@ -759,3 +760,108 @@ class TestUploads:
             check_created=False,
             fetch_metadata=False
         )
+
+
+class TestCrossRegionMove:
+
+    @pytest.mark.asyncio
+    async def test_move_file(self, provider_one, provider_two, file_stream, upload_response):
+
+        # aliased for clarity
+        src_provider, dst_provider = provider_one, provider_two
+
+        src_provider.download = utils.MockCoroutine(return_value=file_stream)
+        src_provider.intra_move = utils.MockCoroutine(return_value=(upload_response, True))
+        dst_provider._send_to_storage_provider = utils.MockCoroutine()
+
+        src_path = WaterButlerPath('/foo', _ids=('Test', '56ab34'))
+        dest_path = WaterButlerPath('/', _ids=('Test',))
+
+        metadata, created = await src_provider.move(dst_provider, src_path, dest_path,
+                                                    handle_naming=False);
+
+        assert metadata is not None
+        assert created is True
+
+        src_provider.download.assert_called_once_with(WaterButlerPath('/foo'))
+        dst_provider._send_to_storage_provider.assert_called_once_with(file_stream,
+                                                                       WaterButlerPath('/'),
+                                                                       rename=None,
+                                                                       conflict='replace')
+        src_provider.intra_move.assert_called_once_with(dst_provider, WaterButlerPath('/foo'),
+                                                        WaterButlerPath('/'))
+
+    @pytest.mark.asyncio
+    async def test_move_folder(self, provider_one, provider_two):
+
+        # aliased for clarity
+        src_provider, dst_provider = provider_one, provider_two
+
+        src_provider._folder_file_op = utils.MockCoroutine(return_value=(upload_response, True))
+        src_provider.delete = utils.MockCoroutine()
+
+        src_path = WaterButlerPath('/foo/', _ids=('Test', '56ab34'), folder=True)
+        dest_path = WaterButlerPath('/', _ids=('Test',), folder=True)
+
+        metadata, created = await src_provider.move(dst_provider, src_path, dest_path,
+                                                    handle_naming=False);
+
+        assert metadata is not None
+        assert created is True
+
+        src_provider._folder_file_op.assert_called_once_with(src_provider.move,
+                                                             dst_provider,
+                                                             WaterButlerPath('/foo/'),
+                                                             WaterButlerPath('/'),
+                                                             rename=None,
+                                                             conflict='replace')
+        src_provider.delete.assert_called_once_with(WaterButlerPath('/foo/'))
+
+    @pytest.mark.asyncio
+    async def test_move_cross_provider(self, monkeypatch, provider_one, provider_two):
+
+        # aliased for clarity
+        src_provider, dst_provider = provider_one, provider_two
+
+        src_provider.download = utils.MockCoroutine()
+        dst_provider.NAME = 'not-osfstorage'
+
+        core_move = utils.MockCoroutine()
+        monkeypatch.setattr('waterbutler.core.provider.BaseProvider.move', core_move)
+
+        src_path = WaterButlerPath('/foo', _ids=('Test', '56ab34'))
+        dest_path = WaterButlerPath('/', _ids=('Test',))
+
+        await src_provider.move(dst_provider, src_path, dest_path, handle_naming=False);
+
+        core_move.assert_called_once_with(dst_provider, src_path, dest_path, rename=None,
+                                          conflict='replace', handle_naming=False);
+        src_provider.download.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_move_but_intra_move(self, provider_one, auth, credentials,
+                                       settings_region_one):
+        """OSFStorageProvider.move checks to see if intra_move can be called as an optimization.
+        This is copied over from the `BaseProvider.move()` implementation, and is unlikely to be
+        called in a real-world situation.  All calls to `OSFStorageProvider.move()` have probably
+        passed through a `can_intra_move` check already.  Nevertheless, let's test it to make sure
+        it behaves as expected."""
+
+        # aliased for clarity
+        src_provider = provider_one
+
+        settings_region_one['nid'] = 'fake-nid'
+        dst_provider = OSFStorageProvider(auth, credentials, settings_region_one)
+
+        src_provider.can_intra_move = mock.Mock(return_value=True)
+        src_provider.intra_move = utils.MockCoroutine()
+        src_provider.download = utils.MockCoroutine()
+
+        src_path = WaterButlerPath('/foo', _ids=('Test', '56ab34'))
+        dest_path = WaterButlerPath('/', _ids=('Test',))
+
+        await src_provider.move(dst_provider, src_path, dest_path, handle_naming=False);
+
+        src_provider.can_intra_move.assert_called_once_with(dst_provider, src_path)
+        src_provider.intra_move.assert_called_once_with(dst_provider, src_path, dest_path)
+        src_provider.download.assert_not_called()

--- a/tests/server/api/v1/fixtures.py
+++ b/tests/server/api/v1/fixtures.py
@@ -43,6 +43,7 @@ def handler(http_request):
     }
     mocked_handler.path = '/test_path'
     mocked_handler.provider = MockProvider()
+    mocked_handler.requested_version = None
 
     mocked_handler.resource = 'test_source_resource'
     mocked_handler.metadata = MockFileMetadata()

--- a/tests/server/api/v1/test_fuzzing.py
+++ b/tests/server/api/v1/test_fuzzing.py
@@ -1,7 +1,7 @@
-import pytest
 from http import client
 from unittest import mock
 
+import pytest
 import aiohttp
 
 from tornado import gen

--- a/tests/server/api/v1/test_metadata_mixin.py
+++ b/tests/server/api/v1/test_metadata_mixin.py
@@ -146,7 +146,7 @@ class TestMetadataMixin:
     @pytest.mark.asyncio
     async def test_file_metadata_version(self, handler, mock_file_metadata):
         handler.provider.metadata = MockCoroutine(return_value=mock_file_metadata)
-        handler.request.query_arguments['version'] = ['version id']
+        handler.requested_version = 'version id'
 
         await handler.file_metadata()
 

--- a/tests/server/api/v1/utils.py
+++ b/tests/server/api/v1/utils.py
@@ -1,5 +1,5 @@
-import asyncio
 import os
+import asyncio
 
 from tornado import testing
 from tornado.platform.asyncio import AsyncIOMainLoop

--- a/waterbutler/auth/osf/handler.py
+++ b/waterbutler/auth/osf/handler.py
@@ -90,7 +90,8 @@ class OsfAuthHandler(BaseAuthHandler):
         payload['auth']['callback_url'] = payload['callback_url']
         return payload
 
-    async def get(self, resource, provider, request, action=None, auth_type=AuthType.SOURCE):
+    async def get(self, resource, provider, request, action=None, auth_type=AuthType.SOURCE,
+                  path='', version=None):
         """Used for v1"""
         method = request.method.lower()
 
@@ -136,7 +137,9 @@ class OsfAuthHandler(BaseAuthHandler):
             self.build_payload({
                 'nid': resource,
                 'provider': provider,
-                'action': osf_action
+                'action': osf_action,
+                'path': path,
+                'version': version,
             }, cookie=cookie, view_only=view_only),
             headers,
             dict(request.cookies)

--- a/waterbutler/core/auth.py
+++ b/waterbutler/core/auth.py
@@ -14,5 +14,6 @@ class BaseAuthHandler(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    async def get(self, resource, provider, request, action=None, auth_type=AuthType.SOURCE):
+    async def get(self, resource, provider, request, action=None, auth_type=AuthType.SOURCE,
+                  path='', version=None):
         pass

--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -66,10 +66,13 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
         if method in self.PRE_VALIDATORS:
             getattr(self, self.PRE_VALIDATORS[method])()
 
-        # Delay setup of the provider when method is post, as we need to evaluate the json body action.
+        # Delay setup of the provider when method is post, as we need to evaluate the json body
+        # action.
         if method != 'post':
-            self.auth = await auth_handler.get(self.resource, provider, self.request)
-            self.provider = utils.make_provider(provider, self.auth['auth'], self.auth['credentials'], self.auth['settings'])
+            self.auth = await auth_handler.get(self.resource, provider, self.request,
+                                               path=self.path, version=self.requested_version)
+            self.provider = utils.make_provider(provider, self.auth['auth'],
+                                                self.auth['credentials'], self.auth['settings'])
             self.path = await self.provider.validate_v1_path(self.path, **self.arguments)
 
         self.target_path = None

--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -48,6 +48,12 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
             for key, value in self.request.query_arguments.items()
         }
 
+        # Going with version as its the most correct term
+        # TODO Change all references of revision to version @chrisseto
+        # revisions will still be accepted until necessary changes are made to OSF
+        self.requested_version = (self.get_query_argument('version', default=None) or
+                                  self.get_query_argument('revision', default=None))
+
         self.path = self.path_kwargs['path'] or '/'
         provider = self.path_kwargs['provider']
         self.resource = self.path_kwargs['resource']

--- a/waterbutler/server/api/v1/provider/movecopy.py
+++ b/waterbutler/server/api/v1/provider/movecopy.py
@@ -87,7 +87,9 @@ class MoveCopyMixin:
             provider,
             self.request,
             action=auth_action,
-            auth_type=AuthType.SOURCE
+            auth_type=AuthType.SOURCE,
+            path=self.path,
+            version=self.requested_version,
         )
         self.provider = make_provider(
             provider,

--- a/waterbutler/server/auth.py
+++ b/waterbutler/server/auth.py
@@ -21,9 +21,12 @@ class AuthHandler:
                 return credential
         raise AuthHandler('no valid credential found')
 
-    async def get(self, resource, provider, request, action=None, auth_type=AuthType.SOURCE):
+    async def get(self, resource, provider, request, action=None, auth_type=AuthType.SOURCE,
+                  path='', version=None):
         for extension in self.manager.extensions:
-            credential = await extension.obj.get(resource, provider, request, action=action, auth_type=auth_type)
+            credential = await extension.obj.get(resource, provider, request,
+                                                 action=action, auth_type=auth_type,
+                                                 path=path, version=version)
             if credential:
                 return credential
         raise AuthHandler('no valid credential found')


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-892

## Purpose

Cross-region moves in osfstorage are wonky b/c they can't use `intra_move` (which won't copy the data) and they can't use the default `move` (which will create all-new file metadata entries on the OSF, losing guids and versions in the process).   This PR adds an osfstorage-specific `move` method which will both copy the data to the new region and update the file metadata entry on the OSF.

## Changes

* Factor out duplicate code in osfstorage's `intra_move` and `intra_copy` to make it easier to reason about.  Rewrite associated tests to improve coverage and accuracy.
* Split out the "upload-to-data-storage" and "upload-to-metadata-provider" code from `upload` so that they can be called independently of each other.
* Add an osfstorage-specific `move` method that will upload to the new region's data storage, then call `intra_move` to preserve and update the metadata entry.
* Send the file path and requested version to the OSF when requesting auth.  This will allow the OSF to send the correct settings and credentials for the region the file version is saved in.  This depends on CenterForOpenScience/osf.io#8643 to function correctly for old versions, but will not break requests on current versions or old versions in the same region as current.

## Side effects

goodness gracious yes

## QA Notes

* Need to test move and copy behavior for osfstorage, both for same-region and cross-region move/copies.  After move, file guids and version history should be preserved.  All previous versions should be downloadable.

## Deployment Notes

Shouldn't need any deployment changes on the WB-side.
