### PR TITLE
[No Ticket] Fix The Issue that Branch Name with Slash Breaks BB Repo Endpoints

### DIFF
--- a/tests/providers/bitbucket/fixtures/branch_metadata.json
+++ b/tests/providers/bitbucket/fixtures/branch_metadata.json
@@ -1,0 +1,5 @@
+{
+    "target": {
+        "hash": "dd8c7b642e3240a494414ac93c7fbc119ebe1179"
+    }
+}

--- a/tests/providers/bitbucket/provider_fixtures.py
+++ b/tests/providers/bitbucket/provider_fixtures.py
@@ -38,6 +38,13 @@ def path_metadata_file():
 
 
 @pytest.fixture()
+def branch_metadata():
+    with open(os.path.join(os.path.dirname(__file__), 'fixtures/branch_metadata.json'),
+              'r') as file_pointer:
+        return file_pointer.read()
+
+
+@pytest.fixture()
 def folder_contents_page_1():
     with open(os.path.join(os.path.dirname(__file__), 'fixtures/folder_contents_page_1.json'),
               'r') as file_pointer:


### PR DESCRIPTION
## Ticket

No Ticket

## Purpose

The BB API 2.0 `path` endpoint  [/2.0/repositories/{username}/{repo_slug}/src/{node}/{path}](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/src/%7Bnode%7D/%7Bpath%7D) WB uses returns `HTTP 404` if the `{node}` segment is a branch of which the name contains a slash. This is either a limitation or a bug on several BB API 2.0 endpoints, which has nothing to do with encoding. More specifically, neither encoding / with %2F nor enclosing ``node`` with curly braces (%7B and %7D) works.

[Here](https://bitbucket.org/site/master/issues/9969/get-commit-revision-api-does-not-accept) is the closest reference to this issue we have found as of May 2019 and [here](https://github.com/netlify/netlify-cms/issues/2105) is another one without further discussion or solution.

Note: this is an issue with BB API 2.0 only and was introduced to **staging servers** by https://github.com/CenterForOpenScience/waterbutler/pull/375 ([ENG-303](https://openscience.atlassian.net/browse/ENG-303)).

This PR fixes the above issue by making an extra request to fetch the commit SHA of the branch.

## Changes

### The BB Provider

- Added a provider method `_fetch_branch_commit_sha()`. It uses the [/2.0/repositories/{username}/{repo_slug}/refs/branches/{name}](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/refs/branches/%7Bname%7D) endpoint to fetch the branch metadata which contians the commit SHA.
- Every time before a `path.ref` is used to build BB API URL, apply the following fix if the `path` does not have a commit SHA yet.
  - Making an extra request to fetch the commit SHA of the branch
  - Setting the `path` commit SHA

### BB Unit Tests

- Added one test for fetching the commit SHA of a branch
- Added tests for fetching path metadata, w/ and w/o commit SHA
- Updated the file meta test and fixed the folder meta test

## Side effects

An extra request is made, which is unavoidable. However, this performance overhead is alright.
- Locally I am not seeing visible delay during accessing the BB provider
- This only happen when the commit SHA is not set before. For example, `_fetch_dir_listing()` never makes this extra request due to `path_metadata()` has always been called in advance which sets the commit SHA.

## QA Notes

- [ ] Please verify that all actions on BB works with a branch of which the name contains a slash.

### Local Tests I Have Verified

- [x] Switch branches and load the root-level contents
- [x] Expand sub directories
- [x] View a file
- [x] View a file's revision list
- [x] View a file revision 

## Deployment Notes

Not I can think of yet.
