### PR TITLE
[ENG-337] [OATHPIT] Throw ownCloud into the Oath Pit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
             # 'gitlab = waterbutler.providers.gitlab:GitLabProvider',
             'bitbucket = waterbutler.providers.bitbucket:BitbucketProvider',
             'osfstorage = waterbutler.providers.osfstorage:OSFStorageProvider',
-            # 'owncloud = waterbutler.providers.owncloud:OwnCloudProvider',
+            'owncloud = waterbutler.providers.owncloud:OwnCloudProvider',
             # 's3 = waterbutler.providers.s3:S3Provider',
             'dataverse = waterbutler.providers.dataverse:DataverseProvider',
             'box = waterbutler.providers.box:BoxProvider',

--- a/tasks.py
+++ b/tasks.py
@@ -95,7 +95,6 @@ def test(ctx, verbose=False, types=False, nocov=False, provider=None, path=None)
                         '--ignore=tests/providers/gitlab/ ' \
                         '--ignore=tests/providers/googledrive ' \
                         '--ignore=tests/providers/onedrive ' \
-                        '--ignore=tests/providers/owncloud ' \
                         '--ignore=tests/providers/s3'
 
     cmd = 'py.test{} {} tests{} {}'.format(coverage, ignored_providers, path, verbose)

--- a/waterbutler/providers/owncloud/provider.py
+++ b/waterbutler/providers/owncloud/provider.py
@@ -50,7 +50,7 @@ class OwnCloudProvider(provider.BaseProvider):
         self.metrics.add('host', self.url)
 
     def connector(self):
-        return aiohttp.TCPConnector(verify_ssl=self.verify_ssl)
+        return aiohttp.TCPConnector(ssl=self.verify_ssl)
 
     @property
     def _webdav_url_(self):

--- a/waterbutler/settings.py
+++ b/waterbutler/settings.py
@@ -177,3 +177,5 @@ KEEN_PRIVATE_WRITE_KEY = keen_private_config.get_nullable('WRITE_KEY', None)
 keen_public_config = keen_config.child('PUBLIC')
 KEEN_PUBLIC_PROJECT_ID = keen_public_config.get_nullable('PROJECT_ID', None)
 KEEN_PUBLIC_WRITE_KEY = keen_public_config.get_nullable('WRITE_KEY', None)
+
+WEBDAV_METHODS = {'PROPFIND', 'MKCOL', 'MOVE', 'COPY'}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-337

## Purpose

Enable and update the ownCloud provider for `aiohttp` 3.

## Changes

* WB `.make_request()` now supports WebDAV methods
  * `aiohttp.ClientSession` only has functions available for native HTTP methods. For WebDAV (a protocol that extends HTTP) ones, WB lets the `ClientSession` instance call `_request()` directly and then wraps the return object with `aiohttp.client._RequestContextManager`.

</br>

* WB client session now supports customized connector
  * For providers that use a customized connector such as owncloud, the new session is created (if no session is found in the event loop) with the given connector while an existing session simply ignores (and closes) the new connector. Given that the session is per loop for each instance, the existing session if found must already have a connector with qualified customizations.

</br>

* Use kwarg `ssl=` instead of `verify_ssl=` when initializing `aiohttp.TCPConnecto`
  * `verify_ssl=` has been deprecated and no longer takes any effect on setting the property `_ssl` of a `TCPConnector` instance. Use `ssl=` instead. For details see the following links.
    * https://github.com/aio-libs/aiohttp/blob/3.5/aiohttp/connector.py#L733
    * https://github.com/aio-libs/aiohttp/blob/3.5/aiohttp/client_reqrep.py#L152
    * https://github.com/aio-libs/aiohttp/blob/v0.18.4/aiohttp/connector.py#L402

## Side effects

No

## QA Notes

Here is a list of tests that I have done locally, all of which have passed. Extra notes and quirks are added under each list if there is any. In addition, tests are done for both non-root and root.

* Getting metadata for a file and folder
  * This is automatic when you list files and expand folders

* Downloading (20B, 1 MB, 11 MB, 88 MB, 264MB)

* Contiguous Uploading (20B, 1 MB, 11 MB, 88 MB, 264MB one-by-one and together)
  * Chunked upload: N / A

* DAZ (a folder containing five files of 20B, 1 MB, 11 MB, 88 MB, 264MB)

* Delete a file and a folder; delete multiple files and folders

* Folder creation and deletion

* Rename files and folders
  * After renaming a folder or file (successfully), clicking on the renamed folder triggers the following error. Please see the video attachment in the ticket.

![click-on-an-renamed-file-or-folder](https://user-images.githubusercontent.com/3750414/68881801-d6d35500-06db-11ea-862e-60c4f54e0970.png)

* Intra move and copy
  * ownCloud supports intra move / copy. My local tests includes moving file and folders between two ownCloud projects with the same ownCloud account.

* Inter move and copy
  * Between ownCloud and OSFStorage
  * Between ownCloud and another 3rd-party (S3 in this case)

* Comments persist with moves

* Revisions: N / A

* Project root is storage root vs. a subfolder
  * Not required but I still tested this since I have to create two projects  (one with root and the other with subfolder) anyway for testing intra copy / move.

* Updating a file

## Deployment Notes

N / A
