### PR TITLE
[ENG-748] Fix Incorrect Parent Folder For Box Chunked Upload

### DIFF
--- a/waterbutler/providers/box/provider.py
+++ b/waterbutler/providers/box/provider.py
@@ -604,7 +604,7 @@ class BoxProvider(provider.BaseProvider):
         async with self.request(
             'POST',
             self._build_upload_url(*segments),
-            data=json.dumps(data),
+            data=json.dumps(data, sort_keys=True),
             headers={'Content-Type': 'application/json'},
             expects=(201, ),
             throws=exceptions.UploadError,


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-748

## Purpose

### Main

Chunked upload fails to upload the file to the intended folder. Instead, the file ends up in the root folder. During chunked upload session creation, the wrong folder was provided as the parent in the data payload. It should be `path.parent.identifier` instead of the `self.folder`. Here is the [correct one](https://github.com/CenterForOpenScience/waterbutler/blob/develop/waterbutler/providers/box/provider.py#L504) with contiguous upload and here is the [wrong one](https://github.com/CenterForOpenScience/waterbutler/blob/develop/waterbutler/providers/box/provider.py#L596) with chunked upload.

- [x] Unit tests

### By-product

Correctly handle the mutually exclusiveness between file ID and parent folder ID during chunked upload session creation. During the creation, WB should EITHER provide the `path.identifier` (file ID) in the URL if the file already exists OR provide the `path.parent.identifier` (parent folder ID) in the data payload. In addition, providing both will get [a 400 with error `multiple_destinations`](https://developer.box.com/reference#section-error-response-body). Moreover, providing the parent folder ID when the file exists will get [a 409 with error `item_name_in_use`](https://developer.box.com/docs/error-codes#section-409-conflict).  Finally, chunked upload never asks user to confirm file conflicts and just overwrites.

- [x] Unit tests

### Out-of-scope

* [ENG-749](https://openscience.atlassian.net/browse/ENG-749)
  * When session creation returns status other than the expected 201, the error is not delivered to OSF files page immediately. This cause the OSF files page upload to hang either forever or  for a long time until a "unable to reach the provider" error is shown to the user.
* [ENG-750](https://openscience.atlassian.net/browse/ENG-750)
  * Box does not ask for user to confirm file overwrite during both normal and chunked upload.

## Changes

### Main

Use `path.parent.identifier` instead of the `self.folder`.

### By-product

Only add `folder_id` to payload data when `path.identifier` is `None`.

## Side effects

No

## QA Notes

Please refer to the **QA Notes** section in the [ticket](https://openscience.atlassian.net/browse/ENG-748).

## Deployment Notes

No
