### PR TITLE
[ENG-380] Fix the web view link for figshare and refactor fileset to dataset

### DIFF
--- a/tests/providers/figshare/fixtures.py
+++ b/tests/providers/figshare/fixtures.py
@@ -38,3 +38,34 @@ def project_article_type_3_metadata():
         'r'
     ) as fp:
         return json.load(fp)
+
+
+@pytest.fixture
+def project_list_articles():
+    with open(
+            os.path.join(os.path.dirname(__file__), 'fixtures/project_list_articles.json'),
+            'r'
+    ) as fp:
+        return json.load(fp)
+
+
+@pytest.fixture
+def project_article_type_1_file_metadata():
+    with open(
+        os.path.join(
+            os.path.dirname(__file__),
+            'fixtures/project_article_type_1_file_metadata.json'
+        ), 'r'
+    ) as fp:
+        return json.load(fp)
+
+
+@pytest.fixture
+def project_article_type_3_file_metadata():
+    with open(
+        os.path.join(
+            os.path.dirname(__file__),
+            'fixtures/project_article_type_3_file_metadata.json'
+        ), 'r'
+    ) as fp:
+        return json.load(fp)

--- a/tests/providers/figshare/fixtures.py
+++ b/tests/providers/figshare/fixtures.py
@@ -20,3 +20,21 @@ def crud_fixtures():
 def error_fixtures():
     with open(os.path.join(os.path.dirname(__file__), 'fixtures/errors.json'), 'r') as fp:
         return json.load(fp)
+
+
+@pytest.fixture
+def project_article_type_1_metadata():
+    with open(
+        os.path.join(os.path.dirname(__file__), 'fixtures/project_article_type_1_metadata.json'),
+        'r'
+    ) as fp:
+        return json.load(fp)
+
+
+@pytest.fixture
+def project_article_type_3_metadata():
+    with open(
+        os.path.join(os.path.dirname(__file__), 'fixtures/project_article_type_3_metadata.json'),
+        'r'
+    ) as fp:
+        return json.load(fp)

--- a/tests/providers/figshare/fixtures/crud.json
+++ b/tests/providers/figshare/fixtures/crud.json
@@ -1,161 +1,152 @@
-{  
-    "create_article_metadata":{  
-        "location":"https://api.figshare.com/v2/account/projects/13423/articles/4055568"
+{
+    "create_article_metadata": {
+        "location": "https://api.figshare.com/v2/account/projects/13423/articles/4055568"
     },
-    "create_file_metadata":{  
-        "location":"https://api.figshare.com/v2/account/articles/4055568/files/6530715"
+    "create_file_metadata": {
+        "location": "https://api.figshare.com/v2/account/articles/4055568/files/6530715"
     },
-
-    "create_upload_article_metadata":{  
-        "location":"https://api.figshare.com/v2/account/projects/13423/articles/4040019"
+    "create_upload_article_metadata": {
+        "location": "https://api.figshare.com/v2/account/projects/13423/articles/4040019"
     },
-    "upload_article_metadata":{  
-        "group_resource_id":null,
-        "embargo_date":null,
-        "citation":"Baxter, Thomas (): barricade.gif. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
-        "embargo_reason":"",
-        "references":[  
-
+    "upload_article_metadata": {
+        "group_resource_id": null,
+        "embargo_date": null,
+        "citation": "Baxter, Thomas (): barricade.gif. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
+        "embargo_reason": "",
+        "references": [
         ],
-        "id":4055568,
-        "custom_fields":[  
-
+        "id": 4055568,
+        "custom_fields": [
         ],
-        "size":0,
-        "metadata_reason":"",
-        "funding":"",
-        "figshare_url":"https://figshare.com/articles/_/4037952",
-        "embargo_type":null,
-        "title":"barricade.gif",
-        "defined_type":3,
-        "is_embargoed":false,
-        "version":0,
-        "resource_doi":null,
-        "confidential_reason":"",
-        "files":[  
-            {  
-                "status":"available",
-                "is_link_only":false,
-                "name":"barricade.gif",
-                "viewer_type":"",
-                "preview_state":"preview_not_supported",
-                "download_url":"https://ndownloader.figshare.com/files/6530715",
-                "supplied_md5":"13365d367683301ee26d9d76d25c518b",
-                "computed_md5":"13365d367683301ee26d9d76d25c518b",
-                "upload_token":"878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
-                "upload_url":"",
-                "id":6530715,
-                "size":6
+        "size": 0,
+        "metadata_reason": "",
+        "funding": "",
+        "figshare_url": "https://figshare.com/articles/_/4037952",
+        "embargo_type": null,
+        "title": "barricade.gif",
+        "defined_type": 3,
+        "is_embargoed": false,
+        "version": 0,
+        "resource_doi": null,
+        "confidential_reason": "",
+        "files": [
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "barricade.gif",
+                "viewer_type": "",
+                "preview_state": "preview_not_supported",
+                "download_url": "https://ndownloader.figshare.com/files/6530715",
+                "supplied_md5": "13365d367683301ee26d9d76d25c518b",
+                "computed_md5": "13365d367683301ee26d9d76d25c518b",
+                "upload_token": "878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
+                "upload_url": "",
+                "id": 6530715,
+                "size": 6
             }
         ],
-        "description":"",
-        "tags":[  
-
+        "description": "",
+        "tags": [
         ],
-        "created_date":"2016-10-18T12:55:44Z",
-        "is_active":true,
-        "authors":[  
-            {  
-                "url_name":"_",
-                "is_active":true,
-                "id":2665435,
-                "full_name":"Thomas Baxter",
-                "orcid_id":""
+        "created_date": "2016-10-18T12:55:44Z",
+        "is_active": true,
+        "authors": [
+            {
+                "url_name": "_",
+                "is_active": true,
+                "id": 2665435,
+                "full_name": "Thomas Baxter",
+                "orcid_id": ""
             }
         ],
-        "is_public":false,
-        "categories":[  
-
+        "is_public": false,
+        "categories": [
         ],
-        "modified_date":"2016-10-18T12:56:27Z",
-        "is_confidential":false,
-        "doi":"",
-        "license":{  
-            "url":"https://creativecommons.org/licenses/by/4.0/",
-            "name":"CC-BY",
-            "value":1
+        "modified_date": "2016-10-18T12:56:27Z",
+        "is_confidential": false,
+        "doi": "",
+        "license": {
+            "url": "https://creativecommons.org/licenses/by/4.0/",
+            "name": "CC-BY",
+            "value": 1
         },
-        "has_linked_file":false,
-        "url":"https://api.figshare.com/v2/account/projects/13423/articles/4037952",
-        "resource_title":null,
-        "status":"draft",
-        "published_date":null,
-        "is_metadata_record":false
+        "has_linked_file": false,
+        "url": "https://api.figshare.com/v2/account/projects/13423/articles/4037952",
+        "resource_title": null,
+        "status": "draft",
+        "published_date": null,
+        "is_metadata_record": false
     },
-    "upload_folder_article_metadata":{  
-        "group_resource_id":null,
-        "embargo_date":null,
-        "citation":"Baxter, Thomas (): barricade.gif. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
-        "embargo_reason":"",
-        "references":[  
-
+    "upload_folder_article_metadata": {
+        "group_resource_id": null,
+        "embargo_date": null,
+        "citation": "Baxter, Thomas (): barricade.gif. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
+        "embargo_reason": "",
+        "references": [
         ],
-        "id":4040019,
-        "custom_fields":[  
-
+        "id": 4040019,
+        "custom_fields": [
         ],
-        "size":0,
-        "metadata_reason":"",
-        "funding":"",
-        "figshare_url":"https://figshare.com/articles/_/4040019",
-        "embargo_type":null,
-        "title":"barricade.gif",
-        "defined_type":4,
-        "is_embargoed":false,
-        "version":0,
-        "resource_doi":null,
-        "confidential_reason":"",
-        "files":[  
-            {  
-                "status":"available",
-                "is_link_only":false,
-                "name":"barricade.gif",
-                "viewer_type":"",
-                "preview_state":"preview_not_supported",
-                "download_url":"https://ndownloader.figshare.com/files/6530715",
-                "supplied_md5":"13365d367683301ee26d9d76d25c518b",
-                "computed_md5":"13365d367683301ee26d9d76d25c518b",
-                "upload_token":"878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
-                "upload_url":"",
-                "id":6530715,
-                "size":7
+        "size": 0,
+        "metadata_reason": "",
+        "funding": "",
+        "figshare_url": "https://figshare.com/articles/_/4040019",
+        "embargo_type": null,
+        "title": "barricade.gif",
+        "defined_type": 4,
+        "is_embargoed": false,
+        "version": 0,
+        "resource_doi": null,
+        "confidential_reason": "",
+        "files": [
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "barricade.gif",
+                "viewer_type": "",
+                "preview_state": "preview_not_supported",
+                "download_url": "https://ndownloader.figshare.com/files/6530715",
+                "supplied_md5": "13365d367683301ee26d9d76d25c518b",
+                "computed_md5": "13365d367683301ee26d9d76d25c518b",
+                "upload_token": "878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
+                "upload_url": "",
+                "id": 6530715,
+                "size": 7
             }
         ],
-        "description":"",
-        "tags":[  
-
+        "description": "",
+        "tags": [
         ],
-        "created_date":"2016-10-18T12:55:44Z",
-        "is_active":true,
-        "authors":[  
-            {  
-                "url_name":"_",
-                "is_active":true,
-                "id":2665435,
-                "full_name":"Thomas Baxter",
-                "orcid_id":""
+        "created_date": "2016-10-18T12:55:44Z",
+        "is_active": true,
+        "authors": [
+            {
+                "url_name": "_",
+                "is_active": true,
+                "id": 2665435,
+                "full_name": "Thomas Baxter",
+                "orcid_id": ""
             }
         ],
-        "is_public":false,
-        "categories":[  
-
+        "is_public": false,
+        "categories": [
         ],
-        "modified_date":"2016-10-18T12:56:27Z",
-        "is_confidential":false,
-        "doi":"",
-        "license":{  
-            "url":"https://creativecommons.org/licenses/by/4.0/",
-            "name":"CC-BY",
-            "value":1
+        "modified_date": "2016-10-18T12:56:27Z",
+        "is_confidential": false,
+        "doi": "",
+        "license": {
+            "url": "https://creativecommons.org/licenses/by/4.0/",
+            "name": "CC-BY",
+            "value": 1
         },
-        "has_linked_file":false,
-        "url":"https://api.figshare.com/v2/account/projects/13423/articles/4040019",
-        "resource_title":null,
-        "status":"draft",
-        "published_date":null,
-        "is_metadata_record":false
+        "has_linked_file": false,
+        "url": "https://api.figshare.com/v2/account/projects/13423/articles/4040019",
+        "resource_title": null,
+        "status": "draft",
+        "published_date": null,
+        "is_metadata_record": false
     },
-"checksum_mismatch_article_metadata":{
+    "checksum_mismatch_article_metadata": {
         "group_resource_id": null,
         "embargo_date": null,
         "citation": "Baxter, Thomas (): barricade.gif. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
@@ -174,31 +165,35 @@
         "version": 0,
         "resource_doi": null,
         "confidential_reason": "",
-        "files": [{
-            "status": "available",
-            "is_link_only": false,
-            "name": "barricade.gif",
-            "viewer_type": "",
-            "preview_state": "preview_not_supported",
-            "download_url": "https://ndownloader.figshare.com/files/6530715",
-            "supplied_md5": "super-duper-bogus",
-            "computed_md5": "super-duper-bogus",
-            "upload_token": "878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
-            "upload_url": "",
-            "id": 6530715,
-            "size": 6
-        }],
+        "files": [
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "barricade.gif",
+                "viewer_type": "",
+                "preview_state": "preview_not_supported",
+                "download_url": "https://ndownloader.figshare.com/files/6530715",
+                "supplied_md5": "super-duper-bogus",
+                "computed_md5": "super-duper-bogus",
+                "upload_token": "878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
+                "upload_url": "",
+                "id": 6530715,
+                "size": 6
+            }
+        ],
         "description": "",
         "tags": [],
         "created_date": "2016-10-18T12:55:44Z",
         "is_active": true,
-        "authors": [{
-            "url_name": "_",
-            "is_active": true,
-            "id": 2665435,
-            "full_name": "Thomas Baxter",
-            "orcid_id": ""
-        }],
+        "authors": [
+            {
+                "url_name": "_",
+                "is_active": true,
+                "id": 2665435,
+                "full_name": "Thomas Baxter",
+                "orcid_id": ""
+            }
+        ],
         "is_public": false,
         "categories": [],
         "modified_date": "2016-10-18T12:56:27Z",
@@ -216,8 +211,7 @@
         "published_date": null,
         "is_metadata_record": false
     },
-
-"checksum_mismatch_folder_article_metadata": {
+    "checksum_mismatch_folder_article_metadata": {
         "group_resource_id": null,
         "embargo_date": null,
         "citation": "Baxter, Thomas (): barricade.gif. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
@@ -236,31 +230,35 @@
         "version": 0,
         "resource_doi": null,
         "confidential_reason": "",
-        "files": [{
-            "status": "available",
-            "is_link_only": false,
-            "name": "barricade.gif",
-            "viewer_type": "",
-            "preview_state": "preview_not_supported",
-            "download_url": "https://ndownloader.figshare.com/files/6530715",
-            "supplied_md5": "mismatch-invalid",
-            "computed_md5": "mismatch-invalid",
-            "upload_token": "878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
-            "upload_url": "",
-            "id": 6530715,
-            "size": 7
-        }],
+        "files": [
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "barricade.gif",
+                "viewer_type": "",
+                "preview_state": "preview_not_supported",
+                "download_url": "https://ndownloader.figshare.com/files/6530715",
+                "supplied_md5": "mismatch-invalid",
+                "computed_md5": "mismatch-invalid",
+                "upload_token": "878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
+                "upload_url": "",
+                "id": 6530715,
+                "size": 7
+            }
+        ],
         "description": "",
         "tags": [],
         "created_date": "2016-10-18T12:55:44Z",
         "is_active": true,
-        "authors": [{
-            "url_name": "_",
-            "is_active": true,
-            "id": 2665435,
-            "full_name": "Thomas Baxter",
-            "orcid_id": ""
-        }],
+        "authors": [
+            {
+                "url_name": "_",
+                "is_active": true,
+                "id": 2665435,
+                "full_name": "Thomas Baxter",
+                "orcid_id": ""
+            }
+        ],
         "is_public": false,
         "categories": [],
         "modified_date": "2016-10-18T12:56:27Z",
@@ -278,5 +276,4 @@
         "published_date": null,
         "is_metadata_record": false
     }
-
 }

--- a/tests/providers/figshare/fixtures/crud.json
+++ b/tests/providers/figshare/fixtures/crud.json
@@ -9,6 +9,8 @@
         "location": "https://api.figshare.com/v2/account/projects/13423/articles/4040019"
     },
     "upload_article_metadata": {
+        "url_public_html": "url_public_html_fake",
+        "url_private_html": "url_private_html_fake",
         "group_resource_id": null,
         "embargo_date": null,
         "citation": "Baxter, Thomas (): barricade.gif. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
@@ -78,6 +80,8 @@
         "is_metadata_record": false
     },
     "upload_folder_article_metadata": {
+        "url_public_html": "url_public_html_fake",
+        "url_private_html": "url_private_html_fake",
         "group_resource_id": null,
         "embargo_date": null,
         "citation": "Baxter, Thomas (): barricade.gif. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
@@ -93,7 +97,7 @@
         "figshare_url": "https://figshare.com/articles/_/4040019",
         "embargo_type": null,
         "title": "barricade.gif",
-        "defined_type": 4,
+        "defined_type": 3,
         "is_embargoed": false,
         "version": 0,
         "resource_doi": null,
@@ -147,6 +151,8 @@
         "is_metadata_record": false
     },
     "checksum_mismatch_article_metadata": {
+        "url_public_html": "url_public_html_fake",
+        "url_private_html": "url_private_html_fake",
         "group_resource_id": null,
         "embargo_date": null,
         "citation": "Baxter, Thomas (): barricade.gif. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
@@ -212,6 +218,8 @@
         "is_metadata_record": false
     },
     "checksum_mismatch_folder_article_metadata": {
+        "url_public_html": "url_public_html_fake",
+        "url_private_html": "url_private_html_fake",
         "group_resource_id": null,
         "embargo_date": null,
         "citation": "Baxter, Thomas (): barricade.gif. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
@@ -225,7 +233,7 @@
         "figshare_url": "https://figshare.com/articles/_/4040019",
         "embargo_type": null,
         "title": "barricade.gif",
-        "defined_type": 4,
+        "defined_type": 3,
         "is_embargoed": false,
         "version": 0,
         "resource_doi": null,

--- a/tests/providers/figshare/fixtures/errors.json
+++ b/tests/providers/figshare/fixtures/errors.json
@@ -13,6 +13,8 @@
         "size": 7
     },
     "file_article_metadata_missing_download_url": {
+        "url_public_html": "url_public_html_fake",
+        "url_private_html": "url_private_html_fake",
         "group_resource_id": null,
         "embargo_date": null,
         "citation": "Baxter, Thomas (): file_article. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",

--- a/tests/providers/figshare/fixtures/errors.json
+++ b/tests/providers/figshare/fixtures/errors.json
@@ -1,87 +1,84 @@
-{    "file_metadata_missing_download_url":{  
-        "status":"available",
-        "is_link_only":false,
-        "name":"file",
-        "viewer_type":"",
-        "preview_state":"preview_not_supported",
-        "supplied_md5":"b3e656f8b0828a31f3ed396a1c868786",
-        "computed_md5":"b3e656f8b0828a31f3ed396a1c868786",
-        "upload_token":"878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
-        "upload_url":"",
-        "id":6530715,
-        "size":7
+{
+    "file_metadata_missing_download_url": {
+        "status": "available",
+        "is_link_only": false,
+        "name": "file",
+        "viewer_type": "",
+        "preview_state": "preview_not_supported",
+        "supplied_md5": "b3e656f8b0828a31f3ed396a1c868786",
+        "computed_md5": "b3e656f8b0828a31f3ed396a1c868786",
+        "upload_token": "878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
+        "upload_url": "",
+        "id": 6530715,
+        "size": 7
     },
-    "file_article_metadata_missing_download_url":{  
-        "group_resource_id":null,
-        "embargo_date":null,
-        "citation":"Baxter, Thomas (): file_article. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
-        "embargo_reason":"",
-        "references":[  
-
+    "file_article_metadata_missing_download_url": {
+        "group_resource_id": null,
+        "embargo_date": null,
+        "citation": "Baxter, Thomas (): file_article. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
+        "embargo_reason": "",
+        "references": [
         ],
-        "id":4037952,
-        "custom_fields":[  
-
+        "id": 4037952,
+        "custom_fields": [
         ],
-        "size":0,
-        "metadata_reason":"",
-        "funding":"",
-        "figshare_url":"https://figshare.com/articles/_/4037952",
-        "embargo_type":null,
-        "title":"file_article",
-        "defined_type":3,
-        "is_embargoed":false,
-        "version":0,
-        "resource_doi":null,
-        "confidential_reason":"",
-        "files":[  
-            {  
-                "status":"available",
-                "is_link_only":false,
-                "name":"file",
-                "viewer_type":"",
+        "size": 0,
+        "metadata_reason": "",
+        "funding": "",
+        "figshare_url": "https://figshare.com/articles/_/4037952",
+        "embargo_type": null,
+        "title": "file_article",
+        "defined_type": 3,
+        "is_embargoed": false,
+        "version": 0,
+        "resource_doi": null,
+        "confidential_reason": "",
+        "files": [
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "file",
+                "viewer_type": "",
                 "download_url": null,
-                "preview_state":"preview_not_supported",
-                "supplied_md5":"b3e656f8b0828a31f3ed396a1c868786",
-                "computed_md5":"b3e656f8b0828a31f3ed396a1c868786",
-                "upload_token":"878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
-                "upload_url":"",
-                "id":6530715,
-                "size":7
+                "preview_state": "preview_not_supported",
+                "supplied_md5": "b3e656f8b0828a31f3ed396a1c868786",
+                "computed_md5": "b3e656f8b0828a31f3ed396a1c868786",
+                "upload_token": "878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
+                "upload_url": "",
+                "id": 6530715,
+                "size": 7
             }
         ],
-        "description":"",
-        "tags":[  
-
+        "description": "",
+        "tags": [
         ],
-        "created_date":"2016-10-18T12:55:44Z",
-        "is_active":true,
-        "authors":[  
-            {  
-                "url_name":"_",
-                "is_active":true,
-                "id":2665435,
-                "full_name":"Thomas Baxter",
-                "orcid_id":""
+        "created_date": "2016-10-18T12:55:44Z",
+        "is_active": true,
+        "authors": [
+            {
+                "url_name": "_",
+                "is_active": true,
+                "id": 2665435,
+                "full_name": "Thomas Baxter",
+                "orcid_id": ""
             }
         ],
-        "is_public":false,
-        "categories":[  
-
+        "is_public": false,
+        "categories": [
         ],
-        "modified_date":"2016-10-18T12:56:27Z",
-        "is_confidential":false,
-        "doi":"",
-        "license":{  
-            "url":"https://creativecommons.org/licenses/by/4.0/",
-            "name":"CC-BY",
-            "value":1
+        "modified_date": "2016-10-18T12:56:27Z",
+        "is_confidential": false,
+        "doi": "",
+        "license": {
+            "url": "https://creativecommons.org/licenses/by/4.0/",
+            "name": "CC-BY",
+            "value": 1
         },
-        "has_linked_file":false,
-        "url":"https://api.figshare.com/v2/account/projects/13423/articles/4037952",
-        "resource_title":null,
-        "status":"draft",
-        "published_date":null,
-        "is_metadata_record":false
+        "has_linked_file": false,
+        "url": "https://api.figshare.com/v2/account/projects/13423/articles/4037952",
+        "resource_title": null,
+        "status": "draft",
+        "published_date": null,
+        "is_metadata_record": false
     }
 }

--- a/tests/providers/figshare/fixtures/project_article_type_1_file_metadata.json
+++ b/tests/providers/figshare/fixtures/project_article_type_1_file_metadata.json
@@ -1,0 +1,16 @@
+{
+    "private": {
+        "status": "available",
+        "is_link_only": false,
+        "name": "FigurePrivate01.png",
+        "viewer_type": "image",
+        "preview_state": "preview_available",
+        "download_url": "https://ndownloader.figshare.com/files/15562817",
+        "supplied_md5": "cae3869aa4b144a3aa5cffe979359836",
+        "computed_md5": "cae3869aa4b144a3aa5cffe979359836",
+        "upload_token": "105ca509-759b-491b-af48-fa5589cd7b49",
+        "upload_url": "",
+        "id": 15562817,
+        "size": 89281
+    }
+}

--- a/tests/providers/figshare/fixtures/project_article_type_1_metadata.json
+++ b/tests/providers/figshare/fixtures/project_article_type_1_metadata.json
@@ -1,0 +1,212 @@
+{
+    "private": {
+        "group_resource_id": null,
+        "embargo_date": null,
+        "defined_type_name": "figure",
+        "citation": "Chen, Longze (2019): FigurePrivate. figshare. Figure.",
+        "url_private_api": "https://api.figshare.com/v2/account/articles/8305859",
+        "embargo_reason": "",
+        "references": [],
+        "funding_list": [],
+        "url_public_api": "https://api.figshare.com/v2/articles/8305859",
+        "id": 8305859,
+        "custom_fields": [],
+        "size": 89281,
+        "metadata_reason": "",
+        "funding": null,
+        "figshare_url": "https://figshare.com/articles/_/8305859",
+        "embargo_type": "file",
+        "title": "FigurePrivate",
+        "defined_type": 1,
+        "is_embargoed": false,
+        "version": 0,
+        "resource_doi": null,
+        "confidential_reason": "",
+        "files": [
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "FigurePrivate01.png",
+                "viewer_type": "",
+                "preview_state": "preview_error",
+                "download_url": "https://ndownloader.figshare.com/files/15562817",
+                "supplied_md5": "cae3869aa4b144a3aa5cffe979359836",
+                "computed_md5": "cae3869aa4b144a3aa5cffe979359836",
+                "upload_token": "105ca509-759b-491b-af48-fa5589cd7b49",
+                "upload_url": "",
+                "id": 15562817,
+                "size": 89281
+            }
+        ],
+        "handle": "",
+        "description": "FigurePrivate",
+        "tags": [],
+        "timeline": {},
+        "url_private_html": "https://figshare.com/account/articles/8305859",
+        "created_date": "2019-06-21T06:23:08Z",
+        "is_active": true,
+        "authors": [
+            {
+                "url_name": "Longze_Chen",
+                "is_active": true,
+                "id": 4449739,
+                "full_name": "Longze Chen",
+                "orcid_id": ""
+            }
+        ],
+        "is_public": false,
+        "categories": [
+            {
+                "parent_id": 5,
+                "id": 23,
+                "title": "Software Engineering"
+            }
+        ],
+        "thumb": "",
+        "status": "draft",
+        "is_confidential": false,
+        "doi": "",
+        "license": {
+            "url": "https://creativecommons.org/licenses/by/4.0/",
+            "name": "CC BY 4.0",
+            "value": 1
+        },
+        "has_linked_file": false,
+        "url": "https://api.figshare.com/v2/account/projects/64916/articles/8305859",
+        "resource_title": null,
+        "url_public_html": "https://figshare.com/articles/_/8305859",
+        "published_date": null,
+        "group_id": null,
+        "is_metadata_record": false,
+        "modified_date": "2019-06-21T06:24:39Z"
+    },
+    "public": {
+        "group_resource_id": null,
+        "embargo_date": null,
+        "defined_type_name": "figure",
+        "citation": "Chen, Longze (2019): Figure. figshare. Figure.",
+        "url_private_api": "https://api.figshare.com/v2/account/articles/8263730",
+        "embargo_reason": "",
+        "references": [],
+        "funding_list": [],
+        "url_public_api": "https://api.figshare.com/v2/articles/8263730",
+        "id": 8263730,
+        "custom_fields": [],
+        "size": 338002,
+        "metadata_reason": "",
+        "funding": null,
+        "figshare_url": "https://figshare.com/articles/Figure01_png/8263730",
+        "embargo_type": "file",
+        "title": "Figure",
+        "defined_type": 1,
+        "is_embargoed": false,
+        "version": 3,
+        "resource_doi": null,
+        "confidential_reason": "",
+        "files": [
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "Figure01.png",
+                "viewer_type": "image",
+                "preview_state": "preview_available",
+                "download_url": "https://ndownloader.figshare.com/files/15451592",
+                "supplied_md5": "cae3869aa4b144a3aa5cffe979359836",
+                "computed_md5": "cae3869aa4b144a3aa5cffe979359836",
+                "upload_token": "ecb258a2-6286-441d-89a1-02cb39c7e34f",
+                "upload_url": "",
+                "id": 15451592,
+                "size": 89281
+            },
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "Figure02.png",
+                "viewer_type": "image",
+                "preview_state": "preview_available",
+                "download_url": "https://ndownloader.figshare.com/files/15461024",
+                "supplied_md5": "507b58e2f7dfb23811441e6f2d64e0d6",
+                "computed_md5": "507b58e2f7dfb23811441e6f2d64e0d6",
+                "upload_token": "e0ead5b2-d897-479c-a375-7a2ab81ea19d",
+                "upload_url": "",
+                "id": 15461024,
+                "size": 106291
+            },
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "Figure03.png",
+                "viewer_type": "image",
+                "preview_state": "preview_available",
+                "download_url": "https://ndownloader.figshare.com/files/15461030",
+                "supplied_md5": "5697bb03e20c3a841e7331ee51362c8d",
+                "computed_md5": "5697bb03e20c3a841e7331ee51362c8d",
+                "upload_token": "ebd3cf1e-17ad-4d10-8edf-899ab06c60e7",
+                "upload_url": "",
+                "id": 15461030,
+                "size": 40995
+            },
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "Figure04.png",
+                "viewer_type": "image",
+                "preview_state": "preview_available",
+                "download_url": "https://ndownloader.figshare.com/files/15461033",
+                "supplied_md5": "154d71b2cd8a657caadd18641918ce4f",
+                "computed_md5": "154d71b2cd8a657caadd18641918ce4f",
+                "upload_token": "45232cd5-cc19-4702-9c15-d205952ad860",
+                "upload_url": "",
+                "id": 15461033,
+                "size": 101435
+            }
+        ],
+        "handle": "",
+        "description": "Figure",
+        "tags": [
+            "Software Development And Testing"
+        ],
+        "timeline": {
+            "revision": "2019-06-13T13:56:05",
+            "firstOnline": "2019-06-12T14:47:31",
+            "posted": "2019-06-13T13:56:05"
+        },
+        "url_private_html": "https://figshare.com/account/articles/8263730",
+        "created_date": "2019-06-12T14:41:44Z",
+        "is_active": true,
+        "authors": [
+            {
+                "url_name": "Longze_Chen",
+                "is_active": true,
+                "id": 4449739,
+                "full_name": "Longze Chen",
+                "orcid_id": ""
+            }
+        ],
+        "is_public": true,
+        "categories": [
+            {
+                "parent_id": 5,
+                "id": 23,
+                "title": "Software Engineering"
+            }
+        ],
+        "thumb": "https://s3-eu-west-1.amazonaws.com/pfigshare-u-previews/15461024/thumb.png",
+        "status": "public",
+        "is_confidential": false,
+        "doi": "10.6084/m9.figshare.8263730",
+        "license": {
+            "url": "https://creativecommons.org/licenses/by/4.0/",
+            "name": "CC BY 4.0",
+            "value": 1
+        },
+        "has_linked_file": false,
+        "url": "https://api.figshare.com/v2/account/projects/64916/articles/8263730",
+        "resource_title": null,
+        "url_public_html": "https://figshare.com/articles/Figure01_png/8263730",
+        "published_date": "2019-06-13T13:56:05Z",
+        "group_id": null,
+        "is_metadata_record": false,
+        "modified_date": "2019-06-13T13:56:05Z"
+    }
+}

--- a/tests/providers/figshare/fixtures/project_article_type_3_file_metadata.json
+++ b/tests/providers/figshare/fixtures/project_article_type_3_file_metadata.json
@@ -1,0 +1,16 @@
+{
+    "private": {
+        "status": "available",
+        "is_link_only": false,
+        "name": "Dataset03Private.txt",
+        "viewer_type": "txt",
+        "preview_state": "preview_available",
+        "download_url": "https://ndownloader.figshare.com/files/15461879",
+        "supplied_md5": "68c3a15be1ddc27893c17eaab61f2d3d",
+        "computed_md5": "68c3a15be1ddc27893c17eaab61f2d3d",
+        "upload_token": "79a06e48-87ec-4583-8faf-68fe83bf408c",
+        "upload_url": "",
+        "id": 15461879,
+        "size": 20
+    }
+}

--- a/tests/providers/figshare/fixtures/project_article_type_3_metadata.json
+++ b/tests/providers/figshare/fixtures/project_article_type_3_metadata.json
@@ -1,0 +1,220 @@
+{
+    "private": {
+        "group_resource_id": null,
+        "embargo_date": null,
+        "defined_type_name": "dataset",
+        "citation": "Chen, Longze (2019): DatasetPrivate. figshare. Dataset.",
+        "url_private_api": "https://api.figshare.com/v2/account/articles/8269766",
+        "embargo_reason": "",
+        "references": [],
+        "funding_list": [],
+        "url_public_api": "https://api.figshare.com/v2/articles/8269766",
+        "id": 8269766,
+        "custom_fields": [],
+        "size": 40,
+        "metadata_reason": "",
+        "funding": null,
+        "figshare_url": "https://figshare.com/articles/_/8269766",
+        "embargo_type": "file",
+        "title": "DatasetPrivate",
+        "defined_type": 3,
+        "is_embargoed": false,
+        "version": 0,
+        "resource_doi": null,
+        "confidential_reason": "",
+        "files": [
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "Dataset03Private.txt",
+                "viewer_type": "txt",
+                "preview_state": "preview_available",
+                "download_url": "https://ndownloader.figshare.com/files/15461879",
+                "supplied_md5": "68c3a15be1ddc27893c17eaab61f2d3d",
+                "computed_md5": "68c3a15be1ddc27893c17eaab61f2d3d",
+                "upload_token": "79a06e48-87ec-4583-8faf-68fe83bf408c",
+                "upload_url": "",
+                "id": 15461879,
+                "size": 20
+            },
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "Dataset04Private.txt",
+                "viewer_type": "txt",
+                "preview_state": "preview_available",
+                "download_url": "https://ndownloader.figshare.com/files/15461876",
+                "supplied_md5": "90569bfdc7b68ffe6e06f444a05bb77a",
+                "computed_md5": "90569bfdc7b68ffe6e06f444a05bb77a",
+                "upload_token": "34285cee-faa9-4a8f-84ba-ac1b85688426",
+                "upload_url": "",
+                "id": 15461876,
+                "size": 20
+            }
+        ],
+        "handle": "",
+        "description": "DatasetPrivate",
+        "tags": [],
+        "timeline": {},
+        "url_private_html": "https://figshare.com/account/articles/8269766",
+        "created_date": "2019-06-13T15:58:25Z",
+        "is_active": true,
+        "authors": [
+            {
+                "url_name": "Longze_Chen",
+                "is_active": true,
+                "id": 4449739,
+                "full_name": "Longze Chen",
+                "orcid_id": ""
+            }
+        ],
+        "is_public": false,
+        "categories": [],
+        "thumb": "",
+        "status": "draft",
+        "is_confidential": false,
+        "doi": "",
+        "license": {
+            "url": "https://creativecommons.org/licenses/by/4.0/",
+            "name": "CC BY 4.0",
+            "value": 1
+        },
+        "has_linked_file": false,
+        "url": "https://api.figshare.com/v2/account/projects/64916/articles/8269766",
+        "resource_title": null,
+        "url_public_html": "https://figshare.com/articles/_/8269766",
+        "published_date": null,
+        "group_id": null,
+        "is_metadata_record": false,
+        "modified_date": "2019-06-13T16:00:12Z"
+    },
+    "public": {
+        "group_resource_id": null,
+        "embargo_date": null,
+        "defined_type_name": "dataset",
+        "citation": "Chen, Longze (2019): Dataset. figshare. Dataset.",
+        "url_private_api": "https://api.figshare.com/v2/account/articles/8263811",
+        "embargo_reason": "",
+        "references": [],
+        "funding_list": [],
+        "url_public_api": "https://api.figshare.com/v2/articles/8263811",
+        "id": 8263811,
+        "custom_fields": [],
+        "size": 80,
+        "metadata_reason": "",
+        "funding": null,
+        "figshare_url": "https://figshare.com/articles/Dataset01_txt/8263811",
+        "embargo_type": "file",
+        "title": "Dataset",
+        "defined_type": 3,
+        "is_embargoed": false,
+        "version": 3,
+        "resource_doi": null,
+        "confidential_reason": "",
+        "files": [
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "Dataset02.txt",
+                "viewer_type": "txt",
+                "preview_state": "preview_available",
+                "download_url": "https://ndownloader.figshare.com/files/15460985",
+                "supplied_md5": "a9b178098c990ebd37833eb3a555bbef",
+                "computed_md5": "a9b178098c990ebd37833eb3a555bbef",
+                "upload_token": "1d08c67f-e8ac-490f-843c-a72481d92847",
+                "upload_url": "",
+                "id": 15460985,
+                "size": 20
+            },
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "Dataset01.txt",
+                "viewer_type": "txt",
+                "preview_state": "preview_available",
+                "download_url": "https://ndownloader.figshare.com/files/15460988",
+                "supplied_md5": "63af72b6287856019456d183842a543c",
+                "computed_md5": "63af72b6287856019456d183842a543c",
+                "upload_token": "38814a5d-b625-450a-a7c1-06701a36f537",
+                "upload_url": "",
+                "id": 15460988,
+                "size": 20
+            },
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "Dataset04.txt",
+                "viewer_type": "txt",
+                "preview_state": "preview_available",
+                "download_url": "https://ndownloader.figshare.com/files/15525491",
+                "supplied_md5": "d4ffc4d71ddb2027f1f44c5305d5a006",
+                "computed_md5": "d4ffc4d71ddb2027f1f44c5305d5a006",
+                "upload_token": "4f94aab4-0cea-4dd9-ba4e-6c0daa0217a4",
+                "upload_url": "",
+                "id": 15525491,
+                "size": 20
+            },
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "Dataset03.txt",
+                "viewer_type": "txt",
+                "preview_state": "preview_available",
+                "download_url": "https://ndownloader.figshare.com/files/15525488",
+                "supplied_md5": "b0abfd2a4d171b38de3e63d3036d9e8c",
+                "computed_md5": "b0abfd2a4d171b38de3e63d3036d9e8c",
+                "upload_token": "b50cc7ec-27d1-4993-9b87-a2152a6d361a",
+                "upload_url": "",
+                "id": 15525488,
+                "size": 20
+            }
+        ],
+        "handle": "",
+        "description": "Dataset",
+        "tags": [
+            "Software Development And Testing"
+        ],
+        "timeline": {
+            "revision": "2019-06-18T14:45:32",
+            "firstOnline": "2019-06-12T14:53:26",
+            "posted": "2019-06-18T14:45:32"
+        },
+        "url_private_html": "https://figshare.com/account/articles/8263811",
+        "created_date": "2019-06-12T14:51:31Z",
+        "is_active": true,
+        "authors": [
+            {
+                "url_name": "Longze_Chen",
+                "is_active": true,
+                "id": 4449739,
+                "full_name": "Longze Chen",
+                "orcid_id": ""
+            }
+        ],
+        "is_public": true,
+        "categories": [
+            {
+                "parent_id": 5,
+                "id": 23,
+                "title": "Software Engineering"
+            }
+        ],
+        "thumb": "",
+        "status": "public",
+        "is_confidential": false,
+        "doi": "10.6084/m9.figshare.8263811",
+        "license": {
+            "url": "https://creativecommons.org/licenses/by/4.0/",
+            "name": "CC BY 4.0",
+            "value": 1
+        },
+        "has_linked_file": false,
+        "url": "https://api.figshare.com/v2/account/projects/64916/articles/8263811",
+        "resource_title": null,
+        "url_public_html": "https://figshare.com/articles/Dataset01_txt/8263811",
+        "published_date": "2019-06-18T14:45:32Z",
+        "group_id": null,
+        "is_metadata_record": false,
+        "modified_date": "2019-06-18T14:45:32Z"
+    }
+}

--- a/tests/providers/figshare/fixtures/project_list_articles.json
+++ b/tests/providers/figshare/fixtures/project_list_articles.json
@@ -1,0 +1,98 @@
+{
+    "page1": [
+        {
+            "defined_type_name": "figure",
+            "handle": "",
+            "url_private_html": "https://figshare.com/account/articles/8263730",
+            "timeline": {
+                "revision": "2019-06-13T13:56:05",
+                "firstOnline": "2019-06-12T14:47:31",
+                "posted": "2019-06-13T13:56:05"
+            },
+            "created_date": "2019-06-12T14:41:44Z",
+            "url_private_api": "https://api.figshare.com/v2/account/articles/8263730",
+            "url_public_api": "https://api.figshare.com/v2/articles/8263730",
+            "id": 8263730,
+            "modified_date": "2019-06-13T13:56:05Z",
+            "doi": "10.6084/m9.figshare.8263730",
+            "thumb": "https://s3-eu-west-1.amazonaws.com/pfigshare-u-previews/15461024/thumb.png",
+            "title": "Figure",
+            "url": "https://api.figshare.com/v2/account/projects/64916/articles/8263730",
+            "defined_type": 1,
+            "resource_title": null,
+            "url_public_html": "https://figshare.com/articles/Figure01_png/8263730",
+            "resource_doi": null,
+            "published_date": "2019-06-13T13:56:05Z",
+            "group_id": null
+        },
+        {
+            "defined_type_name": "figure",
+            "handle": "",
+            "url_private_html": "https://figshare.com/account/articles/8305859",
+            "timeline": {},
+            "created_date": "2019-06-21T06:23:08Z",
+            "url_private_api": "https://api.figshare.com/v2/account/articles/8305859",
+            "url_public_api": "https://api.figshare.com/v2/articles/8305859",
+            "id": 8305859,
+            "modified_date": "2019-06-21T06:24:39Z",
+            "doi": "",
+            "thumb": "https://ndownloader.figshare.com/files/15562817/preview/15562817/thumb.png",
+            "title": "FigurePrivate",
+            "url": "https://api.figshare.com/v2/account/projects/64916/articles/8305859",
+            "defined_type": 1,
+            "resource_title": null,
+            "url_public_html": "https://figshare.com/articles/_/8305859",
+            "resource_doi": null,
+            "published_date": null,
+            "group_id": null
+        }
+    ],
+    "page2": [
+        {
+            "defined_type_name": "dataset",
+            "handle": "",
+            "url_private_html": "https://figshare.com/account/articles/8263811",
+            "timeline": {
+                "revision": "2019-06-18T14:45:32",
+                "firstOnline": "2019-06-12T14:53:26",
+                "posted": "2019-06-18T14:45:32"
+            },
+            "created_date": "2019-06-12T14:51:31Z",
+            "url_private_api": "https://api.figshare.com/v2/account/articles/8263811",
+            "url_public_api": "https://api.figshare.com/v2/articles/8263811",
+            "id": 8263811,
+            "modified_date": "2019-06-18T14:45:32Z",
+            "doi": "10.6084/m9.figshare.8263811",
+            "thumb": "",
+            "title": "Dataset",
+            "url": "https://api.figshare.com/v2/account/projects/64916/articles/8263811",
+            "defined_type": 3,
+            "resource_title": null,
+            "url_public_html": "https://figshare.com/articles/Dataset01_txt/8263811",
+            "resource_doi": null,
+            "published_date": "2019-06-18T14:45:32Z",
+            "group_id": null
+        },
+        {
+            "defined_type_name": "dataset",
+            "handle": "",
+            "url_private_html": "https://figshare.com/account/articles/8269766",
+            "timeline": {},
+            "created_date": "2019-06-13T15:58:25Z",
+            "url_private_api": "https://api.figshare.com/v2/account/articles/8269766",
+            "url_public_api": "https://api.figshare.com/v2/articles/8269766",
+            "id": 8269766,
+            "modified_date": "2019-06-13T16:00:12Z",
+            "doi": "",
+            "thumb": "",
+            "title": "DatasetPrivate",
+            "url": "https://api.figshare.com/v2/account/projects/64916/articles/8269766",
+            "defined_type": 3,
+            "resource_title": null,
+            "url_public_html": "https://figshare.com/articles/_/8269766",
+            "resource_doi": null,
+            "published_date": null,
+            "group_id": null
+        }
+    ]
+}

--- a/tests/providers/figshare/fixtures/root_provider.json
+++ b/tests/providers/figshare/fixtures/root_provider.json
@@ -1,270 +1,261 @@
-{  
-    "get_file_metadata":{  
-        "status":"created",
-        "is_link_only":false,
-        "name":"barricade.gif",
-        "viewer_type":"",
-        "preview_state":"preview_not_available",
-        "download_url":"https://ndownloader.figshare.com/files/6530715",
-        "supplied_md5":"",
-        "computed_md5":"",
-        "upload_token":"c9d1a465-f3f6-402c-8106-db3493942303",
-        "upload_url":"https://fup100310.figshare.com/upload/c9d1a465-f3f6-402c-8106-db3493942303",
-        "id":6530715,
-        "size":6
+{
+    "get_file_metadata": {
+        "status": "created",
+        "is_link_only": false,
+        "name": "barricade.gif",
+        "viewer_type": "",
+        "preview_state": "preview_not_available",
+        "download_url": "https://ndownloader.figshare.com/files/6530715",
+        "supplied_md5": "",
+        "computed_md5": "",
+        "upload_token": "c9d1a465-f3f6-402c-8106-db3493942303",
+        "upload_url": "https://fup100310.figshare.com/upload/c9d1a465-f3f6-402c-8106-db3493942303",
+        "id": 6530715,
+        "size": 6
     },
-    "get_upload_metadata":{  
-        "token":"c9d1a465-f3f6-402c-8106-db3493942303",
-        "md5":"13365d367683301ee26d9d76d25c518b",      
+    "get_upload_metadata": {
+        "token": "c9d1a465-f3f6-402c-8106-db3493942303",
+        "md5": "13365d367683301ee26d9d76d25c518b",
         "size": 6,
-        "name":"6530715/barricade.gif",
-        "status":"PENDING",
-        "parts":[  
-            {  
-                "partNo":1,
-                "startOffset":0,
-                "endOffset":5,
-                "status":"PENDING",
-                "locked":false
+        "name": "6530715/barricade.gif",
+        "status": "PENDING",
+        "parts": [
+            {
+                "partNo": 1,
+                "startOffset": 0,
+                "endOffset": 5,
+                "status": "PENDING",
+                "locked": false
             }
         ]
     },
-    "list_project_articles":[  
-        {  
-            "modified_date":"2016-10-18T12:56:27Z",
-            "doi":"",
-            "title":"file_article",
-            "url":"https://api.figshare.com/v2/account/projects/13423/articles/4037952",
-            "created_date":"2016-10-18T12:55:44Z",
-            "id":4037952,
-            "published_date":null
+    "list_project_articles": [
+        {
+            "modified_date": "2016-10-18T12:56:27Z",
+            "doi": "",
+            "title": "file_article",
+            "url": "https://api.figshare.com/v2/account/projects/13423/articles/4037952",
+            "created_date": "2016-10-18T12:55:44Z",
+            "id": 4037952,
+            "published_date": null
         },
-        {  
-            "modified_date":"2016-10-18T20:47:25Z",
-            "doi":"",
-            "title":"folder_article",
-            "url":"https://api.figshare.com/v2/account/projects/13423/articles/4040019",
-            "created_date":"2016-10-18T20:47:25Z",
-            "id":4040019,
-            "published_date":null
+        {
+            "modified_date": "2016-10-18T20:47:25Z",
+            "doi": "",
+            "title": "folder_article",
+            "url": "https://api.figshare.com/v2/account/projects/13423/articles/4040019",
+            "created_date": "2016-10-18T20:47:25Z",
+            "id": 4040019,
+            "published_date": null
         }
     ],
-    "public_list_project_articles":[  
-        {  
-            "modified_date":"2016-10-18T12:56:27Z",
-            "doi":"",
-            "title":"file_article",
-            "url":"https://bad/v2/account/projects/13423/articles/4037952",
-            "created_date":"2016-10-18T12:55:44Z",
-            "id":4037952,
-            "published_date":null
+    "public_list_project_articles": [
+        {
+            "modified_date": "2016-10-18T12:56:27Z",
+            "doi": "",
+            "title": "file_article",
+            "url": "https://bad/v2/account/projects/13423/articles/4037952",
+            "created_date": "2016-10-18T12:55:44Z",
+            "id": 4037952,
+            "published_date": null
         },
-        {  
-            "modified_date":"2016-10-18T20:47:25Z",
-            "doi":"",
-            "title":"folder_article",
-            "url":"https://api.figshare.com/v2/account/projects/13423/articles/4040019",
-            "created_date":"2016-10-18T20:47:25Z",
-            "id":4040019,
-            "published_date":null
+        {
+            "modified_date": "2016-10-18T20:47:25Z",
+            "doi": "",
+            "title": "folder_article",
+            "url": "https://api.figshare.com/v2/account/projects/13423/articles/4040019",
+            "created_date": "2016-10-18T20:47:25Z",
+            "id": 4040019,
+            "published_date": null
         },
-        {  
-            "modified_date":"2016-10-18T20:47:25Z",
-            "doi":"",
-            "title":"file_article_bad",
-            "url":"https://bad/v2/account/projects/13423/articles/5040019",
-            "created_date":"2016-10-18T20:47:25Z",
-            "id":5040019,
-            "published_date":null
+        {
+            "modified_date": "2016-10-18T20:47:25Z",
+            "doi": "",
+            "title": "file_article_bad",
+            "url": "https://bad/v2/account/projects/13423/articles/5040019",
+            "created_date": "2016-10-18T20:47:25Z",
+            "id": 5040019,
+            "published_date": null
         }
     ],
-    "file_article_metadata":{  
-        "group_resource_id":null,
-        "embargo_date":null,
-        "citation":"Baxter, Thomas (): file_article. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
-        "embargo_reason":"",
-        "references":[  
-
+    "file_article_metadata": {
+        "group_resource_id": null,
+        "embargo_date": null,
+        "citation": "Baxter, Thomas (): file_article. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
+        "embargo_reason": "",
+        "references": [
         ],
-        "id":4037952,
-        "custom_fields":[  
-
+        "id": 4037952,
+        "custom_fields": [
         ],
-        "size":0,
-        "metadata_reason":"",
-        "funding":"",
-        "figshare_url":"https://figshare.com/articles/_/4037952",
-        "embargo_type":null,
-        "title":"file_article",
-        "defined_type":3,
-        "is_embargoed":false,
-        "version":0,
-        "resource_doi":null,
-        "confidential_reason":"",
-        "files":[  
-            {  
-                "status":"available",
-                "is_link_only":false,
-                "name":"file",
-                "viewer_type":"",
-                "preview_state":"preview_not_supported",
-                "download_url":"https://ndownloader.figshare.com/files/6530715",
-                "supplied_md5":"b3e656f8b0828a31f3ed396a1c868786",
-                "computed_md5":"b3e656f8b0828a31f3ed396a1c868786",
-                "upload_token":"878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
-                "upload_url":"",
-                "id":6530715,
-                "size":7
+        "size": 0,
+        "metadata_reason": "",
+        "funding": "",
+        "figshare_url": "https://figshare.com/articles/_/4037952",
+        "embargo_type": null,
+        "title": "file_article",
+        "defined_type": 3,
+        "is_embargoed": false,
+        "version": 0,
+        "resource_doi": null,
+        "confidential_reason": "",
+        "files": [
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "file",
+                "viewer_type": "",
+                "preview_state": "preview_not_supported",
+                "download_url": "https://ndownloader.figshare.com/files/6530715",
+                "supplied_md5": "b3e656f8b0828a31f3ed396a1c868786",
+                "computed_md5": "b3e656f8b0828a31f3ed396a1c868786",
+                "upload_token": "878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
+                "upload_url": "",
+                "id": 6530715,
+                "size": 7
             }
         ],
-        "description":"",
-        "tags":[  
-
+        "description": "",
+        "tags": [
         ],
-        "created_date":"2016-10-18T12:55:44Z",
-        "is_active":true,
-        "authors":[  
-            {  
-                "url_name":"_",
-                "is_active":true,
-                "id":2665435,
-                "full_name":"Thomas Baxter",
-                "orcid_id":""
+        "created_date": "2016-10-18T12:55:44Z",
+        "is_active": true,
+        "authors": [
+            {
+                "url_name": "_",
+                "is_active": true,
+                "id": 2665435,
+                "full_name": "Thomas Baxter",
+                "orcid_id": ""
             }
         ],
-        "is_public":false,
-        "categories":[  
-
+        "is_public": false,
+        "categories": [
         ],
-        "modified_date":"2016-10-18T12:56:27Z",
-        "is_confidential":false,
-        "doi":"",
-        "license":{  
-            "url":"https://creativecommons.org/licenses/by/4.0/",
-            "name":"CC-BY",
-            "value":1
+        "modified_date": "2016-10-18T12:56:27Z",
+        "is_confidential": false,
+        "doi": "",
+        "license": {
+            "url": "https://creativecommons.org/licenses/by/4.0/",
+            "name": "CC-BY",
+            "value": 1
         },
-        "has_linked_file":false,
-        "url":"https://api.figshare.com/v2/account/projects/13423/articles/4037952",
-        "resource_title":null,
-        "status":"draft",
-        "published_date":null,
-        "is_metadata_record":false
+        "has_linked_file": false,
+        "url": "https://api.figshare.com/v2/account/projects/13423/articles/4037952",
+        "resource_title": null,
+        "status": "draft",
+        "published_date": null,
+        "is_metadata_record": false
     },
-    "file_metadata":{  
-        "status":"available",
-        "is_link_only":false,
-        "name":"file",
-        "viewer_type":"",
-        "preview_state":"preview_not_supported",
-        "download_url":"https://ndownloader.figshare.com/files/6530715",
-        "supplied_md5":"b3e656f8b0828a31f3ed396a1c868786",
-        "computed_md5":"b3e656f8b0828a31f3ed396a1c868786",
-        "upload_token":"878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
-        "upload_url":"",
-        "id":6530715,
-        "size":7
+    "file_metadata": {
+        "status": "available",
+        "is_link_only": false,
+        "name": "file",
+        "viewer_type": "",
+        "preview_state": "preview_not_supported",
+        "download_url": "https://ndownloader.figshare.com/files/6530715",
+        "supplied_md5": "b3e656f8b0828a31f3ed396a1c868786",
+        "computed_md5": "b3e656f8b0828a31f3ed396a1c868786",
+        "upload_token": "878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
+        "upload_url": "",
+        "id": 6530715,
+        "size": 7
     },
-    "file_metadata_public":{  
-        "status":"available",
-        "is_link_only":false,
-        "name":"file",
-        "viewer_type":"",
-        "preview_state":"preview_not_supported",
-        "download_url":"https://ndownloader.figshare.com/files/5040019",
-        "supplied_md5":"b3e656f8b0828a31f3ed396a1c868786",
-        "computed_md5":"b3e656f8b0828a31f3ed396a1c868786",
-        "upload_token":"878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
-        "upload_url":"",
-        "id":5040019,
-        "size":7
+    "file_metadata_public": {
+        "status": "available",
+        "is_link_only": false,
+        "name": "file",
+        "viewer_type": "",
+        "preview_state": "preview_not_supported",
+        "download_url": "https://ndownloader.figshare.com/files/5040019",
+        "supplied_md5": "b3e656f8b0828a31f3ed396a1c868786",
+        "computed_md5": "b3e656f8b0828a31f3ed396a1c868786",
+        "upload_token": "878068bf-8cdb-40c9-bcf4-5d8065ac2f7d",
+        "upload_url": "",
+        "id": 5040019,
+        "size": 7
     },
-    "folder_article_metadata":{  
-        "group_resource_id":null,
-        "embargo_date":null,
-        "citation":"Baxter, Thomas (): folder_article. figshare.\n \n Retrieved: 19 27, Oct 19, 2016 (GMT)",
-        "embargo_reason":"",
-        "references":[  
-
+    "folder_article_metadata": {
+        "group_resource_id": null,
+        "embargo_date": null,
+        "citation": "Baxter, Thomas (): folder_article. figshare.\n \n Retrieved: 19 27, Oct 19, 2016 (GMT)",
+        "embargo_reason": "",
+        "references": [
         ],
-        "id":4040019,
-        "custom_fields":[  
-
+        "id": 4040019,
+        "custom_fields": [
         ],
-        "size":0,
-        "metadata_reason":"",
-        "funding":"",
-        "figshare_url":"https://figshare.com/articles/_/4040019",
-        "embargo_type":null,
-        "title":"folder_article",
-        "defined_type":4,
-        "is_embargoed":false,
-        "version":0,
-        "resource_doi":null,
-        "confidential_reason":"",
-        "files":[  
-            {  
-                "status":"available",
-                "is_link_only":false,
-                "name":"folder_file.png",
-                "viewer_type":"image",
-                "preview_state":"preview_available",
-                "download_url":"https://ndownloader.figshare.com/files/6517539",
-                "supplied_md5":"",
-                "computed_md5":"03dee7cf60f17a8453ccd2f51cbbbd86",
-                "upload_token":"3f106f31-d62e-40e7-bac8-c6092392142d",
-                "upload_url":"",
-                "id":6517539,
-                "size":15584
+        "size": 0,
+        "metadata_reason": "",
+        "funding": "",
+        "figshare_url": "https://figshare.com/articles/_/4040019",
+        "embargo_type": null,
+        "title": "folder_article",
+        "defined_type": 4,
+        "is_embargoed": false,
+        "version": 0,
+        "resource_doi": null,
+        "confidential_reason": "",
+        "files": [
+            {
+                "status": "available",
+                "is_link_only": false,
+                "name": "folder_file.png",
+                "viewer_type": "image",
+                "preview_state": "preview_available",
+                "download_url": "https://ndownloader.figshare.com/files/6517539",
+                "supplied_md5": "",
+                "computed_md5": "03dee7cf60f17a8453ccd2f51cbbbd86",
+                "upload_token": "3f106f31-d62e-40e7-bac8-c6092392142d",
+                "upload_url": "",
+                "id": 6517539,
+                "size": 15584
             }
         ],
-        "description":"",
-        "tags":[  
-
+        "description": "",
+        "tags": [
         ],
-        "created_date":"2016-10-18T20:47:25Z",
-        "is_active":true,
-        "authors":[  
-            {  
-                "url_name":"_",
-                "is_active":true,
-                "id":2665435,
-                "full_name":"Thomas Baxter",
-                "orcid_id":""
+        "created_date": "2016-10-18T20:47:25Z",
+        "is_active": true,
+        "authors": [
+            {
+                "url_name": "_",
+                "is_active": true,
+                "id": 2665435,
+                "full_name": "Thomas Baxter",
+                "orcid_id": ""
             }
         ],
-        "is_public":false,
-        "categories":[  
-
+        "is_public": false,
+        "categories": [
         ],
-        "modified_date":"2016-10-18T20:47:25Z",
-        "is_confidential":false,
-        "doi":"",
-        "license":{  
-            "url":"https://creativecommons.org/licenses/by/4.0/",
-            "name":"CC-BY",
-            "value":1
+        "modified_date": "2016-10-18T20:47:25Z",
+        "is_confidential": false,
+        "doi": "",
+        "license": {
+            "url": "https://creativecommons.org/licenses/by/4.0/",
+            "name": "CC-BY",
+            "value": 1
         },
-        "has_linked_file":false,
-        "url":"https://api.figshare.com/v2/account/projects/13423/articles/4040019",
-        "resource_title":null,
-        "status":"draft",
-        "published_date":null,
-        "is_metadata_record":false
+        "has_linked_file": false,
+        "url": "https://api.figshare.com/v2/account/projects/13423/articles/4040019",
+        "resource_title": null,
+        "status": "draft",
+        "published_date": null,
+        "is_metadata_record": false
     },
-    "folder_file_metadata":{  
-        "status":"available",
-        "is_link_only":false,
-        "name":"folder_file.png",
-        "viewer_type":"image",
-        "preview_state":"preview_available",
-        "download_url":"https://ndownloader.figshare.com/files/6517539",
-        "supplied_md5":"",
-        "computed_md5":"03dee7cf60f17a8453ccd2f51cbbbd86",
-        "upload_token":"3f106f31-d62e-40e7-bac8-c6092392142d",
-        "upload_url":"",
-        "id":6517539,
-        "size":15584
+    "folder_file_metadata": {
+        "status": "available",
+        "is_link_only": false,
+        "name": "folder_file.png",
+        "viewer_type": "image",
+        "preview_state": "preview_available",
+        "download_url": "https://ndownloader.figshare.com/files/6517539",
+        "supplied_md5": "",
+        "computed_md5": "03dee7cf60f17a8453ccd2f51cbbbd86",
+        "upload_token": "3f106f31-d62e-40e7-bac8-c6092392142d",
+        "upload_url": "",
+        "id": 6517539,
+        "size": 15584
     }
-
 }

--- a/tests/providers/figshare/fixtures/root_provider.json
+++ b/tests/providers/figshare/fixtures/root_provider.json
@@ -79,6 +79,8 @@
         }
     ],
     "file_article_metadata": {
+        "url_public_html": "url_public_html_fake",
+        "url_private_html": "url_private_html_fake",
         "group_resource_id": null,
         "embargo_date": null,
         "citation": "Baxter, Thomas (): file_article. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
@@ -94,7 +96,7 @@
         "figshare_url": "https://figshare.com/articles/_/4037952",
         "embargo_type": null,
         "title": "file_article",
-        "defined_type": 3,
+        "defined_type": 1,
         "is_embargoed": false,
         "version": 0,
         "resource_doi": null,
@@ -176,6 +178,8 @@
         "size": 7
     },
     "folder_article_metadata": {
+        "url_public_html": "url_public_html_fake",
+        "url_private_html": "url_private_html_fake",
         "group_resource_id": null,
         "embargo_date": null,
         "citation": "Baxter, Thomas (): folder_article. figshare.\n \n Retrieved: 19 27, Oct 19, 2016 (GMT)",

--- a/tests/providers/figshare/test_metadata.py
+++ b/tests/providers/figshare/test_metadata.py
@@ -4,27 +4,25 @@ from waterbutler.providers.figshare.metadata import (FigshareFileMetadata,
                                                      FigshareFolderMetadata,
                                                      FigshareFileRevisionMetadata)
 
-from tests.providers.figshare.fixtures import root_provider_fixtures
+from tests.providers.figshare.fixtures import (project_article_type_1_metadata,
+                                               project_article_type_3_metadata)
 
 
 class TestFigshareFileMetadata:
 
-    def test_file_metadata(self, root_provider_fixtures):
-        base_meta = root_provider_fixtures['file_article_metadata']
-        data = FigshareFileMetadata(
-            base_meta,
-            base_meta['files'][0]
-        )
+    def test_private_file_metadata(self, project_article_type_1_metadata):
+        base_meta = project_article_type_1_metadata['private']
+        data = FigshareFileMetadata(base_meta, base_meta['files'][0])
 
-        assert data.id == 6530715
-        assert data.name == 'file'
-        assert data.article_id == 4037952
-        assert data.article_name == 'file_article'
-        assert data.path == '/4037952/6530715'
-        assert data.materialized_path == '/file_article/file'
-        assert data.upload_path == '/4037952/6530715'
-        assert data.size == 7
-        assert data.size_as_int == 7
+        assert data.id == 15562817
+        assert data.name == 'FigurePrivate01.png'
+        assert data.article_id == 8305859
+        assert data.article_name == 'FigurePrivate'
+        assert data.path == '/8305859/15562817'
+        assert data.materialized_path == '/FigurePrivate/FigurePrivate01.png'
+        assert data.upload_path == '/8305859/15562817'
+        assert data.size == 89281
+        assert data.size_as_int == 89281
         assert type(data.size_as_int) == int
 
         assert data.content_type is None
@@ -33,75 +31,75 @@ class TestFigshareFileMetadata:
         assert data.created_utc is None
         assert data.can_delete is True
         assert data.is_public is False
-        assert data.etag == 'draft:4037952:b3e656f8b0828a31f3ed396a1c868786'
-        assert data.web_view == 'https://figshare.com/account/articles/4037952'
+        assert data.etag == 'draft:8305859:cae3869aa4b144a3aa5cffe979359836'
+        assert data.web_view == 'https://figshare.com/account/articles/8305859'
         assert data.extra == {
-            'fileId': 6530715,
-            'articleId': 4037952,
+            'fileId': 15562817,
+            'articleId': 8305859,
             'status': 'draft',
-            'downloadUrl': 'https://ndownloader.figshare.com/files/6530715',
+            'downloadUrl': 'https://ndownloader.figshare.com/files/15562817',
             'canDelete': True,
-            'webView': 'https://figshare.com/account/articles/4037952',
+            'webView': 'https://figshare.com/account/articles/8305859',
             'hashes': {
-                'md5': 'b3e656f8b0828a31f3ed396a1c868786'
+                'md5': 'cae3869aa4b144a3aa5cffe979359836'
             }
         }
 
         assert data.kind == 'file'
         assert data.serialized() == {
             'extra': {
-                'fileId': 6530715,
-                'articleId': 4037952,
+                'fileId': 15562817,
+                'articleId': 8305859,
                 'status': 'draft',
-                'downloadUrl': 'https://ndownloader.figshare.com/files/6530715',
+                'downloadUrl': 'https://ndownloader.figshare.com/files/15562817',
                 'canDelete': True,
-                'webView': 'https://figshare.com/account/articles/4037952',
+                'webView': 'https://figshare.com/account/articles/8305859',
                 'hashes': {
-                    'md5': 'b3e656f8b0828a31f3ed396a1c868786'
+                    'md5': 'cae3869aa4b144a3aa5cffe979359836'
                 }
             },
             'kind': 'file',
-            'name': 'file',
-            'path': '/4037952/6530715',
+            'name': 'FigurePrivate01.png',
+            'path': '/8305859/15562817',
             'provider': 'figshare',
-            'materialized': '/file_article/file',
-            'etag': 'c22302dc6826efe0a70f9528a3edd3ec3af340d52ac248b2bf23fd64d6ffea8d',
+            'materialized': '/FigurePrivate/FigurePrivate01.png',
+            'etag': '0113713d8af08db5fb6a0f6565b115d98d0f6c284b808a58997f1e73bdec397e',
             'contentType': None,
             'modified': None,
             'modified_utc': None,
             'created_utc': None,
-            'size': 7,
-            'sizeInt': 7,
+            'size': 89281,
+            'sizeInt': 89281,
         }
 
-        api_url = 'http://localhost:7777/v1/resources/cn42d/providers/figshare/4037952/6530715'
+        api_url = 'http://localhost:7777/v1/resources/cn42d/providers/figshare/8305859/15562817'
         assert data.json_api_serialized('cn42d') == {
-            'id': 'figshare/4037952/6530715',
+            'id': 'figshare/8305859/15562817',
             'type': 'files',
             'attributes': {
                 'extra': {
-                    'fileId': 6530715,
-                    'articleId': 4037952,
+                    'fileId': 15562817,
+                    'articleId': 8305859,
                     'status': 'draft',
-                    'downloadUrl': 'https://ndownloader.figshare.com/files/6530715',
+                    'downloadUrl': 'https://ndownloader.figshare.com/files/15562817',
                     'canDelete': True,
-                    'webView': 'https://figshare.com/account/articles/4037952',
+                    'webView': 'https://figshare.com/account/articles/8305859',
                     'hashes': {
-                        'md5': 'b3e656f8b0828a31f3ed396a1c868786'
+                        'md5': 'cae3869aa4b144a3aa5cffe979359836'
                     }
                 },
                 'kind': 'file',
-                'name': 'file',
-                'path': '/4037952/6530715',
+                'name': 'FigurePrivate01.png',
+                'path': '/8305859/15562817',
                 'provider': 'figshare',
-                'materialized': '/file_article/file',
-                'etag': 'c22302dc6826efe0a70f9528a3edd3ec3af340d52ac248b2bf23fd64d6ffea8d',
+                'materialized': '/FigurePrivate/FigurePrivate01.png',
+                'etag': '0113713d8af08db5fb6a0f6565b115d98d0f6c284b808a58997f1e73bdec397e',
                 'contentType': None,
                 'modified': None,
                 'modified_utc': None,
                 'created_utc': None,
-                'size': 7,
-                'sizeInt': 7,
+                'size': 89281,
+                'sizeInt': 89281,
                 'resource': 'cn42d'
             },
             'links': {
@@ -119,72 +117,78 @@ class TestFigshareFileMetadata:
             'download': api_url,
         }
 
-    def test_public_file_metadata(self, root_provider_fixtures):
-        item = root_provider_fixtures['file_article_metadata']
+    def test_public_file_metadata(self, project_article_type_1_metadata):
+        item = project_article_type_1_metadata['public']
         public_metadata = FigshareFileMetadata(item, item['files'][0])
-        public_metadata.raw['url'] = 'https://api.figshare.com/v2'
 
-        assert public_metadata.name == 'file'
+        assert public_metadata.id == 15451592
+        assert public_metadata.name == 'Figure01.png'
+        assert public_metadata.article_id == 8263730
+        assert public_metadata.article_name == 'Figure'
         assert public_metadata.is_public is True
-        assert public_metadata.web_view == 'https://figshare.com/articles/4037952'
+        assert public_metadata.web_view == 'https://figshare.com/articles/Figure01_png/8263730'
+        assert public_metadata.extra.get('status') == 'public'
 
-    def test_metadata_article_identifier(self, root_provider_fixtures):
-        item = root_provider_fixtures['file_article_metadata']
+    def test_metadata_article_identifier(self, project_article_type_1_metadata):
+        item = project_article_type_1_metadata['private']
         article_metadata = FigshareFileMetadata(item, item['files'][0])
-        article_metadata.raw['url'] = 'https://api.figshare.com/v2/account/articles/'
+        article_metadata.raw['url'] = 'https://api.figshare.com/v2/account/articles/8263730'
 
+        assert article_metadata.id == 15562817
+        assert article_metadata.name == 'FigurePrivate01.png'
+        assert article_metadata.article_id == 8305859
         assert article_metadata.article_name == ''
-        assert article_metadata.path == '/6530715'
-        assert article_metadata.materialized_path == '/file'
+        assert article_metadata.path == '/15562817'
+        assert article_metadata.materialized_path == '/FigurePrivate01.png'
 
-    def test_folder_metadata(self, root_provider_fixtures):
-        data = FigshareFolderMetadata(root_provider_fixtures['folder_article_metadata'])
+    def test_private_folder_metadata(self, project_article_type_3_metadata):
+        data = FigshareFolderMetadata(project_article_type_3_metadata['private'])
 
-        assert data.id == 4040019
-        assert data.name == 'folder_article'
-        assert data.path == '/4040019/'
-        assert data.materialized_path == '/folder_article/'
+        assert data.id == 8269766
+        assert data.name == 'DatasetPrivate'
+        assert data.path == '/8269766/'
+        assert data.materialized_path == '/DatasetPrivate/'
         assert data.size is None
-        assert data.modified == '2016-10-18T20:47:25Z'
+        assert data.modified == '2019-06-13T16:00:12Z'
         assert data.created_utc is None
-        assert data.etag == 'draft::::4040019'
+        assert data.etag == 'draft::::8269766'
         assert data.kind == 'folder'
         assert data.extra == {
-            'id': 4040019,
+            'id': 8269766,
             'doi': '',
             'status': 'draft'
         }
 
         assert data.serialized() == {
             'extra': {
-                'id': 4040019,
+                'id': 8269766,
                 'doi': '',
                 'status': 'draft'
             },
             'kind': 'folder',
-            'name': 'folder_article',
-            'path': '/4040019/',
+            'name': 'DatasetPrivate',
+            'path': '/8269766/',
             'provider': 'figshare',
-            'materialized': '/folder_article/',
-            'etag': '6bef522e6f14597fd939b6b5c29e99091dc0b0badcac332da6e75bec0a69cf5e'
+            'materialized': '/DatasetPrivate/',
+            'etag': 'd7dc67b05e9c50c8adefabc9e2ff2cfaabad26913e8c9916396f067216941389'
         }
 
-        api_url = 'http://localhost:7777/v1/resources/45hjnz/providers/figshare/4040019/'
+        api_url = 'http://localhost:7777/v1/resources/45hjnz/providers/figshare/8269766/'
         assert data.json_api_serialized('45hjnz') == {
-            'id': 'figshare/4040019/',
+            'id': 'figshare/8269766/',
             'type': 'files',
             'attributes': {
                 'extra': {
-                    'id': 4040019,
+                    'id': 8269766,
                     'doi': '',
                     'status': 'draft'
                 },
                 'kind': 'folder',
-                'name': 'folder_article',
-                'path': '/4040019/',
+                'name': 'DatasetPrivate',
+                'path': '/8269766/',
                 'provider': 'figshare',
-                'materialized': '/folder_article/',
-                'etag': '6bef522e6f14597fd939b6b5c29e99091dc0b0badcac332da6e75bec0a69cf5e',
+                'materialized': '/DatasetPrivate/',
+                'etag': 'd7dc67b05e9c50c8adefabc9e2ff2cfaabad26913e8c9916396f067216941389',
                 'resource': '45hjnz',
                 'size': None,
                 'sizeInt': None,
@@ -203,6 +207,13 @@ class TestFigshareFileMetadata:
             'delete': api_url,
             'new_folder': '{}?kind=folder'.format(api_url),
         }
+
+    def test_public_folder_metadata(self, project_article_type_3_metadata):
+        data = FigshareFolderMetadata(project_article_type_3_metadata['public'])
+
+        assert data.id == 8263811
+        assert data.name == 'Dataset'
+        assert data.extra.get('status') == 'public'
 
     def test_revision_metadata(self):
         data = FigshareFileRevisionMetadata()

--- a/waterbutler/auth/osf/handler.py
+++ b/waterbutler/auth/osf/handler.py
@@ -116,7 +116,12 @@ class OsfAuthHandler(BaseAuthHandler):
                 raise exceptions.UnsupportedActionError(mfr_action, supported=mfr_action_map.keys())
         else:
             try:
-                osf_action = self.ACTION_MAP[method]
+                if method == 'get' and 'meta' in request.query_arguments:
+                    osf_action = 'metadata'
+                elif method == 'get' and 'revisions' in request.query_arguments:
+                    osf_action = 'revisions'
+                else:
+                    osf_action = self.ACTION_MAP[method]
             except KeyError:
                 raise exceptions.UnsupportedHTTPMethodError(method, supported=self.ACTION_MAP.keys())
 

--- a/waterbutler/providers/figshare/metadata.py
+++ b/waterbutler/providers/figshare/metadata.py
@@ -1,6 +1,4 @@
 from waterbutler.core import metadata
-from waterbutler.core.provider import build_url
-
 from waterbutler.providers.figshare import settings
 
 
@@ -81,15 +79,27 @@ class FigshareFileMetadata(BaseFigshareMetadata, metadata.BaseFileMetadata):
 
     @property
     def is_public(self):
-        return (settings.PRIVATE_IDENTIFIER not in self.raw['url'])
+        """A property which indicates whether the article is public or not.
+
+        The figshare "articles" endpoint now returns a dedicated field "is_public" to indicate if
+        this article is public or not.  Every file in the article shares the same public/private
+        attribute with its parent article.
+        """
+        return self.raw['is_public']
 
     @property
     def web_view(self):
+        """A property which is a URL that let users view the article on the figshare website.
+
+        The figshare "articles" endpoint now returns two dedicated fields for users to view the
+        article on the figshare website, namely "url_private_html" and "url_public_html".  For all
+        articles, both EXIST in the API response with a non-empty value.  The trick is, however,
+        that both URLs WORK for public articles while only the former WORKS for private ones.
+        """
         if self.is_public:
-            segments = ('articles', str(self.article_id))
+            return self.raw['url_public_html']
         else:
-            segments = ('account', 'articles', str(self.article_id))
-        return build_url(settings.VIEW_URL, *segments)
+            return self.raw['url_private_html']
 
     @property
     def can_delete(self):

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -389,6 +389,7 @@ class FigshareProjectProvider(BaseFigshareProvider):
                 article_name = article['title']
                 is_public = article['published_date'] is not None
                 break
+        # Raise error earlier instead of on 404.  Please note that this is different than V0.
         if not article_name:
             raise exceptions.NotFoundError('Path {} with article ID {} not found in the project\'s '
                                            'article list'.format(path, article_id))
@@ -460,9 +461,7 @@ class FigshareProjectProvider(BaseFigshareProvider):
                 article_name = article['title']
                 is_public = article['published_date'] is not None
                 break
-        if not article_name:
-            raise exceptions.NotFoundError('Path {} with article ID {} not found in the project\'s '
-                                           'article list'.format(path, article_id))
+
         article_segments = (*self.root_path_parts, 'articles', article_id)
 
         if file_id:

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -136,11 +136,22 @@ class BaseFigshareProvider(provider.BaseProvider):
         :param dict \*\*query: A dictionary that will be turned into query parameters ``?foo=bar``
         :rtype: str
 
-        Subclassed to include handling of ``is_public`` argument. ``collection`` containers may
-        contain public articles which are accessed through an URN with a different prefix.
+        Overrides its parent's ``build_url()`` by building a URL that points to the public access
+        API of an article or its files if the ``is_public`` argument is set.  This is a special
+        design for figshare collections which may contain public articles that don't belong to the
+        current figshare-OSF OAuth user.
+
+        Quirk: Due to the facts that 1) the public URL Waterbulter builds no longer works due to
+               figshare-side changes and that 2) the collections stuff is still WIP, we decide to
+               ignore the ``is_public`` argument for now and always build private API URLs.
+
+        TODO [SVCS-996]: fix the public API and set public only when the container is a collection
+        TODO [SVCS-996]: set the public flag only when the container is a collection
         """
-        if not is_public:
-            segments = ('account', (*segments))
+        if is_public:
+            logger.debug('figshare provider is yet to build the public API URL correctly. '
+                         'Switch back to use the private one instead')
+        segments = ('account', (*segments))
         return (super().build_url(*segments, **query))
 
     async def make_request(self, method, url, *args, **kwargs):

--- a/waterbutler/providers/figshare/settings.py
+++ b/waterbutler/providers/figshare/settings.py
@@ -12,7 +12,6 @@ VALID_CONTAINER_TYPES = ['project', 'collection', 'article', 'dataset', 'fileset
 ARTICLE_CONTAINER_TYPES = ['article', 'dataset', 'fileset']
 FOLDER_TYPES = [3, 4]  # figshare ID for Dataset (3) and Fileset (4, deprecated)
 
-PRIVATE_IDENTIFIER = 'https://api.figshare.com/v2/account/'
 ARTICLE_TYPE_IDENTIFIER = 'https://api.figshare.com/v2/account/articles/'
 
 # During initial testing this was set to 2 because file was not instantly ready after receiving HTTP 201

--- a/waterbutler/providers/figshare/settings.py
+++ b/waterbutler/providers/figshare/settings.py
@@ -7,8 +7,9 @@ BASE_URL = config.get('BASE_URL', 'https://api.figshare.com/v2')
 VIEW_URL = config.get('VIEW_URL', 'https://figshare.com/')
 DOWNLOAD_URL = config.get('VIEW_URL', 'https://ndownloader.figshare.com/')
 
-VALID_CONTAINER_TYPES = ['project', 'collection', 'article', 'fileset']
-# TODO [SVCS-996]: expand the list with more folder-like article types
+# TODO [SVCS-996]: expand all 3 lists below with more folder-like article types
+VALID_CONTAINER_TYPES = ['project', 'collection', 'article', 'dataset', 'fileset']
+ARTICLE_CONTAINER_TYPES = ['article', 'dataset', 'fileset']
 FOLDER_TYPES = [3, 4]  # figshare ID for Dataset (3) and Fileset (4, deprecated)
 
 PRIVATE_IDENTIFIER = 'https://api.figshare.com/v2/account/'

--- a/waterbutler/providers/figshare/settings.py
+++ b/waterbutler/providers/figshare/settings.py
@@ -8,7 +8,8 @@ VIEW_URL = config.get('VIEW_URL', 'https://figshare.com/')
 DOWNLOAD_URL = config.get('VIEW_URL', 'https://ndownloader.figshare.com/')
 
 VALID_CONTAINER_TYPES = ['project', 'collection', 'article', 'fileset']
-FOLDER_TYPES = [4]  # Figshare ID for filesets
+# TODO [SVCS-996]: expand the list with more folder-like article types
+FOLDER_TYPES = [3, 4]  # figshare ID for Dataset (3) and Fileset (4, deprecated)
 
 PRIVATE_IDENTIFIER = 'https://api.figshare.com/v2/account/'
 ARTICLE_TYPE_IDENTIFIER = 'https://api.figshare.com/v2/account/articles/'


### PR DESCRIPTION
## Ticket

WB: https://openscience.atlassian.net/browse/ENG-380
By-product: https://openscience.atlassian.net/browse/ENG-649
Future-fix: https://openscience.atlassian.net/browse/ENG-996

## Purpose

### Main

Fix the broken web view link for figshare files. (ENG-380)

* Previously, WB checks whether a figshare article is public or not simply by checking if the `url` field in the JSON response for the article details contains (starts with) the `PRIVATE_IDENTIFIER`: "https://api.figshare.com/v2/account/". This no longer works now since figshare uses the same format for this field for all articles. Fortunately, the JSON response now provides the `is_public` field which is more intuitive and more convenient.

* In addition, the public **HTML** URL we build no longer works either. The aforementioned JSON response also provides two new fields: `url_public_html` and `url_private_html`, which are exactly what we need.

### By-product

* Similarly to figshare file metadata, checking whether a figshare path is public or not is fixed. Please don't confuse `FigsharePath.is_public` with `FigshareFileMetadata.is_public`. In addition, `FigshareBaseProvider.build_url()` now builds private **API** URL only. The main reasons are public **API** URL 1) is broken as it is written and 2) should've been used for collections only. (ENG-380)
* Refactored `Fileset` to `Dataset`. (ENG-649)

### No Fix

* All article types now become folder-like containers for figshare.
* Public API URL for collection containers.
* Comments and DocStr is not fully rewritten due to this is a partial fix.

Please refer to this [JIRA page](https://openscience.atlassian.net/wiki/spaces/SVCS/pages/817037313) for a comprehensive solution for article types and public API endpoints and this [SVCS task](https://openscience.atlassian.net/browse/ENG-996) for implementation for a full fix.

## Changes

### Figshare File Metadata

fighsare article details request now returns several useful information including: `is_public`, `url_private_html` and `url_public_html`.

* `FigshareFileMetadata.is_public` is now set by the `is_public` key.
* `FigshareFileMetadata.web_view` is now set by either the `url_public_html` or `url_private_html` key, depending on the value of `FigshareFileMetadata.is_public`.

### By-product: Path Validation for Figshare Project Provider

Unlike the article detail request, the project article listing request only returns limited metadata for each article. While it does not provide the `is_public` field, WB can use the `published_date` field instead.

* In both V0 and V1 path validation, `FigsharePath.is_public` is now set by whether the `published_date` field for the current article is a date or `null`.

### By-product: Building URL

For more information on figshare project, collection, article and file, see the aforementioned [JIRA page](https://openscience.atlassian.net/wiki/spaces/SVCS/pages/817037313).

* The fix of `FigsharePath.is_public` reveals another issue that the public API URL WB builds for public project-article and project-article-file no longer works. Actually, figshare doesn't provide such a public API endpoint for them at all. To fix this, simply let the `BaseFigshareProvider.build_url()` build private API URL for project-article and project-article-file all the time, even if the `is_public` argument is `True`.

* Please note that the above fix is a correction instead of a fall-back. `project-article` and `project-article-file` should be accessed with the private API with the credentials of the figshare-OSF auth user. The public API URL was designed for collections only but never tested and enabled. The previous design to make the `FigshareProjectProvider` handle both projects and collections may no longer be feasible due to API differences.

* Please also note that article and article-file are independent of the project they are in. Some may not even belong to any project. figshare provides both public and private API URL at the article level (not the project level. However, we cannot use this public API URL when fetching metadata for an article with a project in the context since the response lacks necessary project information. The article level public API URL should only be used for article and article-file that belongs to collections.

### By-product: `Fileset` -> `Dataset`

Figshare somehow deprecates `Fileset` without any announcement and internally converts `Fileset` to `Dataset`. For example, previous `Fileset` article now becomes `Dataset` on the figshare website. Using API to create a `Fileset` ends up creating a `Dataset`. Fixing this issue makes figshare have folders again so we can test both folder and files. For the OSF side fix, see [OSF-PR#9078](https://github.com/CenterForOpenScience/osf.io/pull/9078).

* When detecting article types (folder or file), we now detects both `Dataset` and `Fileset`.
* When creating folders, we create `Dataset` instead of `Fileset`.
* In addition, added `Dataset` to valid container and folder list.

### Tests

I recommend you review the tests update by following the commits. Personally, I prefer having both a complex refactor for test_metadata` and `test_provider.TestProjectMetadata` and a fixture tweak for the rest. 

- [ ] However, if you prefer the simple fix for all, I will do that.

* Tests in `test_metadata` and `test_provider.TestProjectMetadata` have been fully rewritten and improved using newly generated fixtures. See https://github.com/CenterForOpenScience/waterbutler/pull/378/commits/1d5b97f2a2aee40785daa9525dda5fe08f7db9ba and https://github.com/CenterForOpenScience/waterbutler/pull/378/commits/f97f6de8051e9936ff8b02ada1d777c785e1b083.

* The rest of the tests in the `test_provider` are fixed by tweaking existing fixtures. See https://github.com/CenterForOpenScience/waterbutler/pull/378/commits/896973c9f1cdfb52c73a330d9e537a48776b9aff and https://github.com/CenterForOpenScience/waterbutler/pull/378/commits/2b93c73cf76bd40a1ecf04dde40d6787b9cdfb6a.

## Side effects

No

## QA Notes

First, you should expect to see a **working** figshare provider as you did before, where **working** is WB-wise not figshare-wise, that is to say, previous folders remain to be folders and previous files remain to be files.

As for the web view link, please test that the link works for the following case. Please note that the public and private has nothing to do with whether the OSF projects is public or not.

* When a figshare project is loaded as root.
  * Public file (the one file in a public article that are neither `Fileset` nor `Dataset`)
  * Private file (the one file in a private article  that are neither `Fileset` nor `Dataset`)
  * Public file in public folder (one of the file in a public article that is either `Fileset` or `Dataset`)
  * Private file in private folder (one of the file in a private article that is either `Fileset` or `Dataset`)
* When a figshare article (of folder type) is loaded as root, which can't be tested until the OSF side [OSF-PR#9078](https://github.com/CenterForOpenScience/osf.io/pull/9078) is merged.
  * Public file (the one file in a public article that are neither `Fileset` nor `Dataset`)
  * Private file (the one file in a private article  that are neither `Fileset` nor `Dataset`)

## Deployment Notes

This PR can be merged and deployed independent of the OSF side [OSF-PR#9078](https://github.com/CenterForOpenScience/osf.io/pull/9078) but I would recommend doing them together so QA can test both project root and article root.
