### PR TITLE
[ENG-328] [OATHPIT] Throw Dataverse into the Oath Pit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
             'osfstorage = waterbutler.providers.osfstorage:OSFStorageProvider',
             # 'owncloud = waterbutler.providers.owncloud:OwnCloudProvider',
             # 's3 = waterbutler.providers.s3:S3Provider',
-            # 'dataverse = waterbutler.providers.dataverse:DataverseProvider',
+            'dataverse = waterbutler.providers.dataverse:DataverseProvider',
             'box = waterbutler.providers.box:BoxProvider',
             # 'googledrive = waterbutler.providers.googledrive:GoogleDriveProvider',
             # 'onedrive = waterbutler.providers.onedrive:OneDriveProvider',

--- a/tasks.py
+++ b/tasks.py
@@ -90,7 +90,6 @@ def test(ctx, verbose=False, types=False, nocov=False, provider=None, path=None)
 
     # TODO: update this ignore list when new providers are added
     ignored_providers = '--ignore=tests/providers/cloudfiles/ ' \
-                        '--ignore=tests/providers/dataverse/ ' \
                         '--ignore=tests/providers/figshare/ ' \
                         '--ignore=tests/providers/github/ ' \
                         '--ignore=tests/providers/gitlab/ ' \

--- a/waterbutler/providers/dataverse/provider.py
+++ b/waterbutler/providers/dataverse/provider.py
@@ -4,6 +4,8 @@ import tempfile
 from typing import Tuple
 from http import HTTPStatus
 
+from aiohttp.helpers import BasicAuth
+
 from waterbutler.core.utils import AsyncIterator
 from waterbutler.core.path import WaterButlerPath
 from waterbutler.core import exceptions, provider, streams
@@ -176,7 +178,7 @@ class DataverseProvider(provider.BaseProvider):
             'POST',
             self.build_url(pd_settings.EDIT_MEDIA_BASE_URL, 'study', self.doi),
             headers=dv_headers,
-            auth=(self.token, ),
+            auth=BasicAuth(self.token),
             data=file_stream,
             expects=(201, ),
             throws=exceptions.UploadError
@@ -204,7 +206,7 @@ class DataverseProvider(provider.BaseProvider):
         resp = await self.make_request(
             'DELETE',
             self.build_url(pd_settings.EDIT_MEDIA_BASE_URL, 'file', path.identifier),
-            auth=(self.token, ),
+            auth=BasicAuth(self.token),
             expects=(204, ),
             throws=exceptions.DeleteError,
         )

--- a/waterbutler/providers/dataverse/settings.py
+++ b/waterbutler/providers/dataverse/settings.py
@@ -5,5 +5,6 @@ config = settings.child('DATAVERSE_PROVIDER_CONFIG')
 
 EDIT_MEDIA_BASE_URL = config.get('EDIT_MEDIA_BASE_URL', "/dvn/api/data-deposit/v1.1/swordv2/edit-media/")
 DOWN_BASE_URL = config.get('DOWN_BASE_URL', "/api/access/datafile/")
+# TODO: double check and remove this unused API URL / endpoint
 METADATA_BASE_URL = config.get('METADATA_BASE_URL', "/dvn/api/data-deposit/v1.1/swordv2/statement/study/")
 JSON_BASE_URL = config.get('JSON_BASE_URL', "/api/v1/datasets/{0}/versions/:{1}")


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-328

## Purpose

Enable and update the Dataverse provider for `aiohttp` 3.

## Changes

* Enabled the provider (including tests)
* Fixed basic auth for request (upload and delete)
  -  Please refer to the last part of the updated DocStr for details.
* Updated DocStr and added TODO comments
  - General DocStr on different API endpoints used
  - General DocStr on `aiohttp.helpersBasicAuth`
  - TODO comments to use `X-Dataverse-key` header for download and metadata
  - TODO comment to remove unused endpoint

## Side effects

No

## QA Notes

- [ ] Probably need to sit with QA on what to tests and expect. Here is what I found for the **expected behavior**: [osf.io/blob/develop/addons/dataverse/README.md](https://github.com/CenterForOpenScience/osf.io/blob/develop/addons/dataverse/README.md)

## Deployment Notes

No
