### PR TITLE
[ENG-339] [Oath Pit] Throw the Bitbucket provider into the Oath Pit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
             # 'filesystem = waterbutler.providers.filesystem:FileSystemProvider',
             # 'github = waterbutler.providers.github:GitHubProvider',
             # 'gitlab = waterbutler.providers.gitlab:GitLabProvider',
-            # 'bitbucket = waterbutler.providers.bitbucket:BitbucketProvider',
+            'bitbucket = waterbutler.providers.bitbucket:BitbucketProvider',
             'osfstorage = waterbutler.providers.osfstorage:OSFStorageProvider',
             # 'owncloud = waterbutler.providers.owncloud:OwnCloudProvider',
             # 's3 = waterbutler.providers.s3:S3Provider',

--- a/tasks.py
+++ b/tasks.py
@@ -89,8 +89,7 @@ def test(ctx, verbose=False, types=False, nocov=False, provider=None, path=None)
     verbose = '-v' if verbose else ''
 
     # TODO: update this ignore list when new providers are added
-    ignored_providers = '--ignore=tests/providers/bitbucket/ ' \
-                        '--ignore=tests/providers/cloudfiles/ ' \
+    ignored_providers = '--ignore=tests/providers/cloudfiles/ ' \
                         '--ignore=tests/providers/dataverse/ ' \
                         '--ignore=tests/providers/dropbox/ ' \
                         '--ignore=tests/providers/figshare/ ' \


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-339

## Purpose

"_Refactor_" the `bitbucket` provider to work with `aiohttp3`.

## Changes

* NO CHANGE:
  * `bitbucket` is a read-only provider and uses `.make_request()` exclusively for its limited number of requests, which works as it is with `aiohttp3` surprisingly as expected.

## Side effects

No

## QA Notes

Please refer to the ticket.

## Deployment Notes

No
