### PR TITLE
[OathPit] Throw the Box Provider into OathPit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
             # 'owncloud = waterbutler.providers.owncloud:OwnCloudProvider',
             # 's3 = waterbutler.providers.s3:S3Provider',
             # 'dataverse = waterbutler.providers.dataverse:DataverseProvider',
-            # 'box = waterbutler.providers.box:BoxProvider',
+            'box = waterbutler.providers.box:BoxProvider',
             # 'googledrive = waterbutler.providers.googledrive:GoogleDriveProvider',
             # 'onedrive = waterbutler.providers.onedrive:OneDriveProvider',
             'googlecloud = waterbutler.providers.googlecloud:GoogleCloudProvider',

--- a/tasks.py
+++ b/tasks.py
@@ -90,7 +90,6 @@ def test(ctx, verbose=False, types=False, nocov=False, provider=None, path=None)
 
     # TODO: update this ignore list when new providers are added
     ignored_providers = '--ignore=tests/providers/bitbucket/ ' \
-                        '--ignore=tests/providers/box/ ' \
                         '--ignore=tests/providers/cloudfiles/ ' \
                         '--ignore=tests/providers/dataverse/ ' \
                         '--ignore=tests/providers/dropbox/ ' \

--- a/tests/providers/box/test_provider.py
+++ b/tests/providers/box/test_provider.py
@@ -84,10 +84,10 @@ class TestValidatePath:
         good_url = provider.build_url('files', file_id, fields='id,name,path_collection')
         bad_url = provider.build_url('folders', file_id, fields='id,name,path_collection')
 
-        aiohttpretty.register_json_uri('get', good_url,
+        aiohttpretty.register_json_uri('GET', good_url,
                                        body=root_provider_fixtures['file_metadata']['entries'][0],
                                        status=200)
-        aiohttpretty.register_uri('get', bad_url, status=404)
+        aiohttpretty.register_uri('GET', bad_url, status=404)
 
         try:
             wb_path_v1 = await provider.validate_v1_path('/' + file_id)
@@ -112,10 +112,10 @@ class TestValidatePath:
         good_url = provider.build_url('folders', folder_id, fields='id,name,path_collection')
         bad_url = provider.build_url('files', folder_id, fields='id,name,path_collection')
 
-        aiohttpretty.register_json_uri('get', good_url,
+        aiohttpretty.register_json_uri('GET', good_url,
                                        body=root_provider_fixtures['folder_object_metadata'],
                                        status=200)
-        aiohttpretty.register_uri('get', bad_url, status=404)
+        aiohttpretty.register_uri('GET', bad_url, status=404)
         try:
             wb_path_v1 = await provider.validate_v1_path('/' + folder_id + '/')
         except Exception as exc:
@@ -448,11 +448,13 @@ class TestUpload:
         responses = [
             {
                 'body': json.dumps(root_provider_fixtures['upload_part_one']),
-                'status': 201
+                'status': 201,
+                'headers': {'Content-Type': 'application/json'},
             },
             {
                 'body': json.dumps(root_provider_fixtures['upload_part_two']),
-                'status': 201
+                'status': 201,
+                'headers': {'Content-Type': 'application/json'},
             }
         ]
 
@@ -595,7 +597,7 @@ class TestDelete:
 
         url = provider.build_url('files', item['id'], fields='id,name,path_collection')
         delete_url = provider.build_url('files', path.identifier)
-        aiohttpretty.register_json_uri('get', url,
+        aiohttpretty.register_json_uri('GET', url,
                                        body=root_provider_fixtures['file_metadata']['entries'][0])
         aiohttpretty.register_json_uri('DELETE', delete_url, status=204)
 

--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -153,14 +153,14 @@ class BoxProvider(provider.BaseProvider):
     async def revalidate_path(self, base: WaterButlerPath, path: str,
                               folder: bool=None) -> WaterButlerPath:
         # TODO Research the search api endpoint
-        async with self.request(
+        response = await self.make_request(
             'GET',
             self.build_url('folders', base.identifier, 'items',
                            fields='id,name,type', limit=1000),
             expects=(200,),
-            throws=exceptions.ProviderError
-        ) as resp:
-            data = await resp.json()
+            throws=exceptions.ProviderError,
+        )
+        data = await response.json()
         lower_name = path.lower()
 
         try:
@@ -202,24 +202,24 @@ class BoxProvider(provider.BaseProvider):
         if dest_path.identifier is not None:
             await dest_provider.delete(dest_path)
 
-        async with self.request(
+        response = await self.make_request(
             'POST',
             self.build_url(
                 'files' if src_path.is_file else 'folders',
                 src_path.identifier,
                 'copy'
             ),
-            data=json.dumps({
+            data={
                 'name': dest_path.name,
                 'parent': {
                     'id': dest_path.parent.identifier
                 }
-            }),
+            },
             headers={'Content-Type': 'application/json'},
             expects=(200, 201),
-            throws=exceptions.IntraCopyError
-        ) as resp:
-            data = await resp.json()
+            throws=exceptions.IntraCopyError,
+        )
+        data = await response.json()
 
         return await self._intra_move_copy_metadata(dest_path, data)
 
@@ -229,23 +229,23 @@ class BoxProvider(provider.BaseProvider):
         if dest_path.identifier is not None and str(dest_path).lower() != str(src_path).lower():
             await dest_provider.delete(dest_path)
 
-        async with self.request(
+        response = await self.make_request(
             'PUT',
             self.build_url(
                 'files' if src_path.is_file else 'folders',
                 src_path.identifier,
             ),
-            data=json.dumps({
+            data={
                 'name': dest_path.name,
                 'parent': {
                     'id': dest_path.parent.identifier
                 }
-            }),
+            },
             headers={'Content-Type': 'application/json'},
             expects=(200, 201),
-            throws=exceptions.IntraCopyError
-        ) as resp:
-            data = await resp.json()
+            throws=exceptions.IntraCopyError,
+        )
+        data = await response.json()
 
         return await self._intra_move_copy_metadata(dest_path, data)
 
@@ -255,11 +255,10 @@ class BoxProvider(provider.BaseProvider):
             'Authorization': 'Bearer {}'.format(self.token),
         }
 
-    async def make_request(self, *args, **kwargs) -> aiohttp.client.ClientResponse:
+    async def make_request(self, method: str, url: str, *args, **kwargs) -> aiohttp.ClientResponse:
         if isinstance(kwargs.get('data'), dict):
             kwargs['data'] = json.dumps(kwargs['data'])
-
-        return await super().make_request(*args, **kwargs)
+        return await super().make_request(method, url, *args, **kwargs)
 
     async def download(self,  # type: ignore
                        path: WaterButlerPath, revision: str=None, range: Tuple[int, int]=None,
@@ -331,12 +330,15 @@ class BoxProvider(provider.BaseProvider):
         else:
             url = self.build_url('folders', path.identifier, recursive=True)
 
-        async with self.request(
-            'DELETE', url,
+        response = await self.make_request(
+            'DELETE',
+            url,
             expects=(204, ),
             throws=exceptions.DeleteError,
-        ):
-            return  # Ensures the response is properly released
+        )
+        await response.release()
+
+        return  # Ensures the response is properly released
 
     async def metadata(self,  # type: ignore
                        path: WaterButlerPath, raw: bool=False, folder=False, revision=None,
@@ -353,15 +355,15 @@ class BoxProvider(provider.BaseProvider):
         # Alert: Versions are only tracked for Box users with premium accounts.
         # Few users will have a premium account, return only current if not
         curr = await self.metadata(path, raw=True)
-        async with self.request(
+        response = await self.make_request(
             'GET',
             self.build_url('files', path.identifier, 'versions'),
             expects=(200, 403),
             throws=exceptions.RevisionsError,
-        ) as response:
-            data = await response.json()
+        )
+        data = await response.json()
 
-            revisions = data['entries'] if response.status == HTTPStatus.OK else []
+        revisions = data['entries'] if response.status == HTTPStatus.OK else []
 
         return [BoxRevision(each) for each in [curr] + revisions]
 
@@ -373,22 +375,20 @@ class BoxProvider(provider.BaseProvider):
             if path.identifier is not None:
                 raise exceptions.FolderNamingConflict(path.name)
 
-        async with self.request(
+        response = await self.make_request(
             'POST',
             self.build_url('folders'),
             data={
                 'name': path.name,
-                'parent': {
-                    'id': path.parent.identifier
-                }
+                'parent': {'id': path.parent.identifier}
             },
             expects=(201, 409),
             throws=exceptions.CreateFolderError,
-        ) as resp:
-            # Catch 409s to avoid race conditions
-            if resp.status == 409:
-                raise exceptions.FolderNamingConflict(path.name)
-            resp_json = await resp.json()
+        )
+        # Catch 409s to avoid race conditions
+        if response.status == 409:
+            raise exceptions.FolderNamingConflict(path.name)
+        resp_json = await response.json()
         # save new folder's id into the WaterButlerPath object. logs will need it later.
         path._parts[-1]._id = resp_json['id']
         return BoxFolderMetadata(resp_json, path)
@@ -400,12 +400,13 @@ class BoxProvider(provider.BaseProvider):
         else:
             url = self.build_url('files', path.identifier)
 
-        async with self.request(
-            'GET', url,
+        response = await self.make_request(
+            'GET',
+            url,
             expects=(200, ),
             throws=exceptions.MetadataError,
-        ) as resp:
-            data = await resp.json()
+        )
+        data = await response.json()
 
         if revision:
             try:
@@ -421,12 +422,14 @@ class BoxProvider(provider.BaseProvider):
     async def _get_folder_meta(self, path: WaterButlerPath, raw: bool=False,
                                folder: bool=False) -> Union[dict, List[BoxFolderMetadata]]:
         if folder:
-            async with self.request(
-                'GET', self.build_url('folders', path.identifier),
-                expects=(200, ), throws=exceptions.MetadataError,
-            ) as resp:
-                data = await resp.json()
-                return data if raw else self._serialize_item(data, path)
+            response = await self.make_request(
+                'GET',
+                self.build_url('folders', path.identifier),
+                expects=(200, ),
+                throws=exceptions.MetadataError,
+            )
+            data = await response.json()
+            return data if raw else self._serialize_item(data, path)
 
         # Box maximum limit is 1000
         page_count, page_total, limit = 0, None, 1000
@@ -436,22 +439,26 @@ class BoxProvider(provider.BaseProvider):
                                  fields='id,name,size,modified_at,etag,total_count',
                                  offset=(page_count * limit),
                                  limit=limit)
-            async with self.request('GET', url, expects=(200, ),
-                                    throws=exceptions.MetadataError) as response:
-                resp_json = await response.json()
-                if raw:
-                    full_resp.update(resp_json)  # type: ignore
-                else:
-                    full_resp.extend([  # type: ignore
-                        self._serialize_item(
-                            each, path.child(each['name'], folder=(each['type'] == 'folder'))
-                        )
-                        for each in resp_json['entries']
-                    ])
+            response = await self.make_request(
+                'GET',
+                url,
+                expects=(200, ),
+                throws=exceptions.MetadataError,
+            )
+            resp_json = await response.json()
+            if raw:
+                full_resp.update(resp_json)  # type: ignore
+            else:
+                full_resp.extend([  # type: ignore
+                    self._serialize_item(
+                        each, path.child(each['name'], folder=(each['type'] == 'folder'))
+                    )
+                    for each in resp_json['entries']
+                ])
 
-                page_count += 1
-                if page_total is None:
-                    page_total = ((resp_json['total_count'] - 1) // limit) + 1  # ceiling div
+            page_count += 1
+            if page_total is None:
+                page_total = ((resp_json['total_count'] - 1) // limit) + 1  # ceiling div
         self.metrics.add('metadata.folder.pages', page_total)
         return full_resp
 
@@ -511,15 +518,15 @@ class BoxProvider(provider.BaseProvider):
         else:
             segments = ['files', 'content']
 
-        async with self.request(
+        response = await self.make_request(
             'POST',
             self._build_upload_url(*segments),
             data=data_stream,
             headers=data_stream.headers,
             expects=(201, ),
             throws=exceptions.UploadError,
-        ) as resp:
-            data = await resp.json()
+        )
+        data = await response.json()
 
         entry = data['entries'][0]
         if stream.writers['sha1'].hexdigest != entry['sha1']:
@@ -543,25 +550,21 @@ class BoxProvider(provider.BaseProvider):
         logger.debug('chunked upload session data: {}'.format(json.dumps(session_data)))
 
         metadata = None
-
         try:
             # Step 3. Split the data into parts and upload them to box.
             parts_manifest = await self._upload_parts(stream, session_data)
             logger.debug('chunked upload parts manifest: {}'.format(json.dumps(parts_manifest)))
-
             data_sha = base64.standard_b64encode(stream.writers['sha1'].digest).decode()
-
             # Step 4. Complete the session and return the uploaded file's metadata.
             retry = self.UPLOAD_COMMIT_RETRIES
             while retry > 0:
-                --retry
+                retry -= 1
                 try:
                     metadata = await self._complete_chunked_upload_session(session_data,
                                                                            parts_manifest, data_sha)
                     break
                 except RetryChunkedUploadCommit:
                     continue
-
         except Exception as err:
             msg = 'An unexpected error has occurred during the multi-part upload.'
             logger.error('{} upload_id={} error={!r}'.format(msg, session_data, err))
@@ -570,7 +573,6 @@ class BoxProvider(provider.BaseProvider):
                 msg += '  The abort action failed to clean up the temporary file parts generated ' \
                     'during the upload process.  Please manually remove them.'
             raise exceptions.UploadError(msg)
-
         return metadata
 
     async def _create_chunked_upload_session(self, path: WaterButlerPath,
@@ -583,25 +585,23 @@ class BoxProvider(provider.BaseProvider):
 
         API Docs: https://developer.box.com/reference#create-session-new-file
         """
-
         if path.identifier is not None:
             segments = ['files', path.identifier, 'upload_sessions']
         else:
             segments = ['files', 'upload_sessions']
-
-        async with self.request(
+        response = await self.make_request(
             'POST',
             self._build_upload_url(*segments),
-            data=json.dumps({
+            data={
                 'folder_id': self.folder,
                 'file_size': stream.size,
                 'file_name': path.name
-            }),
+            },
             headers={'Content-Type': 'application/json'},
             expects=(201, ),
             throws=exceptions.UploadError,
-        ) as resp:
-            return await resp.json()
+        )
+        return await response.json()
 
     async def _upload_parts(self, stream: streams.BaseStream, session_data: dict) -> list:
         """Calculate the partitioning scheme and upload the parts of the stream.  Returns a list
@@ -656,7 +656,7 @@ class BoxProvider(provider.BaseProvider):
         byte_range = self._build_range_header((start_offset, start_offset + part_size - 1))
         content_range = str(byte_range).replace('=', ' ') + '/{}'.format(stream.size)
 
-        async with self.request(
+        response = await self.make_request(
             'PUT',
             self._build_upload_url('files', 'upload_sessions', session_id),
             headers={
@@ -669,8 +669,8 @@ class BoxProvider(provider.BaseProvider):
             data=file_stream,
             expects=(201, 200),
             throws=exceptions.UploadError,
-        ) as resp:
-            data = await resp.json()
+        )
+        data = await response.json()
 
         f.close()
         return data['part']
@@ -682,25 +682,23 @@ class BoxProvider(provider.BaseProvider):
 
         https://developer.box.com/reference#commit-upload
         """
-
-        async with self.request(
+        response = await self.make_request(
             'POST',
             self._build_upload_url('files', 'upload_sessions', session_data['id'], 'commit'),
-            data=json.dumps({'parts': parts_manifest}),
+            data={'parts': parts_manifest},
             headers={
                 'Content-Type:': 'application/json',
                 'Digest': 'sha={}'.format(data_sha)
             },
             expects=(201, 202),
             throws=exceptions.UploadError,
-        ) as resp:
-            if resp.status == HTTPStatus.ACCEPTED:
-                await resp.release()
-                await sleep(resp.headers['Retry-After'])
-                raise RetryChunkedUploadCommit('Failed to commit chunked upload')
-            data = await resp.json()
-            entry = data['entries'][0]
-
+        )
+        if response.status == HTTPStatus.ACCEPTED:
+            await response.release()
+            await sleep(response.headers['Retry-After'])
+            raise RetryChunkedUploadCommit('Failed to commit chunked upload')
+        data = await response.json()
+        entry = data['entries'][0]
         return entry
 
     async def _abort_chunked_upload(self, session_data: dict, data_sha: str) -> bool:
@@ -712,7 +710,7 @@ class BoxProvider(provider.BaseProvider):
         :rtype: bool
         :return: `True` if abort request succeeded, `False` otherwise.
         """
-        resp = await self.make_request(
+        response = await self.make_request(
             'DELETE',
             self._build_upload_url('files', 'upload_sessions', session_data['id']),
             headers={
@@ -720,6 +718,5 @@ class BoxProvider(provider.BaseProvider):
                 'Digest': 'sha={}'.format(data_sha)
             },
         )
-
-        await resp.release()
-        return resp.status == HTTPStatus.NO_CONTENT
+        await response.release()
+        return response.status == HTTPStatus.NO_CONTENT


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-313

## Purpose

Throw the box provider into the oath pit. That is, in human-readable English, refactoring the box provider for `aiohttp` 0.18 -> 3.4 upgrade.

## Changes

- Updated MultiStream and CutoffStream with `__aiter__()` and `__anext__()`
Similar to the fix for OSFStorage/GoogleCloud, both streams must implement the `__anext__()` to properly read the chunk. `CutoffStream` is used for chunked upload (Box, Dropbox, FigShare and Amazon S3). `MultiStream` is inherited by `FormDataStream` (Box contiguous upload), by `JsonStream` (GitHub) and by `ZipLocalFile` (`ZipStreamReader`, DataVerse).

- Removed usage of `self.request()` and context manager
  - Before: the provider used `self.request()` and `self.make_request()` interchangeably when making requests; the former was just a simple context wrap-up around the latter so that CM could be used; but it still had to use the latter for streaming requests probably due to similar CM limitations we encountered during `aiohttp` upgrade
  - After: the provider now uses `make_request()` consistently. All CM `async with ... as ...` usages have been replaced with its non-CM counterpart. Please note that `self.request()` was already removed from the core provider during OSFStorage/GoogleCloud upgrade.

- Other Changes
  - Updated configurations to enable the provider and test
  - Removed redundant `json.dumps()` on request data
  - `--retry` -> `retry -= 1` for chunked upload try loop
  - Style updates: more compact (less blank lines), added comma for the last param of each `make_request()` call if not present

- [x] Fixd tests
  - In `aiohttp3`, `ClientResponse`'s `json()` method [now](https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client_reqrep.py#L975) requires a content type header. Thus, `'headers': {'Content-Type': 'application/json'}` (default value, unless another type is explicitly provided) must be provided when registering a URI if `json()` is called by the response.
  - WB core provider's [new](https://github.com/CenterForOpenScience/waterbutler/blob/feature/oathpit/waterbutler/core/provider.py#L261) `make_request()` uses upper case for HTTP method. All lower case method must be changed during URI registration in tests.
    - Before and after: `aiohttpretty` is case sensitive on HTTP method.
    - Before core and OSFStorage upgrade: URI registering in tests must choose the case carefully according to how the code is written in each provider :( After: simply use upper case everywhere in tests :)

## Side effects

No

## QA Notes

No, please refer to the ticket

## Deployment Notes

No, please refer to the ticket
