### PR TITLE
[ENG-335] [OATHPIT] Throw Google Drive into the Oath Pit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
             's3 = waterbutler.providers.s3:S3Provider',
             'dataverse = waterbutler.providers.dataverse:DataverseProvider',
             'box = waterbutler.providers.box:BoxProvider',
-            # 'googledrive = waterbutler.providers.googledrive:GoogleDriveProvider',
+            'googledrive = waterbutler.providers.googledrive:GoogleDriveProvider',
             # 'onedrive = waterbutler.providers.onedrive:OneDriveProvider',
             'googlecloud = waterbutler.providers.googlecloud:GoogleCloudProvider',
         ],

--- a/tasks.py
+++ b/tasks.py
@@ -76,7 +76,6 @@ def test(ctx, verbose=False, types=False, nocov=False, provider=None, path=None)
     ignored_providers = '--ignore=tests/providers/cloudfiles/ ' \
                         '--ignore=tests/providers/figshare/ ' \
                         '--ignore=tests/providers/gitlab/ ' \
-                        '--ignore=tests/providers/googledrive ' \
                         '--ignore=tests/providers/onedrive '
 
     cmd = 'py.test{} {} tests{} {}'.format(coverage, ignored_providers, path, verbose)

--- a/tests/providers/googledrive/test_provider.py
+++ b/tests/providers/googledrive/test_provider.py
@@ -191,9 +191,9 @@ def _build_title_search_query(provider, entity_name, is_folder=True):
         )
 
 
-def generate_list(child_id, **kwargs):
+def generate_list(child_id, root_provider_fixtures, **kwargs):
     item = {}
-    item.update(root_provider_fixtures()['list_file']['items'][0])
+    item.update(root_provider_fixtures['list_file']['items'][0])
     item.update(kwargs)
     item['id'] = str(child_id)
     return {'items': [item]}
@@ -1022,13 +1022,13 @@ class TestMetadata:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_metadata_file_nested(self, provider):
+    async def test_metadata_file_nested(self, provider, root_provider_fixtures):
         path = GoogleDrivePath(
             '/hugo/kim/pins',
             _ids=[str(x) for x in range(4)]
         )
 
-        item = generate_list(3)['items'][0]
+        item = generate_list(3, root_provider_fixtures)['items'][0]
         url = provider.build_url('files', path.identifier)
 
         aiohttpretty.register_json_uri('GET', url, body=item)
@@ -1058,13 +1058,13 @@ class TestMetadata:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_metadata_folder_nested(self, provider):
+    async def test_metadata_folder_nested(self, provider, root_provider_fixtures):
         path = GoogleDrivePath(
             '/hugo/kim/pins/',
             _ids=[str(x) for x in range(4)]
         )
 
-        body = generate_list(3)
+        body = generate_list(3, root_provider_fixtures)
         item = body['items'][0]
 
         query = provider._build_query(path.identifier)
@@ -1089,7 +1089,7 @@ class TestMetadata:
             _ids=[str(x) for x in range(4)]
         )
 
-        body = generate_list(3, **root_provider_fixtures['folder_metadata'])
+        body = generate_list(3, root_provider_fixtures, **root_provider_fixtures['folder_metadata'])
         item = body['items'][0]
 
         query = provider._build_query(path.identifier)
@@ -1562,7 +1562,8 @@ class TestIntraFunctions:
 
         children_query = provider._build_query(dest_path.identifier)
         children_url = provider.build_url('files', q=children_query, alt='json', maxResults=1000)
-        children_list = generate_list(3, **root_provider_fixtures['folder_metadata'])
+        children_list = generate_list(3, root_provider_fixtures,
+                                      **root_provider_fixtures['folder_metadata'])
         aiohttpretty.register_json_uri('GET', children_url, body=children_list)
 
         result, created = await provider.intra_move(provider, src_path, dest_path)


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-335

## Purpose

Enable and update the Google Drive provider for `aiohttp3`.

## Changes

* Simply rewrite `async with ... as resp: ...` into `resp = await ...`.

## Side effects

No

## QA Notes

Below is a list of what I have tested locally according to the list provided by the ticket. Surprisingly, everything works as expected.

As usual, 1) files tested are of five different sizes: 20B, 1.4MB, 11MB, 88MB and 264MB, 2) intra-move-copy are tested between two components connected to the same Google account, one component is the Drive root and the other is a Drive folder, and 3) no comments indicates a PASS for each item.

* Getting metadata for a file / folder: tested along with file view and folder listing

* Downloading

* Uploading (both to the root and a subfolder
  * One file
  * Multiple files
  * Chunked upload: N / A

* DAZ

* Deletion
  * One file
  * Multiple files
  * One folder
  * Multiple folders

* Folder
  * Creation
  * Upload to folder: tested along with **Uploading**
  * Deletion: tested along with **Deletion**

* Rename
  * One file
  * One folder

* Verifying non-root folder access for id-based folders: N / A

* Intra move/copy
  * Move
    * A single file, a single folder, multiple files and multiple folders between the same Google Drive account connected to two different components have been tested.
    * Confirmed from server logs that there was no celery task triggered for all intra-moves
  * Copy
     * A single file and multiple files: similar as intra-move, there was no celery task triggered
     * A single folder and multiple folders: celery tasks were triggered, which indicates inter-copy have been used instead

* Inter move/copy (light testing only)
  * Move and Copy
  * A single file, single folder, multiple files and multiple folders are tested
  * Bidirectional between Google Drive and OSF Storage

* Comments persist with moves (light testing only)

* Revisions: enabled and tested

* Project root is storage root vs. a subfolder: N / A but tested anyway given I need two components for testing intra-move-and-copy

* Updating a file: tested along with **Revisions**

## Deployment Notes

No
