### PR TITLE
[ENG-331] [Oath Pit] Throw the FileSystem provider into the Oath Pit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
             # 'cloudfiles = waterbutler.providers.cloudfiles:CloudFilesProvider',
             # 'dropbox = waterbutler.providers.dropbox:DropboxProvider',
             # 'figshare = waterbutler.providers.figshare:FigshareProvider',
-            # 'filesystem = waterbutler.providers.filesystem:FileSystemProvider',
+            'filesystem = waterbutler.providers.filesystem:FileSystemProvider',
             # 'github = waterbutler.providers.github:GitHubProvider',
             # 'gitlab = waterbutler.providers.gitlab:GitLabProvider',
             'bitbucket = waterbutler.providers.bitbucket:BitbucketProvider',

--- a/tasks.py
+++ b/tasks.py
@@ -93,7 +93,6 @@ def test(ctx, verbose=False, types=False, nocov=False, provider=None, path=None)
                         '--ignore=tests/providers/dataverse/ ' \
                         '--ignore=tests/providers/dropbox/ ' \
                         '--ignore=tests/providers/figshare/ ' \
-                        '--ignore=tests/providers/filesystem/ ' \
                         '--ignore=tests/providers/github/ ' \
                         '--ignore=tests/providers/gitlab/ ' \
                         '--ignore=tests/providers/googledrive ' \


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-331

## Purpose

"_Refactor_" the `filesystem` provider to work with `aiohttp3`.

## Changes

* NO CHANGES:
  * `filesystem` is for local develop only, which replaces the `googlecloud` as the storage provider for OSF Storage. No request is made and all are disk access, which works as it is with `aiohttp3`.

## Side effects

No

## QA Notes

No

## Deployment Notes

No
