### PR TITLE
[PLAT-1310][PLAT-709] Add more client request info to Impact metrics / Wiki embed metrics

### DIFF
--- a/tests/auth/osf/test_handler.py
+++ b/tests/auth/osf/test_handler.py
@@ -78,17 +78,29 @@ class TestOsfAuthHandler(ServerTestCase):
             await self.handler.get(resource, provider, self.request, action=action, auth_type=auth_type)
             if auth_type is AuthType.SOURCE:
                 self.handler.build_payload.assert_called_with({
-                    'nid': resource,
-                    'provider': provider,
+                    'nid': 'test',
+                    'provider': 'test',
                     'action': 'download',
                     'path': '',
                     'version': None,
+                    'metrics': {
+                        'referrer': None,
+                        'origin': None,
+                        'uri': settings.API_URL,
+                        'user_agent': None
+                    }
                 }, cookie=None, view_only=None)
             else:
                 self.handler.build_payload.assert_called_with({
-                    'nid': resource,
-                    'provider': provider,
+                    'nid': 'test',
+                    'provider': 'test',
                     'action': 'upload',
                     'path': '',
                     'version': None,
+                    'metrics': {
+                        'referrer': None,
+                        'origin': None,
+                        'uri': settings.API_URL,
+                        'user_agent': None
+                    }
                 }, cookie=None, view_only=None)

--- a/waterbutler/auth/osf/handler.py
+++ b/waterbutler/auth/osf/handler.py
@@ -144,6 +144,12 @@ class OsfAuthHandler(BaseAuthHandler):
                 'action': osf_action,
                 'path': path,
                 'version': version,
+                'metrics': {
+                    'referrer': request.headers.get('Referer'),
+                    'user_agent': request.headers.get('User-Agent'),
+                    'origin': request.headers.get('Origin'),
+                    'uri': request.uri,
+                }
             }, cookie=cookie, view_only=view_only),
             headers,
             dict(request.cookies)


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/PLAT-1310
https://openscience.atlassian.net/browse/PLAT-709

## Purpose

Pass useful useful info for impact metrics back to the waterbutler auth callback so we can count them perfectly.

## Changes

- adds extra items to payload in auth handler and change test.

## Side effects

None that I know of.

## QA Notes

Not user-facing

## Deployment Notes

Should be deployed before corresponding OSF PR. https://github.com/CenterForOpenScience/osf.io/pull/8918
