### PR TITLE
[ENG-338] [OATHPIT] Throw S3 into the Oath Pit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
             'bitbucket = waterbutler.providers.bitbucket:BitbucketProvider',
             'osfstorage = waterbutler.providers.osfstorage:OSFStorageProvider',
             'owncloud = waterbutler.providers.owncloud:OwnCloudProvider',
-            # 's3 = waterbutler.providers.s3:S3Provider',
+            's3 = waterbutler.providers.s3:S3Provider',
             'dataverse = waterbutler.providers.dataverse:DataverseProvider',
             'box = waterbutler.providers.box:BoxProvider',
             # 'googledrive = waterbutler.providers.googledrive:GoogleDriveProvider',

--- a/tasks.py
+++ b/tasks.py
@@ -94,8 +94,7 @@ def test(ctx, verbose=False, types=False, nocov=False, provider=None, path=None)
                         '--ignore=tests/providers/github/ ' \
                         '--ignore=tests/providers/gitlab/ ' \
                         '--ignore=tests/providers/googledrive ' \
-                        '--ignore=tests/providers/onedrive ' \
-                        '--ignore=tests/providers/s3'
+                        '--ignore=tests/providers/onedrive '
 
     cmd = 'py.test{} {} tests{} {}'.format(coverage, ignored_providers, path, verbose)
     ctx.run(cmd, pty=True)

--- a/tests/providers/s3/fixtures.py
+++ b/tests/providers/s3/fixtures.py
@@ -91,11 +91,11 @@ def folder_empty_metadata():
 @pytest.fixture
 def file_header_metadata():
     return {
-        'CONTENT-LENGTH': 9001,
-        'LAST-MODIFIED': 'SomeTime',
-        'CONTENT-TYPE': 'binary/octet-stream',
-        'ETAG': '"fba9dede5f27731c9771645a39863328"',
-        'X-AMZ-SERVER-SIDE-ENCRYPTION': 'AES256'
+        'Content-Length': '9001',
+        'Last-Modified': 'SomeTime',
+        'Content-Type': 'binary/octet-stream',
+        'Etag': '"fba9dede5f27731c9771645a39863328"',
+        'x-amz-server-side-encryption': 'AES256'
     }
 
 

--- a/tests/providers/s3/test_metadata.py
+++ b/tests/providers/s3/test_metadata.py
@@ -20,7 +20,7 @@ class TestFileMetadataHeaders:
         assert file_metadata_headers_object.materialized_path == '/test-path'
         assert file_metadata_headers_object.kind == 'file'
         assert file_metadata_headers_object.provider == 's3'
-        assert file_metadata_headers_object.size == 9001
+        assert file_metadata_headers_object.size == '9001'
         assert file_metadata_headers_object.size_as_int == 9001
         assert type(file_metadata_headers_object.size_as_int) == int
         assert file_metadata_headers_object.content_type == 'binary/octet-stream'

--- a/waterbutler/providers/s3/metadata.py
+++ b/waterbutler/providers/s3/metadata.py
@@ -28,15 +28,15 @@ class S3FileMetadataHeaders(S3Metadata, metadata.BaseFileMetadata):
 
     @property
     def size(self):
-        return self.raw['CONTENT-LENGTH']
+        return self.raw['Content-Length']
 
     @property
     def content_type(self):
-        return self.raw['CONTENT-TYPE']
+        return self.raw['Content-Type']
 
     @property
     def modified(self):
-        return self.raw['LAST-MODIFIED']
+        return self.raw['Last-Modified']
 
     @property
     def created_utc(self):
@@ -44,14 +44,14 @@ class S3FileMetadataHeaders(S3Metadata, metadata.BaseFileMetadata):
 
     @property
     def etag(self):
-        return self.raw['ETAG'].replace('"', '')
+        return self.raw['Etag'].replace('"', '')
 
     @property
     def extra(self):
-        md5 = self.raw['ETAG'].replace('"', '')
+        md5 = self.raw['Etag'].replace('"', '')
         return {
             'md5': md5,
-            'encryption': self.raw.get('X-AMZ-SERVER-SIDE-ENCRYPTION', ''),
+            'encryption': self.raw.get('x-amz-server-side-encryption', ''),
             'hashes': {
                 'md5': md5,
             },

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -653,14 +653,15 @@ class S3Provider(provider.BaseProvider):
             if (await self.exists(path)):
                 raise exceptions.FolderNamingConflict(path.name)
 
-        async with self.request(
+        await self.make_request(
             'PUT',
             functools.partial(self.bucket.new_key(path.path).generate_url, settings.TEMP_URL_SECS, 'PUT'),
             skip_auto_headers={'CONTENT-TYPE'},
             expects=(200, 201, ),
             throws=exceptions.CreateFolderError
-        ):
-            return S3FolderMetadata({'Prefix': path.path})
+        )
+
+        return S3FolderMetadata({'Prefix': path.path})
 
     async def _metadata_file(self, path, revision=None):
         await self._check_region()


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-338

## Purpose

Enable and update the S3 provider for `aiohttp` 3.

## Changes

It is unknown why `aiohttp-0.18.x` stores HTTP response header names in all-uppercase (e.g. `'CONTENT-LENGTH'`, `'ETAG'`, etc.). `aiohttp-3.5.x` now uses the more popular title case (e.g. `'Content-Length'`, `'ETAG'`, etc.). This breaks the old implementation for class `S3FileMetadataHeaders` whose calling `self.raw['ETAG']` throws `Key Error`. The class and related tests has been updated.

## Side effects

No

## QA Notes

Here is a list of tests that I have done locally, all of which have passed. Extra notes and quirks are added under each list if there is any. In short, S3 behaves as expected.

* Getting metadata for a file and folder
  * This is automatic when you list files and expand folders

* Downloading (20B, 1 MB, 11 MB, 88 MB, 264MB)

* Uploading (20B, 1 MB, 11 MB, 88 MB, 264MB one-by-one and together)
  * Both contiguous and chunked

* DAZ (a folder containing five files of 20B, 1 MB, 11 MB, 88 MB, 264MB)

* Delete a file and a folder; delete multiple files and folders

* Folder creation and deletion

* Renaming files and folders
  * Similar to ownCloud, after renaming a folder or file (successfully), clicking on the renamed folder triggers the following error.

![click-on-an-renamed-file-or-folder](https://user-images.githubusercontent.com/3750414/68881801-d6d35500-06db-11ea-862e-60c4f54e0970.png)

* Intra move and copy
  * Between two components connected to the same account and the same bucket.

* Inter move and copy
  * Between S3 and OSFStorage
  * Between S3 and another 3rd-party (ownCloud in this case)

* Comments persist with moves

* Revisions

* Updating a file

* Project root is storage root vs. a subfolder
  * N / A: s3 only allow bucket root as OSF project root

## Deployment Notes

TBD
