### PR TITLE
[SVCS-904] Hf/fix gdoc renames

### DIFF
--- a/waterbutler/core/log_payload.py
+++ b/waterbutler/core/log_payload.py
@@ -1,6 +1,8 @@
 from waterbutler.constants import IDENTIFIER_PATHS
 from waterbutler.core.path import WaterButlerPath
 
+from waterbutler.providers.googledrive import utils
+
 import logging
 
 logger = logging.getLogger(__name__)
@@ -44,16 +46,20 @@ class LogPayload:
             'resource': self.resource,
         }
         if self.metadata is None:
+
             payload.update({
                 'provider': self.provider.NAME,
                 'kind': self.path.kind,
                 'path': self.path.identifier_path if self.provider.NAME in IDENTIFIER_PATHS else '/' + self.path.raw_path,
                 'name': self.path.name,
                 'materialized': self.path.materialized_path,
+                'type': getattr(self.path, 'file_type', ''),
                 'extra': self.path.extra,
             })
         else:
             payload.update(self.metadata.serialized())
+
+        print(payload)
 
         return payload
 

--- a/waterbutler/core/log_payload.py
+++ b/waterbutler/core/log_payload.py
@@ -59,8 +59,6 @@ class LogPayload:
         else:
             payload.update(self.metadata.serialized())
 
-        print(payload)
-
         return payload
 
     @property

--- a/waterbutler/core/path.py
+++ b/waterbutler/core/path.py
@@ -67,12 +67,13 @@ class WaterButlerPathPart:
 
 
 class WaterButlerPath:
-    """ A standardized and validated immutable WaterButler path.  This is our abstraction around
-    file paths in storage providers.  A WaterButlerPath is an array of WaterButlerPathPart objects.
-    Each PathPart has two important attributes, `value` and `_id`.  `value` is always the
-    human-readable component of the path. If the provider assigns ids to entities (see: Box, Google
-    Drive, OSFStorage), that id belongs in the `_id` attribute. If `/Foo/Bar/baz.txt` is stored on
-    Box, its path parts will be approximately::
+    """ A standardized and validated immutable WaterButler path.  This is our
+    abstraction around file paths in storage providers.  A WaterButlerPath is
+    an array of WaterButlerPathPart objects. Each PathPart has two important
+    attributes, `value` and `_id`.  `value` is always the human-readable
+    component of the path. If the provider assigns ids to entities (see: Box,
+    Google Drive, OSFStorage), that id belongs in the `_id` attribute. If
+    `/Foo/Bar/baz.txt` is stored on Box, its path parts will be approximately::
 
         [
           { value: '/',       _id: None, }, # must have root
@@ -81,16 +82,19 @@ class WaterButlerPath:
           { value: 'baz.txt', _id: '1113345897' },
         ]
 
-    If :func:`WaterButlerPath.identifier` is called on this object, it'll return the `_id` of the
-    last path part. :func:`WaterButlerPath.path` will return `/Foo/Bar/baz.txt`.
+    If :func:`WaterButlerPath.identifier` is called on this object, it'll
+    return the `_id` of the last path part. :func:`WaterButlerPath.path` will
+    return `/Foo/Bar/baz.txt`.
 
     A valid WaterButlerPath should always have a root path part.
 
-    Some providers, such as Google Drive, require paths to be encoded when used in URLs.
-    WaterButlerPathPart has `ENCODE` and `DECODE` class methods that handle this. The encoded path
-    is available through the `.raw_path()` method.
+    Some providers, such as Google Drive, require paths to be encoded when used
+    in URLs. WaterButlerPathPart has `ENCODE` and `DECODE` class methods that
+    handle this. The encoded path is available through the `.raw_path()`
+    method.
 
-    To get a human-readable materialized path, call `str()` on the WaterButlerPath.
+    To get a human-readable materialized path, call `str()` on the
+    WaterButlerPath.
 
     Representations::
 
@@ -156,7 +160,10 @@ class WaterButlerPath:
                  path: str,
                  _ids: typing.Sequence=(),
                  prepend: str=None,
-                 folder: bool=None, **kwargs) -> None:
+                 folder: bool=None,
+                 file_type: str=None,
+                 **kwargs) -> None:
+
         # TODO: Should probably be a static method
         self.__class__.generic_path_validation(path)  # type: ignore
 
@@ -182,6 +189,9 @@ class WaterButlerPath:
 
         if self.is_dir and not self._orig_path.endswith('/'):
             self._orig_path += '/'
+
+        self.file_type = file_type
+
 
     @property
     def is_root(self) -> bool:

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -235,6 +235,8 @@ class BaseProvider(metaclass=abc.ABCMeta):
             kwargs = {}
 
         # files and folders shouldn't overwrite themselves
+        print(src_path)
+        print(dest_path)
         if (
             self.shares_storage_root(dest_provider) and
             src_path.materialized_path == dest_path.materialized_path

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -235,8 +235,6 @@ class BaseProvider(metaclass=abc.ABCMeta):
             kwargs = {}
 
         # files and folders shouldn't overwrite themselves
-        print(src_path)
-        print(dest_path)
         if (
             self.shares_storage_root(dest_provider) and
             src_path.materialized_path == dest_path.materialized_path

--- a/waterbutler/providers/googledrive/metadata.py
+++ b/waterbutler/providers/googledrive/metadata.py
@@ -68,26 +68,16 @@ class GoogleDriveFileMetadata(BaseGoogleDriveMetadata, metadata.BaseFileMetadata
     @property
     def name(self):
         title = self._file_title
-        if self.is_google_doc:
-            ext = utils.get_extension(self.raw)
-            title += ext
         return title
 
     @property
     def path(self):
         path = '/' + self._path.raw_path
-        if self.is_google_doc:
-            ext = utils.get_extension(self.raw)
-            path += ext
         return path
 
     @property
     def materialized_path(self):
-        materialized = str(self._path)
-        if self.is_google_doc:
-            ext = utils.get_extension(self.raw)
-            materialized += ext
-        return materialized
+        return self._path.materialized_path
 
     @property
     def size(self):

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -477,6 +477,8 @@ class GoogleDriveProvider(provider.BaseProvider):
                         path: WaterButlerPath,
                         item: dict,
                         raw: bool=False) -> Union[BaseGoogleDriveMetadata, dict]:
+        import pdb
+        pdb.set_trace()
         if raw:
             return item
         if item['mimeType'] == self.FOLDER_MIME_TYPE:
@@ -634,7 +636,10 @@ class GoogleDriveProvider(provider.BaseProvider):
             # If there are no revisions use etag as vid
             item['version'] = item['etag'] + pd_settings.DRIVE_IGNORE_VERSION
 
-        return self._serialize_item(path, item, raw=raw)
+        ser_item = self._serialize_item(path, item, raw=raw)
+        import pdb
+        pdb.set_trace()
+        return ser_item
 
     async def _folder_metadata(self,
                                path: WaterButlerPath,
@@ -654,6 +659,11 @@ class GoogleDriveProvider(provider.BaseProvider):
                     self._serialize_item(path.child(item['title']), item, raw=raw)
                     for item in resp_json['items']
                 ])
+                import logging
+                logger = logging.getLogger(__name__)
+                logger.debug('***\n  _folder_metadata()\n***')
+                import pdb
+                pdb.set_trace()
                 built_url = resp_json.get('nextLink', None)
         return full_resp
 
@@ -691,6 +701,8 @@ class GoogleDriveProvider(provider.BaseProvider):
         :return: a metadata for the googledoc or the raw response object from the GDrive API
         """
 
+        import pdb
+        pdb.set_trace()
         self.metrics.add('_file_metadata.got_revision', revision is not None)
 
         valid_revision = revision and not revision.endswith(pd_settings.DRIVE_IGNORE_VERSION)
@@ -723,12 +735,15 @@ class GoogleDriveProvider(provider.BaseProvider):
         can_access_revisions = user_role in self.ROLES_ALLOWING_REVISIONS
         if utils.is_docs_file(data):
             if can_access_revisions:
-                return await self._handle_docs_versioning(path, data, raw=raw)
+                docs = await self._handle_docs_versioning(path, data, raw=raw)
+                pdb.set_trace()
+                return docs
             else:
                 # Revisions are not available for some sharing configurations. If revisions list is
                 # empty, use the etag of the file plus a sentinel string as a dummy revision ID.
                 data['version'] = data['etag'] + pd_settings.DRIVE_IGNORE_VERSION
 
+        pdb.set_trace()
         return data if raw else GoogleDriveFileMetadata(data, path)
 
     async def _delete_folder_contents(self, path: WaterButlerPath) -> None:

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -71,7 +71,6 @@ class GoogleDrivePath(WaterButlerPath):
             return ''
         path = '/'.join([x.value for x in self.parts[1:]])
         path = path + ('/' if self.is_dir else '')
-        print('path: ' + path)
         return path
 
 
@@ -126,10 +125,8 @@ class GoogleDriveProvider(provider.BaseProvider):
         if path == '/':
             return GoogleDrivePath('/', _ids=[self.folder['id']], folder=True)
 
-        import pdb; pdb.set_trace()
         implicit_folder = path.endswith('/')
         parts = await self._resolve_path_to_ids(path)
-        print(parts)
         explicit_folder = parts[-1]['mimeType'] == self.FOLDER_MIME_TYPE
         if parts[-1]['id'] is None or implicit_folder != explicit_folder:
             raise exceptions.NotFoundError(str(path))
@@ -464,8 +461,6 @@ class GoogleDriveProvider(provider.BaseProvider):
                         path: WaterButlerPath,
                         item: dict,
                         raw: bool=False) -> Union[BaseGoogleDriveMetadata, dict]:
-        import pdb
-        #pdb.set_trace()
         if raw:
             return item
         if item['mimeType'] == self.FOLDER_MIME_TYPE:
@@ -636,8 +631,6 @@ class GoogleDriveProvider(provider.BaseProvider):
             item['version'] = item['etag'] + pd_settings.DRIVE_IGNORE_VERSION
 
         ser_item = self._serialize_item(path, item, raw=raw)
-        import pdb
-        #pdb.set_trace()
         return ser_item
 
     async def _folder_metadata(self,
@@ -658,11 +651,6 @@ class GoogleDriveProvider(provider.BaseProvider):
                     self._serialize_item(path.child(item['title']), item, raw=raw)
                     for item in resp_json['items']
                 ])
-                import logging
-                logger = logging.getLogger(__name__)
-                logger.debug('***\n  _folder_metadata()\n***')
-                import pdb
-                #pdb.set_trace()
                 built_url = resp_json.get('nextLink', None)
         return full_resp
 
@@ -700,8 +688,6 @@ class GoogleDriveProvider(provider.BaseProvider):
         :return: a metadata for the googledoc or the raw response object from the GDrive API
         """
 
-        import pdb
-        pdb.set_trace()
         self.metrics.add('_file_metadata.got_revision', revision is not None)
 
         valid_revision = revision and not revision.endswith(pd_settings.DRIVE_IGNORE_VERSION)
@@ -735,14 +721,12 @@ class GoogleDriveProvider(provider.BaseProvider):
         if utils.is_docs_file(data):
             if can_access_revisions:
                 docs = await self._handle_docs_versioning(path, data, raw=raw)
-                #pdb.set_trace()
                 return docs
             else:
                 # Revisions are not available for some sharing configurations. If revisions list is
                 # empty, use the etag of the file plus a sentinel string as a dummy revision ID.
                 data['version'] = data['etag'] + pd_settings.DRIVE_IGNORE_VERSION
 
-        #pdb.set_trace()
         return data if raw else GoogleDriveFileMetadata(data, path)
 
     async def _delete_folder_contents(self, path: WaterButlerPath) -> None:

--- a/waterbutler/providers/googledrive/provider.py
+++ b/waterbutler/providers/googledrive/provider.py
@@ -520,6 +520,8 @@ class GoogleDriveProvider(provider.BaseProvider):
                     # if we can't find an intermediate path part, that's an error
                     raise exceptions.MetadataError('{} not found'.format(str(path)),
                                                    code=HTTPStatus.NOT_FOUND)
+                if ext in ('.gdoc', '.gdraw', '.gslides', '.gsheet'):
+                    part_name = name
                 return ret + [{
                     'id': None,
                     'title': part_name,

--- a/waterbutler/providers/googledrive/utils.py
+++ b/waterbutler/providers/googledrive/utils.py
@@ -42,11 +42,11 @@ def get_mimetype_from_ext(ext):
             return format['mime_type']
 
 
-def get_format(metadata):
+def get_format(metadata, default=DOCS_DEFAULT_FORMAT):
     for format in DOCS_FORMATS:
         if format['mime_type'] == metadata['mimeType']:
             return format
-    return DOCS_DEFAULT_FORMAT
+    return default
 
 
 def get_extension(metadata):


### PR DESCRIPTION
# Ticket

https://openscience.atlassian.net/browse/SVCS-904

# Purpose

wb puts an extension on gdrive files so it can tell mfr how to render them, and to tell fangorn what icon to use. Because of this, when a file gets renamed, wb doesn't send a path that matches up with where the old on was on a rename, causing the osf to thing the second half of the rename to actually be a create. This change makes it so wb will send the actual name of the file on the storage provider, rather than modifying it. This change means osf finds the old file when it gets renamed, and the old file is modified to match the rename. rather than creating a new file_node.

As a side effect, mfr needs to be updated to not rely on the extension that wb used to suffix on the path. That PR is here: #352

# Changes

Depends on mfr pr also 
https://github.com/CenterForOpenScience/modular-file-renderer/pull/352

# Side effects

If multiple gdrive documents have the same name there may be some wierdness. Also

# QA Notes
# Deployment Notes