### PR TITLE
[ENG-332] [OATHPIT] Throw GitHub into the Oath Pit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
             'dropbox = waterbutler.providers.dropbox:DropboxProvider',
             # 'figshare = waterbutler.providers.figshare:FigshareProvider',
             'filesystem = waterbutler.providers.filesystem:FileSystemProvider',
-            # 'github = waterbutler.providers.github:GitHubProvider',
+            'github = waterbutler.providers.github:GitHubProvider',
             # 'gitlab = waterbutler.providers.gitlab:GitLabProvider',
             'bitbucket = waterbutler.providers.bitbucket:BitbucketProvider',
             'osfstorage = waterbutler.providers.osfstorage:OSFStorageProvider',

--- a/tasks.py
+++ b/tasks.py
@@ -91,7 +91,6 @@ def test(ctx, verbose=False, types=False, nocov=False, provider=None, path=None)
     # TODO: update this ignore list when new providers are added
     ignored_providers = '--ignore=tests/providers/cloudfiles/ ' \
                         '--ignore=tests/providers/figshare/ ' \
-                        '--ignore=tests/providers/github/ ' \
                         '--ignore=tests/providers/gitlab/ ' \
                         '--ignore=tests/providers/googledrive ' \
                         '--ignore=tests/providers/onedrive '

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -758,7 +758,7 @@ class TestCRUD:
         create_tree_url = provider.build_repo_url('git', 'trees')
         crud_fixtures_1 = crud_fixtures['deleted_subfolder_tree_data_1']
         crud_fixtures_2 = crud_fixtures['deleted_subfolder_tree_data_2']
-        aiohttpretty.register_json_uri(
+        aiohttpretty.register_uri(
             'POST',
             create_tree_url,
             **{

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -1447,8 +1447,8 @@ class TestRateLimit:
             'wb-test-github.cos.io',
             status=HTTPStatus.OK,
             headers={
-                'X-RateLimit-Remaining': 1234,
-                'X-RateLimit-Reset': 5678
+                'X-RateLimit-Remaining': '1234',
+                'X-RateLimit-Reset': '5678'
             })
         await mock_provider.make_request(
             'GET',
@@ -1472,8 +1472,8 @@ class TestRateLimit:
             'wb-test-github.cos.io',
             status=HTTPStatus.OK,
             headers={
-                'X-RateLimit-Remaining': 1234,
-                'X-RateLimit-Reset': 5678
+                'X-RateLimit-Remaining': '1234',
+                'X-RateLimit-Reset': '5678'
             })
         await mock_provider.make_request(
             'GET',
@@ -1497,8 +1497,8 @@ class TestRateLimit:
             'wb-test-github.cos.io',
             status=HTTPStatus.FORBIDDEN,
             headers={
-                'X-RateLimit-Remaining': 0,
-                'X-RateLimit-Reset': 5678,
+                'X-RateLimit-Remaining': '0',
+                'X-RateLimit-Reset': '5678',
             },
             body={'message': 'API rate limit exceeded'}
         )
@@ -1527,8 +1527,8 @@ class TestRateLimit:
             'wb-test-github.cos.io',
             status=HTTPStatus.FORBIDDEN,
             headers={
-                'X-RateLimit-Remaining': 231,
-                'X-RateLimit-Reset': 5678,
+                'X-RateLimit-Remaining': '231',
+                'X-RateLimit-Reset': '5678',
             },
             body={'message': 'this is a fake error'}
         )
@@ -1556,8 +1556,8 @@ class TestRateLimit:
             'wb-test-github.cos.io',
             status=HTTPStatus.FORBIDDEN,
             headers={
-                'X-RateLimit-Remaining': 0,
-                'X-RateLimit-Reset': 5678,
+                'X-RateLimit-Remaining': '0',
+                'X-RateLimit-Reset': '5678',
             },
             body={'message': 'API rate limit exceeded'}
         )
@@ -1586,8 +1586,8 @@ class TestRateLimit:
             'wb-test-github.cos.io',
             status=HTTPStatus.FORBIDDEN,
             headers={
-                'X-RateLimit-Remaining': 123,
-                'X-RateLimit-Reset': 5678,
+                'X-RateLimit-Remaining': '123',
+                'X-RateLimit-Reset': '5678',
             },
             body={'message': 'API rate limit exceeded'}
         )
@@ -1615,8 +1615,8 @@ class TestRateLimit:
             'wb-test-github.cos.io',
             status=HTTPStatus.SERVICE_UNAVAILABLE,
             headers={
-                'X-RateLimit-Remaining': 231,
-                'X-RateLimit-Reset': 5678,
+                'X-RateLimit-Remaining': '231',
+                'X-RateLimit-Reset': '5678',
             },
             body={'message': 'this is a fake error'}
         )

--- a/tests/providers/github/test_provider.py
+++ b/tests/providers/github/test_provider.py
@@ -756,13 +756,26 @@ class TestCRUD:
         )
 
         create_tree_url = provider.build_repo_url('git', 'trees')
-        aiohttpretty.register_json_uri('POST', create_tree_url, **{
-            "responses": [
-                {'body': json.dumps(
-                    crud_fixtures['deleted_subfolder_tree_data_1']).encode('utf-8'), 'status': 201},
-                {'body': json.dumps(
-                    crud_fixtures['deleted_subfolder_tree_data_2']).encode('utf-8'), 'status': 201},
-            ]})
+        crud_fixtures_1 = crud_fixtures['deleted_subfolder_tree_data_1']
+        crud_fixtures_2 = crud_fixtures['deleted_subfolder_tree_data_2']
+        aiohttpretty.register_json_uri(
+            'POST',
+            create_tree_url,
+            **{
+                "responses": [
+                    {
+                        'body': json.dumps(crud_fixtures_1).encode('utf-8'),
+                        'status': 201,
+                        'headers': {'Content-Type': 'application/json'}
+                    },
+                    {
+                        'body': json.dumps(crud_fixtures_2).encode('utf-8'),
+                        'status': 201,
+                        'headers': {'Content-Type': 'application/json'}
+                    },
+                ]
+            }
+        )
 
         commit_url = provider.build_repo_url('git', 'commits')
         aiohttpretty.register_json_uri(


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-332

## Purpose

Enable and update the GitHub provider for `aiohttp3`.

## Changes

### Code

* Fix a response release issue for GitHub rate-limiting. In `aiohttp3`, `release()` not only releases the response but also closes the connection. This causes `exception_from_response()` to encounter a connection already closed failure when trying to release or consume the response. The fix: 1) Don't release the response before `calling _rl_handle_forbidden_error()` and 2) Let `_rl_handle_forbidden_error()` and `exception_from_response()` take care of it.

### Tests

* Fixed mock response header value type in tests: `int` -> `str`. `aiohttpretty` requires the `str` type on both header name and value, which calls `.encode()` on both when building raw headers. Exceptions would be thrown if int header values were provided.

* Fixed missing Content-Type header when registering multiple URLs in tests. `aiohttp3` is more strict on response content type, where `.json()` would fail if the content type were not provided or were incorrect. However, the updated `aiohttpretty` still has the unpleasant limitation that `.register_uri()` ignores headers (and the body) provided by `.register_json_uri()` when multiple URL registrations are used. The fix is to explicitly add the required header to the `responses` param when calling `.register_json_uri()`.

## Side effects

No

## CR / QA Notes

Here is a list of actions that I tested locally multiple times. Consider a **PASS** if no extra comment is provided.

* Getting metadata for a file / folder

* Downloading

* DAZ

* Uploading
  * Upload one file works as expected
  * Upload multiple files at the same time fails. This is an existing bug on staging. Uploading multiple files should be disabled since each upload is independent. The first one gets uploaded successfully but the rest is guaranteed to fail, mostly with `waterbutler.core.exceptions.ProviderError: 422, {"documentation_url": "https://developer.github.com/v3", "message": "Update is not a fast forward"}` and sometimes with `waterbutler.core.exceptions.ProviderError: 422, {"documentation_url": "https://developer.github.com/v3", "message": "Reference cannot be updated"}`.
  * Chunked upload: N / A

* Delete
  * Delete one file fails (an existing bug on staging) with
`waterbutler.core.exceptions.MetadataError: 404, {"documentation_url": "https://developer.github.com/v3/git/commits/#get-a-commit", "message": "Not Found"}`
  * Delete one folder works as expected
  * Delete multiple files / folders not allowed by the frontend

* Folder creation / Upload to folder / Folder deletion

* Rename files and folders

* Verifying non-root folder access for id-based folders: N / A

* Intra move/copy:
  * Nothing happens when moving / copying within the GitHub repo (both OATHPIT and Staging)

* Inter move/copy (light testing only)
  * Copying (1 file and 1 folder containing 128 files) from GitHub to OSFStorage works as expected. 
    * For CR: with the 1 folder of 128 files, I am able to see our rate-limiting handler in effect when there are only about 500 limit left.
    * For QA: please test rate limiting by copying 1 folder containing 32 subfolders, each of which contains 128 files. 
  * Copying multiple files or folders is not allowed by the frontend (same with staging)
  * Moving from GitHub to OSFStorage is not allowed by the frontend  (same with staging)
  * Copying / moving from OSFStorage to GitHub is not allowed by the frontend (same with staging)

* Comments persist with moves (light testing only)

* If enabled, test revisions

* Project root is storage root vs. a subfolder: N / A

* Updating a file

## Deployment Notes

TBD
