### PR TITLE
[ENG-374] Upgrade Tornado From 4.3 to 5.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pytz==2017.2
 raven==5.27.0
 setuptools==37.0.0
 stevedore==1.2.0
-tornado==4.3
+tornado==5.1.1
 xmltodict==0.9.0
 
 # Issue: certifi-2015.9.6.1 and 2015.9.6.2 fail verification (https://github.com/certifi/python-certifi/issues/26)

--- a/tests/server/api/v1/fixtures.py
+++ b/tests/server/api/v1/fixtures.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import json
-import asyncio
 from unittest import mock
 
 import pytest
@@ -30,37 +29,6 @@ def http_request():
     mocked_http_request.request_time = mock.Mock(return_value=10)
     mocked_http_request.body = MockRequestBody()
     return mocked_http_request
-
-
-@pytest.fixture
-def handler(http_request):
-    mocked_handler = ProviderHandler(make_app(True), http_request)
-
-    mocked_handler.path_kwargs = {
-        'provider': 'test',
-        'path': '/file',
-        'resource': 'guid1'
-    }
-    mocked_handler.path = '/test_path'
-    mocked_handler.provider = MockProvider()
-    mocked_handler.requested_version = None
-
-    mocked_handler.resource = 'test_source_resource'
-    mocked_handler.metadata = MockFileMetadata()
-
-    mocked_handler.dest_path = '/test_dest_path'
-    mocked_handler.dest_provider = MockProvider()
-    mocked_handler.dest_resource = 'test_dest_resource'
-    mocked_handler.dest_meta = MockFileMetadata()
-    mocked_handler.arguments = {}
-    mocked_handler.write = mock.Mock()
-    mocked_handler.write_stream = MockCoroutine()
-    mocked_handler.redirect = mock.Mock()
-    mocked_handler.uploader = asyncio.Future()
-    mocked_handler.wsock = mock.Mock()
-    mocked_handler.writer = mock.Mock()
-
-    return mocked_handler
 
 
 @pytest.fixture
@@ -268,7 +236,3 @@ def serialized_metadata():
 def serialized_request():
     with open(os.path.join(os.path.dirname(__file__), 'fixtures/fixtures.json'), 'r') as fp:
         return json.load(fp)['serialized_request']
-
-
-
-

--- a/tests/server/api/v1/test_core.py
+++ b/tests/server/api/v1/test_core.py
@@ -1,42 +1,44 @@
 from unittest import mock
 
-from tests.server.api.v1.fixtures import (http_request, handler, mock_exc_info, mock_exc_info_202,
-                                          mock_exc_info_http)
+from tests.server.api.v1.utils import mock_handler
+from tests.server.api.v1.fixtures import (http_request, mock_exc_info,
+                                          mock_exc_info_202, mock_exc_info_http)
 
 
 class TestBaseHandler:
 
-    def test_write_error(self, handler, mock_exc_info):
+    def test_write_error(self, http_request, mock_exc_info):
+
+        handler = mock_handler(http_request)
         handler.finish = mock.Mock()
         handler.captureException = mock.Mock()
-
         handler.write_error(500, mock_exc_info)
-
         handler.finish.assert_called_with({'message': 'OK', 'code': 500})
         handler.captureException.assert_called_with(mock_exc_info)
 
-    def test_write_error_202(self, handler, mock_exc_info_202):
+    def test_write_error_202(self, http_request, mock_exc_info_202):
+
+        handler = mock_handler(http_request)
         handler.finish = mock.Mock()
         handler.captureException = mock.Mock()
-
         handler.write_error(500, mock_exc_info_202)
-
         handler.finish.assert_called_with()
         handler.captureException.assert_called_with(mock_exc_info_202, data={'level': 'info'})
 
     @mock.patch('tornado.web.app_log.error')
-    def test_log_exception_uncaught(self, mocked_error, handler, mock_exc_info):
+    def test_log_exception_uncaught(self, mocked_error, http_request, mock_exc_info):
 
+        handler = mock_handler(http_request)
         handler.log_exception(*mock_exc_info)
-
         mocked_error.assert_called_with('Uncaught exception %s\n',
                                         'GET /v1/resources/test/providers/test/path/mock (None)',
                                         exc_info=mock_exc_info)
 
     @mock.patch('tornado.web.gen_log.warning')
-    def test_log_exception_http_error(self, mocked_warning, handler, mock_exc_info_http):
-        handler.log_exception(*mock_exc_info_http)
+    def test_log_exception_http_error(self, mocked_warning, http_request, mock_exc_info_http):
 
+        handler = mock_handler(http_request)
+        handler.log_exception(*mock_exc_info_http)
         mocked_warning.assert_called_with('%d %s: test http exception',
                                           500,
                                           'GET /v1/resources/test/providers/test/path/mock (None)')

--- a/tests/server/api/v1/test_create_mixin.py
+++ b/tests/server/api/v1/test_create_mixin.py
@@ -3,17 +3,21 @@ from unittest import mock
 
 import pytest
 
-from tests.utils import MockCoroutine
 from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
-from tests.server.api.v1.fixtures import (http_request, handler, handler_auth, mock_folder_metadata,
-                                          mock_file_metadata)
+
+from tests.utils import MockCoroutine
+from tests.server.api.v1.utils import mock_handler
+from tests.server.api.v1.fixtures import (http_request, handler_auth,
+                                          mock_folder_metadata, mock_file_metadata)
 
 
 class TestValidatePut:
 
     @pytest.mark.asyncio
-    async def test_postvalidate_put_file(self, handler):
+    async def test_postvalidate_put_file(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/file')
         handler.kind = 'file'
         handler.get_query_argument = mock.Mock(return_value=None)
@@ -24,7 +28,9 @@ class TestValidatePut:
         handler.get_query_argument.assert_called_once_with('name', default=None)
 
     @pytest.mark.asyncio
-    async def test_postvalidate_put_folder(self, handler):
+    async def test_postvalidate_put_folder(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/Folder1/')
         handler.kind = 'folder'
         handler.get_query_argument = mock.Mock(return_value='child!')
@@ -39,7 +45,9 @@ class TestValidatePut:
             WaterButlerPath('/Folder1/child!', prepend=None))
 
     @pytest.mark.asyncio
-    async def test_postvalidate_put_folder_naming_conflict(self, handler):
+    async def test_postvalidate_put_folder_naming_conflict(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/Folder1/')
         handler.kind = 'folder'
         handler.get_query_argument = mock.Mock(return_value='child!')
@@ -57,7 +65,9 @@ class TestValidatePut:
             WaterButlerPath('/Folder1/child!', prepend=None))
 
     @pytest.mark.asyncio
-    async def test_postvalidate_put_cant_duplicate_names(self, handler):
+    async def test_postvalidate_put_cant_duplicate_names(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/Folder1/')
         handler.kind = 'folder'
         handler.provider.can_duplicate_names = mock.Mock(return_value=False)
@@ -72,7 +82,9 @@ class TestValidatePut:
         handler.provider.can_duplicate_names.assert_called_once_with()
 
     @pytest.mark.asyncio
-    async def test_postvalidate_put_cant_duplicate_names_and_naming_conflict(self, handler):
+    async def test_postvalidate_put_cant_duplicate_names_and_naming_conflict(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/Folder1/')
         handler.kind = 'folder'
         handler.provider.can_duplicate_names = mock.Mock(return_value=False)
@@ -90,7 +102,9 @@ class TestValidatePut:
         handler.provider.exists.assert_called_with(
             WaterButlerPath('/Folder1/child!', prepend=None))
 
-    def test_invalid_kind(self, handler):
+    def test_invalid_kind(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.get_query_argument = mock.Mock(return_value='notafolder')
 
         with pytest.raises(exceptions.InvalidParameters) as exc:
@@ -100,7 +114,9 @@ class TestValidatePut:
         assert exc.value.message == 'Kind must be file, folder or unspecified (interpreted as ' \
                                     'file), not notafolder'
 
-    def test_default_kind(self, handler):
+    def test_default_kind(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.get_query_argument = mock.Mock(return_value='file')
         handler.request.headers.get = mock.Mock(side_effect=Exception('Breakout'))
 
@@ -112,7 +128,9 @@ class TestValidatePut:
         handler.get_query_argument.assert_called_once_with('kind', default='file')
         handler.request.headers.get.assert_called_once_with('Content-Length')
 
-    def test_length_required_for_files(self, handler):
+    def test_length_required_for_files(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.request.headers = {}
         handler.get_query_argument = mock.Mock(return_value='file')
 
@@ -123,7 +141,9 @@ class TestValidatePut:
         assert exc.value.message == 'Content-Length is required for file uploads'
         handler.get_query_argument.assert_called_once_with('kind', default='file')
 
-    def test_payload_with_folder(self, handler):
+    def test_payload_with_folder(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.request.headers = {'Content-Length': 5000}
         handler.get_query_argument = mock.Mock(return_value='folder')
 
@@ -134,7 +154,9 @@ class TestValidatePut:
         assert exc.value.message == 'Folder creation requests may not have a body'
         handler.get_query_argument.assert_called_once_with('kind', default='file')
 
-    def test_payload_with_invalid_content_length(self, handler):
+    def test_payload_with_invalid_content_length(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.request.headers = {'Content-Length': 'notanumber'}
         handler.get_query_argument = mock.Mock(return_value='file')
 
@@ -146,7 +168,9 @@ class TestValidatePut:
         handler.get_query_argument.assert_called_once_with('kind', default='file')
 
     @pytest.mark.asyncio
-    async def test_name_required_for_dir(self, handler):
+    async def test_name_required_for_dir(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/', folder=True)
         handler.get_query_argument = mock.Mock(return_value=None)
 
@@ -157,7 +181,9 @@ class TestValidatePut:
         handler.get_query_argument.assert_called_once_with('name', default=None)
 
     @pytest.mark.asyncio
-    async def test_name_refused_for_file(self, handler):
+    async def test_name_refused_for_file(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/foo.txt', folder=False)
         handler.get_query_argument = mock.Mock(return_value='bar.txt')
 
@@ -168,7 +194,9 @@ class TestValidatePut:
         handler.get_query_argument.assert_called_once_with('name', default=None)
 
     @pytest.mark.asyncio
-    async def test_kind_must_be_folder(self, handler):
+    async def test_kind_must_be_folder(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/adlkjf')
         handler.get_query_argument = mock.Mock(return_value=None)
         handler.kind = 'folder'
@@ -185,7 +213,9 @@ class TestValidatePut:
 class TestCreateFolder:
 
     @pytest.mark.asyncio
-    async def test_create_folder(self, handler, mock_folder_metadata):
+    async def test_create_folder(self, http_request, mock_folder_metadata):
+
+        handler = mock_handler(http_request)
         handler.resource = '3rqws'
         handler.provider.create_folder = MockCoroutine(return_value=mock_folder_metadata)
         handler.target_path = WaterButlerPath('/apath/')
@@ -203,7 +233,9 @@ class TestCreateFolder:
 class TestUploadFile:
 
     @pytest.mark.asyncio
-    async def test_created(self, handler, mock_file_metadata):
+    async def test_created(self, http_request, mock_file_metadata):
+
+        handler = mock_handler(http_request)
         handler.resource = '3rqws'
         handler.uploader.set_result((mock_file_metadata, True))
         handler.set_status = mock.Mock()
@@ -218,7 +250,9 @@ class TestUploadFile:
         })
 
     @pytest.mark.asyncio
-    async def test_not_created(self, handler, mock_file_metadata):
+    async def test_not_created(self, http_request, mock_file_metadata):
+
+        handler = mock_handler(http_request)
         handler.resource = '3rqws'
         handler.uploader.set_result((mock_file_metadata, False))
         handler.set_status = mock.Mock()
@@ -231,4 +265,3 @@ class TestUploadFile:
         handler.write.assert_called_once_with({
             'data': mock_file_metadata.json_api_serialized('3rqws')
         })
-

--- a/tests/server/api/v1/test_metadata_mixin.py
+++ b/tests/server/api/v1/test_metadata_mixin.py
@@ -19,10 +19,9 @@ class TestMetadataMixin:
         await handler.header_file_metadata()
 
         assert handler._headers['Content-Length'] == '1337'
-        assert handler._headers['Last-Modified'] == b'Wed, 25 Sep 1991 18:20:30 GMT'
-        assert handler._headers['Content-Type'] == b'application/octet-stream'
-        expected = bytes(json.dumps(mock_file_metadata.json_api_serialized(handler.resource)),
-                         'latin-1')
+        assert handler._headers['Last-Modified'] == 'Wed, 25 Sep 1991 18:20:30 GMT'
+        assert handler._headers['Content-Type'] == 'application/octet-stream'
+        expected = json.dumps(mock_file_metadata.json_api_serialized(handler.resource))
         assert handler._headers['X-Waterbutler-Metadata'] == expected
 
     @pytest.mark.asyncio
@@ -87,9 +86,9 @@ class TestMetadataMixin:
 
         await handler.download_file()
 
-        assert handler._headers['Content-Length'] == bytes(str(mock_stream.size), 'latin-1')
-        assert handler._headers['Content-Type'] == bytes(mock_stream.content_type, 'latin-1')
-        disposition = b'attachment; filename="peanut-butter.docx"; filename*=UTF-8\'\'peanut-butter.docx'
+        assert handler._headers['Content-Length'] == str(mock_stream.size)
+        assert handler._headers['Content-Type'] == mock_stream.content_type
+        disposition = 'attachment; filename="peanut-butter.docx"; filename*=UTF-8\'\'peanut-butter.docx'
         assert handler._headers['Content-Disposition'] == disposition
 
         handler.write_stream.assert_awaited_once()
@@ -102,18 +101,18 @@ class TestMetadataMixin:
 
         await handler.download_file()
 
-        assert handler._headers['Content-Length'] == bytes(str(mock_stream.size), 'latin-1')
-        assert handler._headers['Content-Type'] == bytes(mock_stream.content_type, 'latin-1')
-        disposition = b'attachment; filename="test_file"; filename*=UTF-8\'\'test_file'
+        assert handler._headers['Content-Length'] == str(mock_stream.size)
+        assert handler._headers['Content-Type'] == mock_stream.content_type
+        disposition = 'attachment; filename="test_file"; filename*=UTF-8\'\'test_file'
         assert handler._headers['Content-Disposition'] == disposition
 
         handler.write_stream.assert_awaited_once()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("given_arg,expected_name,filtered_name", [
-        (['résumé.doc'], b'r%C3%A9sum%C3%A9.doc', b'resume.doc'),
-        ([''],           b'test_file',            b'test_file'),
-        ([],             b'test_file',            b'test_file'),
+        (['résumé.doc'], 'r%C3%A9sum%C3%A9.doc', 'resume.doc'),
+        ([''],           'test_file',            'test_file'),
+        ([],             'test_file',            'test_file'),
     ])
     async def test_download_file_with_display_name(self, handler, mock_stream, given_arg,
                                                    expected_name, filtered_name):
@@ -124,9 +123,9 @@ class TestMetadataMixin:
 
         await handler.download_file()
 
-        assert handler._headers['Content-Length'] == bytes(str(mock_stream.size), 'latin-1')
-        assert handler._headers['Content-Type'] == bytes(mock_stream.content_type, 'latin-1')
-        disposition = b'attachment; filename="' + filtered_name + b'"; filename*=UTF-8\'\'' + expected_name
+        assert handler._headers['Content-Length'] == str(mock_stream.size)
+        assert handler._headers['Content-Type'] == mock_stream.content_type
+        disposition = 'attachment; filename="' + filtered_name + '"; filename*=UTF-8\'\'' + expected_name
         assert handler._headers['Content-Disposition'] == disposition
 
         handler.write_stream.assert_awaited_once()
@@ -140,8 +139,7 @@ class TestMetadataMixin:
 
         await handler.download_file()
 
-        assert handler._headers['Content-Range'] == bytes(mock_partial_stream.content_range,
-                                                          'latin-1')
+        assert handler._headers['Content-Range'] == mock_partial_stream.content_range
         assert handler.get_status() == 206
         handler.write_stream.assert_called_once_with(mock_partial_stream)
 
@@ -168,7 +166,7 @@ class TestMetadataMixin:
         await handler.download_file()
 
         handler.write_stream.assert_called_once_with(mock_stream)
-        assert handler._headers['Content-Type'] == bytes(mimetype, 'latin-1')
+        assert handler._headers['Content-Type'] == mimetype
 
     @pytest.mark.asyncio
     async def test_file_metadata(self, handler, mock_file_metadata):
@@ -211,8 +209,8 @@ class TestMetadataMixin:
 
         await handler.download_folder_as_zip()
 
-        assert handler._headers['Content-Type'] == bytes('application/zip', 'latin-1')
-        expected = b'attachment; filename="test_file.zip"; filename*=UTF-8\'\'test_file.zip'
+        assert handler._headers['Content-Type'] == 'application/zip'
+        expected = 'attachment; filename="test_file.zip"; filename*=UTF-8\'\'test_file.zip'
         assert handler._headers['Content-Disposition'] == expected
 
         handler.write_stream.assert_called_once_with(mock_stream)
@@ -225,8 +223,8 @@ class TestMetadataMixin:
 
         await handler.download_folder_as_zip()
 
-        assert handler._headers['Content-Type'] == bytes('application/zip', 'latin-1')
-        expected = b'attachment; filename="MockProvider-archive.zip"; filename*=UTF-8\'\'MockProvider-archive.zip'
+        assert handler._headers['Content-Type'] == 'application/zip'
+        expected = 'attachment; filename="MockProvider-archive.zip"; filename*=UTF-8\'\'MockProvider-archive.zip'
         assert handler._headers['Content-Disposition'] == expected
 
         handler.write_stream.assert_called_once_with(mock_stream)

--- a/tests/server/api/v1/test_movecopy.py
+++ b/tests/server/api/v1/test_movecopy.py
@@ -2,7 +2,8 @@ import pytest
 
 from waterbutler.core import exceptions
 
-from tests.server.api.v1.fixtures import (http_request, handler, move_copy_args, handler_auth,
+from tests.server.api.v1.utils import mock_handler
+from tests.server.api.v1.fixtures import (http_request, move_copy_args, handler_auth,
                                           patch_auth_handler, serialized_request,
                                           serialized_metadata, celery_src_copy_params,
                                           celery_dest_copy_params, celery_dest_copy_params_root,
@@ -13,11 +14,13 @@ from tests.server.api.v1.fixtures import (http_request, handler, move_copy_args,
 @pytest.mark.usefixtures('patch_auth_handler', 'patch_make_provider_move_copy')
 class TestMoveOrCopy:
 
-    def test_build_args(self, handler, move_copy_args):
+    def test_build_args(self, http_request, move_copy_args):
+        handler = mock_handler(http_request)
         assert handler.build_args() == move_copy_args
 
     @pytest.mark.asyncio
-    async def test_move_or_copy_invalid_action(self, handler):
+    async def test_move_or_copy_invalid_action(self, http_request):
+        handler = mock_handler(http_request)
         handler._json = {'action': 'invalid'}
 
         with pytest.raises(exceptions.InvalidParameters) as exc:
@@ -26,7 +29,8 @@ class TestMoveOrCopy:
         assert exc.value.message == 'Auth action must be "copy", "move", or "rename", not "invalid"'
 
     @pytest.mark.asyncio
-    async def test_move_or_copy_invalid_path(self, handler):
+    async def test_move_or_copy_invalid_path(self, http_request):
+        handler = mock_handler(http_request)
         handler._json = {'action': 'copy'}
 
         with pytest.raises(exceptions.InvalidParameters) as exc:
@@ -35,7 +39,8 @@ class TestMoveOrCopy:
         assert exc.value.message == '"path" field is required for moves or copies'
 
     @pytest.mark.asyncio
-    async def test_move_or_copy_invalid_path_slash(self, handler):
+    async def test_move_or_copy_invalid_path_slash(self, http_request):
+        handler = mock_handler(http_request)
         handler._json = {'action': 'copy', 'path': '/file'}
         with pytest.raises(exceptions.InvalidParameters) as exc:
             await handler.move_or_copy()
@@ -45,9 +50,10 @@ class TestMoveOrCopy:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('action', ['move', 'copy'])
-    async def test_inter_move_copy(self, action, handler, mock_inter, mock_file_metadata,
+    async def test_inter_move_copy(self, action, http_request, mock_inter, mock_file_metadata,
                                    serialized_metadata, celery_src_copy_params,
                                    celery_dest_copy_params, serialized_request):
+        handler = mock_handler(http_request)
         mock_make_provider, mock_celery = mock_inter
         handler._json = {'action': action, 'path': '/test_path/'}
 
@@ -67,8 +73,9 @@ class TestMoveOrCopy:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('action', ['move', 'copy'])
-    async def test_intra_move_copy(self, action, handler, mock_intra, serialized_metadata,
+    async def test_intra_move_copy(self, action, http_request, mock_intra, serialized_metadata,
                                    mock_file_metadata):
+        handler = mock_handler(http_request)
         handler._json = {'action': action, 'path': '/test_path/'}
         mock_make_provider, mock_celery = mock_intra
 
@@ -88,7 +95,8 @@ class TestMoveOrCopy:
         assert handler.dest_meta == mock_file_metadata
 
     @pytest.mark.asyncio
-    async def test_invalid_rename(self, handler):
+    async def test_invalid_rename(self, http_request):
+        handler = mock_handler(http_request)
         handler._json = {'action': 'rename', 'path': '/test_path/'}
 
         with pytest.raises(exceptions.InvalidParameters) as exc:
@@ -97,7 +105,8 @@ class TestMoveOrCopy:
         assert exc.value.message == '"rename" field is required for renaming'
 
     @pytest.mark.asyncio
-    async def test_move_or_copy_invalid_rename_root(self, handler):
+    async def test_move_or_copy_invalid_rename_root(self, http_request):
+        handler = mock_handler(http_request)
         handler._json = {'action': 'copy', 'path': '/'}
         handler.path = '/'
 
@@ -107,10 +116,11 @@ class TestMoveOrCopy:
         assert exc.value.message == '"rename" field is required for copying root'
 
     @pytest.mark.asyncio
-    async def test_rename(self, handler_auth, handler, mock_inter, mock_file_metadata,
+    async def test_rename(self, handler_auth, http_request, mock_inter, mock_file_metadata,
                           serialized_metadata, celery_src_copy_params,
                           celery_dest_copy_params_root, serialized_request):
 
+        handler = mock_handler(http_request)
         mock_make_provider, mock_celery = mock_inter
         handler._json = {'action': 'rename', 'rename': 'renamed path', 'path': '/test_path/'}
 

--- a/tests/server/api/v1/test_provider.py
+++ b/tests/server/api/v1/test_provider.py
@@ -4,11 +4,12 @@ from unittest import mock
 import pytest
 
 from waterbutler.core.path import WaterButlerPath
-from waterbutler.server.api.v1.provider import ProviderHandler, list_or_value
+from waterbutler.server.api.v1.provider import list_or_value
 
+from tests.server.api.v1.utils import mock_handler
 from tests.utils import MockCoroutine, MockStream, MockWriter, MockProvider
-from tests.server.api.v1.fixtures import (http_request, handler, patch_auth_handler, handler_auth,
-                                          patch_make_provider_core)
+from tests.server.api.v1.fixtures import (http_request, patch_auth_handler,
+                                          handler_auth, patch_make_provider_core)
 
 
 class TestUtils:
@@ -25,15 +26,17 @@ class TestUtils:
 class TestProviderHandler:
 
     @pytest.mark.asyncio
-    async def test_prepare(self, handler, patch_auth_handler, patch_make_provider_core):
+    async def test_prepare(self, http_request, patch_auth_handler, patch_make_provider_core):
+        handler = mock_handler(http_request)
         await handler.prepare()
 
         # check that X-WATERBUTLER-REQUEST-ID is valid UUID
         assert UUID(handler._headers['X-WATERBUTLER-REQUEST-ID'], version=4)
 
     @pytest.mark.asyncio
-    async def test_prepare_put(self, handler, patch_auth_handler, patch_make_provider_core,
+    async def test_prepare_put(self, http_request, patch_auth_handler, patch_make_provider_core,
                                handler_auth):
+        handler = mock_handler(http_request)
         handler.request.method = 'PUT'
         handler.request.headers['Content-Length'] = 100
         await handler.prepare()
@@ -46,12 +49,16 @@ class TestProviderHandler:
         assert UUID(handler._headers['X-WATERBUTLER-REQUEST-ID'], version=4)
 
     @pytest.mark.asyncio
-    async def test_prepare_stream(self, handler):
+    async def test_prepare_stream(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.target_path = WaterButlerPath('/file')
         await handler.prepare_stream()
 
     @pytest.mark.asyncio
-    async def test_head(self, handler):
+    async def test_head(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/file')
         handler.header_file_metadata = MockCoroutine()
 
@@ -60,7 +67,9 @@ class TestProviderHandler:
         handler.header_file_metadata.assert_called_with()
 
     @pytest.mark.asyncio
-    async def test_get_folder(self, handler):
+    async def test_get_folder(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/folder/')
         handler.get_folder = MockCoroutine()
 
@@ -69,7 +78,9 @@ class TestProviderHandler:
         handler.get_folder.assert_called_once_with()
 
     @pytest.mark.asyncio
-    async def test_get_file(self, handler):
+    async def test_get_file(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/file')
         handler.get_file = MockCoroutine()
 
@@ -78,7 +89,9 @@ class TestProviderHandler:
         handler.get_file.assert_called_once_with()
 
     @pytest.mark.asyncio
-    async def test_put_file(self, handler):
+    async def test_put_file(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.target_path = WaterButlerPath('/file')
         handler.upload_file = MockCoroutine()
 
@@ -87,7 +100,9 @@ class TestProviderHandler:
         handler.upload_file.assert_called_once_with()
 
     @pytest.mark.asyncio
-    async def test_put_folder(self, handler):
+    async def test_put_folder(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.target_path = WaterButlerPath('/folder/')
         handler.create_folder = MockCoroutine()
 
@@ -96,7 +111,9 @@ class TestProviderHandler:
         handler.create_folder.assert_called_once_with()
 
     @pytest.mark.asyncio
-    async def test_delete(self, handler):
+    async def test_delete(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/folder/')
         handler.provider.delete = MockCoroutine()
 
@@ -106,7 +123,9 @@ class TestProviderHandler:
                                                         confirm_delete=0)
 
     @pytest.mark.asyncio
-    async def test_delete_confirm_delete(self, handler):
+    async def test_delete_confirm_delete(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/folder/')
         handler.provider.delete = MockCoroutine()
         handler.request.query_arguments['confirm_delete'] = '1'
@@ -117,7 +136,9 @@ class TestProviderHandler:
                                                    confirm_delete=1)
 
     @pytest.mark.asyncio
-    async def test_data_received(self, handler):
+    async def test_data_received(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/folder/')
         handler.stream = None
         handler.body = b''
@@ -128,7 +149,9 @@ class TestProviderHandler:
         assert handler.body == b'1234567890'
 
     @pytest.mark.asyncio
-    async def test_data_received_stream(self, handler):
+    async def test_data_received_stream(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.path = WaterButlerPath('/folder/')
         handler.stream = MockStream()
         handler.writer = MockWriter()
@@ -142,7 +165,9 @@ class TestProviderHandler:
 class TestProviderHandlerFinish:
 
     @pytest.mark.asyncio
-    async def test_on_finish_download_file(self, handler):
+    async def test_on_finish_download_file(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.request.method = 'GET'
         handler.path = WaterButlerPath('/file')
         handler._send_hook = mock.Mock()
@@ -151,7 +176,9 @@ class TestProviderHandlerFinish:
         handler._send_hook.assert_called_once_with('download_file')
 
     @pytest.mark.asyncio
-    async def test_on_finish_download_zip(self, handler):
+    async def test_on_finish_download_zip(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.request.method = 'GET'
         handler.request.query_arguments['zip'] = ''
         handler.path = WaterButlerPath('/folder/')
@@ -161,7 +188,9 @@ class TestProviderHandlerFinish:
         handler._send_hook.assert_called_once_with('download_zip')
 
     @pytest.mark.asyncio
-    async def test_dont_send_hook_on_file_metadata(self, handler):
+    async def test_dont_send_hook_on_file_metadata(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.request.query_arguments['meta'] = ''
         handler.request.method = 'GET'
         handler._send_hook = mock.Mock()
@@ -170,7 +199,9 @@ class TestProviderHandlerFinish:
         assert not handler._send_hook.called
 
     @pytest.mark.asyncio
-    async def test_dont_send_hook_on_folder_metadata(self, handler):
+    async def test_dont_send_hook_on_folder_metadata(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.request.method = 'GET'
         handler.path = WaterButlerPath('/folder/')
         handler._send_hook = mock.Mock()
@@ -179,7 +210,9 @@ class TestProviderHandlerFinish:
         assert not handler._send_hook.called
 
     @pytest.mark.asyncio
-    async def test_dont_send_hook_for_revisions(self, handler):
+    async def test_dont_send_hook_for_revisions(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.request.query_arguments['revisions'] = ''
         handler.request.method = 'GET'
         handler._send_hook = mock.Mock()
@@ -188,7 +221,9 @@ class TestProviderHandlerFinish:
         assert not handler._send_hook.called
 
     @pytest.mark.asyncio
-    async def test_on_finish_update(self, handler):
+    async def test_on_finish_update(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.request.method = 'PUT'
         handler.path = WaterButlerPath('/file')
         handler._send_hook = mock.Mock()
@@ -197,7 +232,9 @@ class TestProviderHandlerFinish:
         handler._send_hook.assert_called_once_with('update')
 
     @pytest.mark.asyncio
-    async def test_on_finish_create(self, handler):
+    async def test_on_finish_create(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.request.method = 'PUT'
         handler._status_code = 201
         handler.target_path = WaterButlerPath('/file')
@@ -207,7 +244,9 @@ class TestProviderHandlerFinish:
         handler._send_hook.assert_called_once_with('create')
 
     @pytest.mark.asyncio
-    async def test_on_finish_create_folder(self, handler):
+    async def test_on_finish_create_folder(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.request.method = 'PUT'
         handler._status_code = 201
         handler.target_path = WaterButlerPath('/folder/')
@@ -217,7 +256,9 @@ class TestProviderHandlerFinish:
         handler._send_hook.assert_called_once_with('create_folder')
 
     @pytest.mark.asyncio
-    async def test_on_finish_move(self, handler):
+    async def test_on_finish_move(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.request.method = 'POST'
         handler.body = b'{"action": "rename"}'
         handler.target_path = WaterButlerPath('/folder/')
@@ -227,7 +268,9 @@ class TestProviderHandlerFinish:
         handler._send_hook.assert_called_once_with('move')
 
     @pytest.mark.asyncio
-    async def test_on_finish_copy(self, handler):
+    async def test_on_finish_copy(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.request.method = 'POST'
         handler.body = b'{"action": "copy"}'
         handler.target_path = WaterButlerPath('/folder/')
@@ -237,7 +280,9 @@ class TestProviderHandlerFinish:
         handler._send_hook.assert_called_once_with('copy')
 
     @pytest.mark.asyncio
-    async def test_on_finish_delete(self, handler):
+    async def test_on_finish_delete(self, http_request):
+
+        handler = mock_handler(http_request)
         handler.request.method = 'DELETE'
         handler.target_path = WaterButlerPath('/file')
         handler._send_hook = mock.Mock()
@@ -250,9 +295,10 @@ class TestProviderHandlerFinish:
         ('HEAD'),
         ('OPTIONS'),
     ])
-    async def test_dont_send_hook_for_method(self, handler, method):
+    async def test_dont_send_hook_for_method(self, http_request, method):
         """Not all HTTP methods merit a callback."""
 
+        handler = mock_handler(http_request)
         handler.request.method = method
         handler._send_hook = mock.Mock()
 
@@ -266,10 +312,11 @@ class TestProviderHandlerFinish:
         (400), (401), (403),
         (500), (501), (502),
     ])
-    async def test_dont_send_hook_for_status(self, handler, status):
+    async def test_dont_send_hook_for_status(self, http_request, status):
         """Callbacks are only called for successful, entirely complete respsonses.  See comments
         in `on_finish` for further explanation."""
 
+        handler = mock_handler(http_request)
         handler._status_code = status
         handler._send_hook = mock.Mock()
 
@@ -277,10 +324,11 @@ class TestProviderHandlerFinish:
         assert not handler._send_hook.called
 
     @pytest.mark.asyncio
-    async def test_logging_direct_partial_download_file(self, handler):
+    async def test_logging_direct_partial_download_file(self, http_request):
         """For now, make sure partial+direct download requests get logged.  Behaviour may be
         changed in the future."""
 
+        handler = mock_handler(http_request)
         handler.request.method = 'GET'
         handler.path = WaterButlerPath('/file')
         handler._status_code = 302

--- a/tests/server/api/v1/test_provider.py
+++ b/tests/server/api/v1/test_provider.py
@@ -29,7 +29,7 @@ class TestProviderHandler:
         await handler.prepare()
 
         # check that X-WATERBUTLER-REQUEST-ID is valid UUID
-        assert UUID(handler._headers['X-WATERBUTLER-REQUEST-ID'].decode('utf-8'), version=4)
+        assert UUID(handler._headers['X-WATERBUTLER-REQUEST-ID'], version=4)
 
     @pytest.mark.asyncio
     async def test_prepare_put(self, handler, patch_auth_handler, patch_make_provider_core,
@@ -43,7 +43,7 @@ class TestProviderHandler:
         assert handler.path == WaterButlerPath('/file', prepend=None)
 
         # check that X-WATERBUTLER-REQUEST-ID is valid UUID
-        assert UUID(handler._headers['X-WATERBUTLER-REQUEST-ID'].decode('utf-8'), version=4)
+        assert UUID(handler._headers['X-WATERBUTLER-REQUEST-ID'], version=4)
 
     @pytest.mark.asyncio
     async def test_prepare_stream(self, handler):

--- a/tests/server/api/v1/utils.py
+++ b/tests/server/api/v1/utils.py
@@ -1,10 +1,15 @@
 import os
 import asyncio
+from unittest.mock import Mock
 
 from tornado import testing
 from tornado.platform.asyncio import AsyncIOMainLoop
 
 from waterbutler.server.app import make_app
+from waterbutler.server.api.v1.provider import ProviderHandler
+
+from tests.server.api.v1.fixtures import http_request
+from tests.utils import MockProvider, MockFileMetadata, MockCoroutine
 
 
 class ServerTestCase(testing.AsyncHTTPTestCase):
@@ -28,3 +33,36 @@ class ServerTestCase(testing.AsyncHTTPTestCase):
 
     def get_new_ioloop(self):
         return AsyncIOMainLoop()
+
+
+def mock_handler(http_request):
+    """
+    Mock WB Provider Handler.
+
+    Since tornado 5.0, handler cannot be shared between tests as fixtures when the testing tornado
+    web server is started with ``autoreload=True``, which is enabled automatically if debug mode is
+    on. Although setting either ``autoreload==False`` or ``Debug=False`` fixes the issue, it is
+    still better to take this mock handler out from fixtures.
+
+    :param http_request: the mocked HTTP request that is required to start the tornado web app
+    :return: a mocked handler
+    """
+    handler = ProviderHandler(make_app(True), http_request)
+    handler.path_kwargs = {'provider': 'test', 'path': '/file', 'resource': 'guid1'}
+    handler.path = '/test_path'
+    handler.provider = MockProvider()
+    handler.requested_version = None
+    handler.resource = 'test_source_resource'
+    handler.metadata = MockFileMetadata()
+    handler.dest_path = '/test_dest_path'
+    handler.dest_provider = MockProvider()
+    handler.dest_resource = 'test_dest_resource'
+    handler.dest_meta = MockFileMetadata()
+    handler.arguments = {}
+    handler.write = Mock()
+    handler.write_stream = MockCoroutine()
+    handler.redirect = Mock()
+    handler.uploader = asyncio.Future()
+    handler.wsock = Mock()
+    handler.writer = Mock()
+    return handler

--- a/waterbutler/server/app.py
+++ b/waterbutler/server/app.py
@@ -49,8 +49,6 @@ def make_app(debug):
 
 
 def serve():
-    tornado.platform.asyncio.AsyncIOMainLoop().install()
-
     app = make_app(server_settings.DEBUG)
 
     ssl_options = None

--- a/waterbutler/server/app.py
+++ b/waterbutler/server/app.py
@@ -43,6 +43,7 @@ def make_app(debug):
         api_to_handlers(v1) +
         [(r'/status', handlers.StatusHandler)],
         debug=debug,
+        autoreload=False
     )
     app.sentry_client = AsyncSentryClient(settings.SENTRY_DSN, release=__version__)
     return app


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-374

## Purpose

Upgrade `tornado` from 4.3 to 5.1.1, required for `aiohttp` 0.18->3.5 upgrade

- [ ] Should we upgrade all the way to 6.0.x?
- [x] This PR replaces https://github.com/CenterForOpenScience/waterbutler/pull/358

## Changes

* Updated requirements for tornado5
* Removed redundant reference to `AsyncIOMainLoop`
  * Starting 5.0, tornado automatically uses the `asyncio` event loop. See
http://www.tornadoweb.org/en/stable/asyncio.html for detailed info.
* Fixed tests
  * `RequestHandler._headers[<header_name>]` returns a byte string in 4.3 but a string in 4.4. This affects tests where we had to do byte-str conversion before/during comparison, which breaks and is no longer needed as well.
  * In tornado, setting `debug=True` automatically sets `autoreload=True`. Starting 5.0, `autoreload` breaks WB unit tests where WB's `ProviderHandler` (inherits tornado's `RequestHandler`) is declared as a fixture. Every other test throws "RuntimeError: Event loop is closed", probably caused by sharing the handler and thus the event loop which has been closed in the one test before the current one.
* Further improvement (optional)
  * Refactored mock handler from a test fixture (which is shared between tests) to a utility function (which gets called by each test). This fixes the "closed event loop" issue caused by `autoreload` in tornado 5.0 breaking shared request handler in tests.

## Side effects

No

## QA Notes

Although this PR is part of the prerequisites for aiohttp3 upgrade, it is recommended to test WB with only this tornado upgrade. Full regression test is required if this follows staging 1 -> test -> prod path. Otherwise if goes to staging 3 (or another dedicated aiohttp3 server), probably quick spot checking is good enough.

- [ ] Need advice on QA tests

## Deployment Notes

No
