### PR TITLE
[SVCS-894] Cache File During Contiguous Upload For Dropbox

### DIFF
--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -61,6 +61,7 @@ class DropboxProvider(provider.BaseProvider):
     BASE_URL = pd_settings.BASE_URL
     CONTIGUOUS_UPLOAD_SIZE_LIMIT = pd_settings.CONTIGUOUS_UPLOAD_SIZE_LIMIT
     CHUNK_SIZE = pd_settings.CHUNK_SIZE
+    MAX_429_RETRIES = pd_settings.MAX_429_RETRIES
 
     def __init__(self, auth, credentials, settings):
         super().__init__(auth, credentials, settings)
@@ -304,7 +305,7 @@ class DropboxProvider(provider.BaseProvider):
             chunk = await stream.read()
 
         rate_limit_retry = 0
-        while rate_limit_retry < 2:
+        while rate_limit_retry < self.MAX_429_RETRIES:
             file_stream = streams.FileStreamReader(file_cache)
             resp = await self.make_request(
                 'POST',

--- a/waterbutler/providers/dropbox/settings.py
+++ b/waterbutler/providers/dropbox/settings.py
@@ -10,3 +10,5 @@ BASE_CONTENT_URL = config.get('BASE_CONTENT_URL', 'https://content.dropboxapi.co
 CONTIGUOUS_UPLOAD_SIZE_LIMIT = int(config.get('CONTIGUOUS_UPLOAD_SIZE_LIMIT', 150000000))  # 150 MB
 
 CHUNK_SIZE = int(config.get('CHUNK_SIZE', 4000000))  # 4 MB
+
+MAX_429_RETRIES = int(config.get('MAX_429_RETRIES', 2))


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-894

## Purpose

Dropbox's rate limit feature may cause uploading/copying/moving many files to fail with "too_many_requests" & "too_many_write_operations". The former is for too many requests literally and the former is for namespace lock contentions. Unlike GitHub, Dropbox doesn't provide detailed information on how they rate limit requests but simply asks clients to retry according to the "Retry-After" header in the 429 response.

The retry doesn't work in a straightforward way for upload (inter copy and move use upload internally) since the stream will have been consumed when the request is finished. The solution is to cache the stream locally into a temporary file and stream from the file for both the initial request and following 429 retries.

## Changes

TBD

## Side effects

TBD

## QA Notes

TBD

## Deployment Notes

TBD
