### PR TITLE
[FR][ENG-444] improved GitHub revision handling

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -332,3 +332,35 @@ OSF-specific parameter used to identify special "view-only" links that are used 
 * **Type**: string
 * **Expected on**: ``GET`` requests for files or folders
 * **Notes**: Only used internally for the Open Science Framework.
+
+
+GitHub Provider Params
+++++++++++++++++++++++
+
+Query parameters specific to the GitHub provider.
+
+
+*commit / branch identification*
+********************************
+
+Not a single parameter, but rather a class of parameters.  WaterButler has used many different parameters to identify the branch or commit a particular file should be found under.  These parameters can be either a commit SHA or a branch name.  These parameters are ``ref``, ``version``, ``branch``, ``sha``, ``revision``.  All will continue to be supported to maintain back-compatibility, but ``ref`` (for SHAs or branch names) and ``branch`` (branch names only) are preferred.
+
+If both a SHA and a branch name are provided in different parameters, the SHA will take precedence.  If multiple parameters are given with different SHAs, then the order of precedence will be: ``ref``, ``version``, ``sha``, ``revision``, ``branch``.  If multiple parameters are given with different branches, the order of precedence is: ``branch``, ``ref``, ``version``, ``sha``, ``revision``.
+
+* **Type**: str
+* **Expected on**: Any GitHub provider request
+* **Interactions**: None
+
+
+fileSha
+*******
+
+Identifies a specific revision of a file via its SHA.
+
+.. warning::
+
+   **PLEASE DON'T USE THIS!**  This was a mistake and should have never been added.  It will hopefully be removed or at the very least demoted in a future version.  File SHAs only identify the contents of a file.  They provide no information about the file name, path, commit, branch, etc.
+
+* **Type**: str
+* **Expected on**: Any GitHub provider request
+* **Interactions**: The ``fileSha`` is always assumed to be a file revision that is an ancestor of the imputed   commit or branch ref.  Providing a ``fileSha`` for a file version that was committed after the imputed ref will result in a 404.

--- a/tests/providers/github/fixtures/root_provider.json
+++ b/tests/providers/github/fixtures/root_provider.json
@@ -181,6 +181,39 @@
         "git_refs_url":"https://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
         "events_url":"https://api.github.com/repos/octocat/Hello-World/events"
     },
+    "commit_metadata": {
+        "sha" : "43798985fdb727843a49946b391409086a7021f2",
+        "url" : "https://api.github.com/repos/felliott/wb-testing/git/commits/43798985fdb727843a49946b391409086a7021f2",
+        "tree" : {
+            "sha" : "394164986adbe26c0c7605c6fe627e4fe3b13aa6",
+            "url" : "https://api.github.com/repos/felliott/wb-testing/git/trees/394164986adbe26c0c7605c6fe627e4fe3b13aa6"
+        },
+        "parents" : [
+            {
+                "url" : "https://api.github.com/repos/felliott/wb-testing/git/commits/189ee803576e85487afe4f6fa590e4ff9a791c6b",
+                "sha" : "189ee803576e85487afe4f6fa590e4ff9a791c6b",
+                "html_url" : "https://github.com/felliott/wb-testing/commit/189ee803576e85487afe4f6fa590e4ff9a791c6b"
+            }
+        ],
+        "committer" : {
+            "email" : "3rzwk@osf.io",
+            "name" : "Fitzfork",
+            "date" : "2017-03-14T19:18:51Z"
+        },
+        "author" : {
+            "date" : "2017-03-14T19:18:51Z",
+            "email" : "felliott@fiskur.org",
+            "name" : "Fitz Elliott"
+        },
+        "message" : "File updated on behalf of WaterButler",
+        "html_url" : "https://github.com/felliott/wb-testing/commit/43798985fdb727843a49946b391409086a7021f2",
+        "verification" : {
+            "payload" : null,
+            "verified" : false,
+            "signature" : null,
+            "reason" : "unsigned"
+        }
+    },
     "branch_metadata":{  
         "commit":{  
             "html_url":"https://github.com/octocat/Hello-World/commit/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -976,8 +976,7 @@ class TestMetadata:
             '/file.txt', _ids=[("master", metadata[0]['sha']), ('master', metadata[0]['sha'])]
         )
 
-        url = provider.build_repo_url('commits', path=path.path, sha=path.file_sha)
-
+        url = provider.build_repo_url('commits', path=path.path, sha='master')
         aiohttpretty.register_json_uri('GET', url, body=metadata)
 
         result = await provider.revisions(path)

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -121,29 +121,30 @@ class TestValidatePath:
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_validate_v1_path_file(self, provider, provider_fixtures):
-        branch_url = provider.build_repo_url('branches', provider.default_branch)
-        tree_url = provider.build_repo_url(
-            'git', 'trees',
-            provider_fixtures['branch_metadata']['commit']['commit']['tree']['sha'],
-            recursive=1
-        )
 
-        aiohttpretty.register_json_uri('GET', branch_url, body=provider_fixtures['branch_metadata'])
-        aiohttpretty.register_json_uri(
-            'GET', tree_url, body=provider_fixtures['repo_tree_metadata_root']
-        )
+        branch_name = provider.default_branch
+        branch_metadata = provider_fixtures['branch_metadata']
+        tree_sha = branch_metadata['commit']['commit']['tree']['sha']
 
-        blob_path = 'file.txt'
+        branch_url = provider.build_repo_url('branches', branch_name)
+        tree_url = provider.build_repo_url('git', 'trees', tree_sha, recursive=1)
 
-        result = await provider.validate_v1_path('/' + blob_path)
+        aiohttpretty.register_json_uri('GET', branch_url, body=branch_metadata)
+        aiohttpretty.register_json_uri('GET', tree_url,
+                                       body=provider_fixtures['repo_tree_metadata_root'])
+
+        blob_name = 'file.txt'
+        blob_path = '/{}'.format(blob_name)
+
+        result = await provider.validate_v1_path(blob_path)
+        expected = GitHubPath(blob_path, _ids=[(branch_name, ''), (branch_name, '')])
+        assert result == expected
+        assert result.identifier[0] == expected.identifier[0]
 
         with pytest.raises(exceptions.NotFoundError) as exc:
-            await provider.validate_v1_path('/' + blob_path + '/')
-
-        expected = GitHubPath('/' + blob_path, _ids=[(provider.default_branch, '')])
+            await provider.validate_v1_path('/{}/'.format(blob_path))
 
         assert exc.value.code == client.NOT_FOUND
-        assert result == expected
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
@@ -161,35 +162,31 @@ class TestValidatePath:
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
     async def test_validate_v1_path_folder(self, provider, provider_fixtures):
-        branch_url = provider.build_repo_url('branches', provider.default_branch)
-        tree_url = provider.build_repo_url(
-            'git', 'trees',
-            provider_fixtures['branch_metadata']['commit']['commit']['tree']['sha'],
-            recursive=1
-        )
 
-        aiohttpretty.register_json_uri(
-            'GET', branch_url, body=provider_fixtures['branch_metadata']
-        )
-        aiohttpretty.register_json_uri(
-            'GET', tree_url, body=provider_fixtures['repo_tree_metadata_root']
-        )
+        branch_name = provider.default_branch
+        branch_metadata = provider_fixtures['branch_metadata']
+        tree_sha = branch_metadata['commit']['commit']['tree']['sha']
 
-        tree_path = 'level1'
+        branch_url = provider.build_repo_url('branches', branch_name)
+        tree_url = provider.build_repo_url('git', 'trees', tree_sha, recursive=1)
 
-        expected = GitHubPath(
-            '/' + tree_path + '/', _ids=[(provider.default_branch, ''),
-            (provider.default_branch, None)]
-        )
+        aiohttpretty.register_json_uri('GET', branch_url, body=branch_metadata)
+        aiohttpretty.register_json_uri('GET', tree_url,
+                                       body=provider_fixtures['repo_tree_metadata_root'])
 
-        result = await provider.validate_v1_path('/' + tree_path + '/')
+        tree_name = 'level1'
+        tree_path = '/{}/'.format(tree_name)
+        result = await provider.validate_v1_path(tree_path)
+        expected = GitHubPath(tree_path, _ids=[(branch_name, ''), (branch_name, None)])
 
-        with pytest.raises(exceptions.NotFoundError) as exc:
-            await provider.validate_v1_path('/' + tree_path)
-
-        assert exc.value.code == client.NOT_FOUND
         assert result == expected
         assert result.extra == expected.extra
+        assert result.identifier[0] == expected.identifier[0]
+
+        with pytest.raises(exceptions.NotFoundError) as exc:
+            await provider.validate_v1_path('/{}'.format(tree_name))
+
+        assert exc.value.code == client.NOT_FOUND
 
     @pytest.mark.asyncio
     async def test_reject_multiargs(self, provider):
@@ -1529,3 +1526,142 @@ class TestUtilities:
 
         assert len(pruned_tree) == 3  # alpha.txt, gamma.txt, epsilon.txt
         assert len([x for x in pruned_tree if x['type'] == 'tree']) == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    @pytest.mark.parametrize('param', [
+        ('branch'),
+        ('ref'),
+        ('version'),
+        ('sha'),
+        ('revision')
+    ])
+    async def test__interpret_query_parameters_branch(self, provider, provider_fixtures, param):
+
+        branch_name = 'develop'
+        branch_metadata = provider_fixtures['branch_metadata']
+        tree_sha = branch_metadata['commit']['commit']['tree']['sha']
+
+        branch_url = provider.build_repo_url('branches', branch_name)
+        tree_url = provider.build_repo_url('git', 'trees', tree_sha, recursive=1)
+
+        aiohttpretty.register_json_uri('GET', branch_url, body=branch_metadata)
+        aiohttpretty.register_json_uri('GET', tree_url,
+                                       body=provider_fixtures['repo_tree_metadata_root'])
+
+        blob_path = '/file.txt'
+        params = {param: branch_name}
+        result = await provider.validate_v1_path(blob_path, **params)
+        expected = GitHubPath(blob_path, _ids=[(branch_name, ''), (branch_name, '')])
+
+        assert result == expected
+        assert result.identifier[0] == expected.identifier[0]
+
+    @pytest.mark.asyncio
+    @pytest.mark.aiohttpretty
+    @pytest.mark.parametrize('param', [
+        ('ref'),
+        ('version'),
+        ('sha'),
+        ('revision')
+    ])
+    async def test__interpret_query_parameters_sha(self, provider, provider_fixtures, param):
+
+        commit_sha = '6dcb09b5b57875f334f61aebed695e2e4193db5e'
+        commit_url = provider.build_repo_url('git', 'commits', commit_sha)
+
+        tree_sha = '394164986adbe26c0c7605c6fe627e4fe3b13aa6'
+        tree_url = provider.build_repo_url('git', 'trees', tree_sha, recursive=1)
+
+        aiohttpretty.register_json_uri('GET', commit_url,
+                                       body=provider_fixtures['commit_metadata'])
+        aiohttpretty.register_json_uri('GET', tree_url,
+                                       body=provider_fixtures['repo_tree_metadata_root'])
+
+        blob_path = '/file.txt'
+        params = {param: commit_sha}
+        result = await provider.validate_v1_path(blob_path, **params)
+        expected = GitHubPath(blob_path, _ids=[(commit_sha, ''), (commit_sha, '')])
+
+        assert result == expected
+        assert result.identifier[0] == expected.identifier[0]
+
+    def test__interpret_query_parameters_sha_priorities(self, provider):
+        params = {
+            'ref': 'b4eecafa9be2f2006ce1b709d6857b07069b4608',
+            'version': '7fd1a60b01f91b314f59955a4e4d4e80d8edf11d',
+            'sha': 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
+            'revision': 'bc1087ebfe8354a684bf9f8b75517784143dde86',
+        }
+
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'commit_sha'
+        assert ref == params['ref']
+
+        del params['ref']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'commit_sha'
+        assert ref == params['version']
+
+        del params['version']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'commit_sha'
+        assert ref == params['sha']
+
+        del params['sha']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'commit_sha'
+        assert ref == params['revision']
+
+        del params['revision']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == provider.default_branch
+
+    def test__interpret_query_parameters_branch_priorities(self, provider):
+        params = {
+            'branch': 'grr',
+            'ref': 'quack',
+            'version': 'woof',
+            'sha': 'moo',
+            'revision': 'meow',
+        }
+
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == params['branch']
+
+        del params['branch']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == params['ref']
+
+        del params['ref']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == params['version']
+
+        del params['version']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == params['sha']
+
+        del params['sha']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == params['revision']
+
+        del params['revision']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == provider.default_branch
+
+    def test__interpret_query_parameters_sha_vs_branch_priority(self, provider):
+        params = {
+            'ref': 'quack',
+            'version': 'ca39bcbf849231525ce9e775935fcb18ed477b5a',
+        }
+
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'commit_sha'
+        assert ref == params['version']

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -1714,3 +1714,13 @@ class TestUtilities:
             provider._interpret_query_parameters(**kwargs)
 
         assert exc.value.code == client.BAD_REQUEST
+
+    @pytest.mark.parametrize('ref,expected', [
+        ('ca39bcbf849231525ce9e775935fcb18ed477b5a', True),
+        ('ca39bcbf849231525ce9e775935fcb18ed477b5', False),  # one character short
+        ('bad', False),  # valid SHA, too short, must be branch
+        ('meow', False),  # not valid base 16, must be branch name
+        ('ca39bcbf849231525ce9e775935fcb18ed477b5x', False),  # 'x' not valid base16
+    ])
+    def test__looks_like_sha(self, provider, ref, expected):
+        assert provider._looks_like_sha(ref) == expected

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -1592,6 +1592,7 @@ class TestUtilities:
             'version': '7fd1a60b01f91b314f59955a4e4d4e80d8edf11d',
             'sha': 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391',
             'revision': 'bc1087ebfe8354a684bf9f8b75517784143dde86',
+            'branch': '71a892a5cd479bc73ae750b121c0d47a33028e66',
         }
 
         ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
@@ -1614,6 +1615,11 @@ class TestUtilities:
         assert ref == params['revision']
 
         del params['revision']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'commit_sha'
+        assert ref == params['branch']
+
+        del params['branch']
         ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
         assert ref_type == 'branch_name'
         assert ref == provider.default_branch
@@ -1660,8 +1666,14 @@ class TestUtilities:
         params = {
             'ref': 'quack',
             'version': 'ca39bcbf849231525ce9e775935fcb18ed477b5a',
+            'branch': 'tooth',
         }
 
         ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
         assert ref_type == 'commit_sha'
         assert ref == params['version']
+
+        del params['version']
+        ref, ref_type, ref_from = provider._interpret_query_parameters(**params)
+        assert ref_type == 'branch_name'
+        assert ref == params['branch']

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -301,10 +301,10 @@ class GitHubProvider(provider.BaseProvider):
         else:
             return (await self._metadata_file(path, **kwargs))
 
-    async def revisions(self, path, sha=None, **kwargs):
+    async def revisions(self, path, **kwargs):
         resp = await self.make_request(
             'GET',
-            self.build_repo_url('commits', path=path.path, sha=sha or path.file_sha),
+            self.build_repo_url('commits', path=path.path, sha=path.branch_ref),
             expects=(200, ),
             throws=exceptions.RevisionsError
         )

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -1030,9 +1030,9 @@ class GitHubProvider(provider.BaseProvider):
             if possible_values[param] == '':
                 possible_values[param] = None
 
-        # look for commit SHA likes
+        # look for commit SHA likes ('branch' is least likely to be a sha)
         inferred_ref, ref_from = None, None
-        for param in possible_params:
+        for param in possible_params + ['branch']:
             v = possible_values[param]
             if v is not None and self._looks_like_sha(v):
                 inferred_ref = v
@@ -1042,7 +1042,7 @@ class GitHubProvider(provider.BaseProvider):
         if inferred_ref is not None:
             return inferred_ref, 'commit_sha', ref_from  # found a SHA!
 
-        # look for branch names
+        # look for branch names ('branch' is most likely to be a branchname)
         for param in ['branch'] + possible_params:
             v = possible_values[param]
             if v is not None:

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -1075,7 +1075,10 @@ class GitHubProvider(provider.BaseProvider):
         return inferred_ref, 'branch_name', ref_from
 
     def _looks_like_sha(self, ref):
-        """Returns `True` if ``ref`` could be a valid SHA (i.e. is a valid hex number).
+        """Returns `True` if ``ref`` could be a valid SHA (i.e. is a valid hex number).  If ``True``
+        also checks to make sure ``ref`` is a valid number of characters, as GH doesn't like
+        abbreviated refs.  Currently only check for 40 characters (length of a sha1-name), but a
+        future git release will add support for 64-character sha256-names.
 
         :param str ref: the string to test
         :rtype: `bool`
@@ -1086,4 +1089,5 @@ class GitHubProvider(provider.BaseProvider):
         except (TypeError, ValueError):
             return False
 
-        return True
+        # 'in' instead of '==' b/c git shas will be changing in future git release.
+        return len(ref) in pd_settings.GITHUB_SHA_LENGTHS

--- a/waterbutler/providers/github/provider.py
+++ b/waterbutler/providers/github/provider.py
@@ -1021,18 +1021,20 @@ class GitHubProvider(provider.BaseProvider):
         query during validation.  The latter is used for analytics.
         """
 
-        possible_params = ['ref', 'version', 'sha', 'revision']
+        all_possible_params = ['ref', 'version', 'sha', 'revision', 'branch']
 
         # empty string values should be made None
         possible_values = {}
-        for param in possible_params + ['branch']:
+        for param in all_possible_params:
             possible_values[param] = kwargs.get(param, '')
             if possible_values[param] == '':
                 possible_values[param] = None
 
-        # look for commit SHA likes ('branch' is least likely to be a sha)
         inferred_ref, ref_from = None, None
-        for param in possible_params + ['branch']:
+
+        # look for commit SHA likes ('branch' is least likely to be a sha)
+        sha_priority_order = ['ref', 'version', 'sha', 'revision', 'branch']
+        for param in sha_priority_order:
             v = possible_values[param]
             if v is not None and self._looks_like_sha(v):
                 inferred_ref = v
@@ -1043,7 +1045,8 @@ class GitHubProvider(provider.BaseProvider):
             return inferred_ref, 'commit_sha', ref_from  # found a SHA!
 
         # look for branch names ('branch' is most likely to be a branchname)
-        for param in ['branch'] + possible_params:
+        branch_priority_order = ['branch', 'ref', 'version', 'sha', 'revision']
+        for param in branch_priority_order:
             v = possible_values[param]
             if v is not None:
                 inferred_ref = v

--- a/waterbutler/providers/github/settings.py
+++ b/waterbutler/providers/github/settings.py
@@ -12,3 +12,17 @@ DELETE_FILE_MESSAGE = config.get('DELETE_FILE_MESSAGE', 'File deleted on behalf 
 UPDATE_FILE_MESSAGE = config.get('UPDATE_FILE_MESSAGE', 'File updated on behalf of WaterButler')
 UPLOAD_FILE_MESSAGE = config.get('UPLOAD_FILE_MESSAGE', 'File uploaded on behalf of WaterButler')
 DELETE_FOLDER_MESSAGE = config.get('DELETE_FOLDER_MESSAGE', 'Folder deleted on behalf of WaterButler')
+
+
+# At some point in the near(?) future git will be changing its internal hash function from SHA-1
+# to SHA-256.  sha1-names are 40 hexdigits long and sha256-names are 64 hexdigits long.  At that
+# point, it seems probable that GitHub will update its API to accept both sha types. When that
+# happens, the following config var will need to be updated to include both sizes.
+#
+# Example for passing multiple length values via an envvar on the command line:
+#   $ GITHUB_PROVIDER_GITHUB_SHA_LENGTHS="40 64" invoke server
+#
+# Example setting in a .docker-compose.env (no quotes):
+#   GITHUB_PROVIDER_GITHUB_SHA_LENGTHS=40 64
+#
+GITHUB_SHA_LENGTHS = [int(x) for x in config.get('GITHUB_SHA_LENGTHS', '40').split(' ')]


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-444

## Purpose

Improve and consistify GH provider revision-identifying query-parameter support.

## Changes

* Unify query param handling: the first commit is a re-application of 9b541f2be708, which was reverted in 5fdc63f2d41e.  Updates the provider to support `ref`, `version`, `sha`, and `revision` as commit sha / branch name -identifying parameters.  Also supports `branch` as a branch name-identifying parameter.
* Allow `branch` to be a commit sha. Since the original implementation was written, it was discovered that some queries **are** passing commit shas in the `branch` parameter. Start supporting this.
* Verify sha length in sha vs. branch identifying heuristic.  GH doesn't support abbreviated SHAs, so improve the test by length-testing the sha string (currently 40 characters, but made configurable for after git newhash work is released).
* Fix revisions endpoint to work with refs.  A bug in the revisions endpoint meant the starting-revision was always being sent to the default branch.

## Side effects

There's a possibility that some urls may start directing to the wrong version.  Some urls in the wild have multiple query parameters with different refs.  The way WB handled this case was undefined before, but we've tried hard to make it DTRT.

## QA Notes

This PR specifically targets operations on non-default branches and old commits, so good places to test for breakage are: 

* Fangorn file listing
* Fangorn branch changer
* Viewing files in MFR
* File revisions
* Links to previous revisions in NodeLogs

No behavior should change, except that some previously-broken links should now work.

## Deployment Notes

* For the future: this PR adds a new setting, `GITHUB_SHA_LENGTHS` to support git Newhash lengths when they arrive.
