### PR TITLE
[ENG-330] [OATHPIT] Throw figshare into the Oath Pit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'waterbutler.providers': [
             # 'cloudfiles = waterbutler.providers.cloudfiles:CloudFilesProvider',
             'dropbox = waterbutler.providers.dropbox:DropboxProvider',
-            # 'figshare = waterbutler.providers.figshare:FigshareProvider',
+            'figshare = waterbutler.providers.figshare:FigshareProvider',
             'filesystem = waterbutler.providers.filesystem:FileSystemProvider',
             'github = waterbutler.providers.github:GitHubProvider',
             # 'gitlab = waterbutler.providers.gitlab:GitLabProvider',

--- a/tasks.py
+++ b/tasks.py
@@ -74,7 +74,6 @@ def test(ctx, verbose=False, types=False, nocov=False, provider=None, path=None)
 
     # TODO: update this ignore list when new providers are added
     ignored_providers = '--ignore=tests/providers/cloudfiles/ ' \
-                        '--ignore=tests/providers/figshare/ ' \
                         '--ignore=tests/providers/gitlab/ '
 
     cmd = 'py.test{} {} tests{} {}'.format(coverage, ignored_providers, path, verbose)

--- a/tests/providers/figshare/fixtures/root_provider.json
+++ b/tests/providers/figshare/fixtures/root_provider.json
@@ -80,8 +80,12 @@
     ],
     "file_article_metadata": {
         "url_public_html": "url_public_html_fake",
+        "url_public_api" : "https://api.figshare.com/v2/articles/11422158",
         "url_private_html": "url_private_html_fake",
+        "url_private_api" : "https://api.figshare.com/v2/account/articles/11422158",
+        "group_id" : null,
         "group_resource_id": null,
+        "handle" : "",
         "embargo_date": null,
         "citation": "Baxter, Thomas (): file_article. figshare.\n \n Retrieved: 19 20, Oct 19, 2016 (GMT)",
         "embargo_reason": "",
@@ -93,10 +97,12 @@
         "size": 0,
         "metadata_reason": "",
         "funding": "",
+        "funding_list" : [],
         "figshare_url": "https://figshare.com/articles/_/4037952",
         "embargo_type": null,
         "title": "file_article",
         "defined_type": 1,
+        "defined_type_name": "",
         "is_embargoed": false,
         "version": 0,
         "resource_doi": null,
@@ -120,8 +126,9 @@
         "description": "",
         "tags": [
         ],
+        "thumb" : "",
+        "timeline" : {},
         "created_date": "2016-10-18T12:55:44Z",
-        "is_active": true,
         "authors": [
             {
                 "url_name": "_",

--- a/tests/providers/figshare/test_metadata.py
+++ b/tests/providers/figshare/test_metadata.py
@@ -40,6 +40,7 @@ class TestFigshareFileMetadata:
             'downloadUrl': 'https://ndownloader.figshare.com/files/15562817',
             'canDelete': True,
             'webView': 'https://figshare.com/account/articles/8305859',
+            'hashingInProgress': False,
             'hashes': {
                 'md5': 'cae3869aa4b144a3aa5cffe979359836'
             }
@@ -54,6 +55,7 @@ class TestFigshareFileMetadata:
                 'downloadUrl': 'https://ndownloader.figshare.com/files/15562817',
                 'canDelete': True,
                 'webView': 'https://figshare.com/account/articles/8305859',
+                'hashingInProgress': False,
                 'hashes': {
                     'md5': 'cae3869aa4b144a3aa5cffe979359836'
                 }
@@ -84,6 +86,7 @@ class TestFigshareFileMetadata:
                     'downloadUrl': 'https://ndownloader.figshare.com/files/15562817',
                     'canDelete': True,
                     'webView': 'https://figshare.com/account/articles/8305859',
+                    'hashingInProgress': False,
                     'hashes': {
                         'md5': 'cae3869aa4b144a3aa5cffe979359836'
                     }

--- a/tests/providers/figshare/test_provider.py
+++ b/tests/providers/figshare/test_provider.py
@@ -1651,14 +1651,24 @@ class TestRevalidatePath:
 
 class TestMisc:
 
-    def test_path_from_metadata(self, project_provider, root_provider_fixtures):
+    def test_path_from_metadata_file(self, project_provider, root_provider_fixtures):
         file_article_metadata = root_provider_fixtures['file_article_metadata']
         fig_metadata = metadata.FigshareFileMetadata(file_article_metadata)
 
         path = FigsharePath('/', _ids=(''), folder=True)
-        item = file_article_metadata['files'][0]
 
-        expected = FigsharePath('/' + item['name'], _ids=('', item['id']), folder=False)
+        expected = FigsharePath('/file_article/file', _ids=('', '4037952', '6530715'), folder=False)
+
+        result = project_provider.path_from_metadata(path, fig_metadata)
+        assert result == expected
+
+    def test_path_from_metadata_folder(self, project_provider, root_provider_fixtures):
+        folder_article_metadata = root_provider_fixtures['folder_article_metadata']
+        fig_metadata = metadata.FigshareFolderMetadata(folder_article_metadata)
+
+        path = FigsharePath('/', _ids=(''), folder=True)
+
+        expected = FigsharePath('/folder_article/', _ids=('', '4040019'), folder=True)
 
         result = project_provider.path_from_metadata(path, fig_metadata)
         assert result == expected

--- a/tests/providers/figshare/test_provider.py
+++ b/tests/providers/figshare/test_provider.py
@@ -93,15 +93,14 @@ def file_stream(file_like):
 
 
 class TestPolymorphism:
-    # These should not be passing but are
 
-    async def test_project_provider(self, project_settings, project_provider):
+    def test_project_provider(self, project_settings, project_provider):
         assert isinstance(project_provider, provider.FigshareProjectProvider)
-        assert project_provider.project_id == project_settings['container_id']
+        assert project_provider.container_id == project_settings['container_id']
 
-    async def test_article_provider(self, article_settings, article_provider):
+    def test_article_provider(self, article_settings, article_provider):
         assert isinstance(article_provider, provider.FigshareArticleProvider)
-        assert article_provider.article_id == article_settings['container_id']
+        assert article_provider.container_id == article_settings['container_id']
 
 
 class TestProjectV1ValidatePath:

--- a/waterbutler/core/provider.py
+++ b/waterbutler/core/provider.py
@@ -254,6 +254,8 @@ class BaseProvider(metaclass=abc.ABCMeta):
         :param \*args: args passed to methods of :class:`aiohttp.ClientSession`
         :param \*\*kwargs: kwargs passed to methods of :class:`aiohttp.ClientSession` except the
             following ones that will be popped and used for Waterbutler specific purposes
+        :keyword no_auth_header: ( :class:`bool` ) An optional boolean flag that determines whether
+            to drop the default authorization header provided by the provider
         :keyword range: ( :class:`tuple` ) An optional tuple (start, end) that is transformed into
             a Range header
         :keyword expects: ( :class:`tuple` ) An optional tuple of HTTP status codes as integers
@@ -268,6 +270,9 @@ class BaseProvider(metaclass=abc.ABCMeta):
         """
 
         kwargs['headers'] = self.build_headers(**kwargs.get('headers', {}))
+        no_auth_header = kwargs.pop('no_auth_header', False)
+        if no_auth_header:
+            kwargs['headers'].pop('Authorization')
         retry = _retry = kwargs.pop('retry', 2)
         expects = kwargs.pop('expects', None)
         throws = kwargs.pop('throws', exceptions.UnhandledProviderError)

--- a/waterbutler/providers/figshare/metadata.py
+++ b/waterbutler/providers/figshare/metadata.py
@@ -115,6 +115,7 @@ class FigshareFileMetadata(BaseFigshareMetadata, metadata.BaseFileMetadata):
             'downloadUrl': self.raw_file['download_url'],
             'canDelete': self.can_delete,
             'webView': self.web_view,
+            'hashingInProgress': self.raw_file['status'] == 'ic_checking',
             'hashes': {
                 'md5': self.raw_file['computed_md5'],
             },

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -5,8 +5,6 @@ import logging
 from typing import Tuple
 from http import HTTPStatus
 
-import aiohttp
-
 from waterbutler.core.streams import CutoffStream
 from waterbutler.core import exceptions, provider, streams
 
@@ -216,10 +214,10 @@ class BaseFigshareProvider(provider.BaseProvider):
         if resp.status in (302, 301):
             await resp.release()
             if range:
-                resp = await aiohttp.request('GET', resp.headers['location'],
-                                             headers={'Range': self._build_range_header(range)})
+                range_header = {'Range': self._build_range_header(range)}
+                resp = await super().make_request('GET', resp.headers['location'], headers=range_header)
             else:
-                resp = await aiohttp.request('GET', resp.headers['location'])
+                resp = await super().make_request('GET', resp.headers['location'])
 
         return streams.ResponseStreamReader(resp)
 

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -239,9 +239,21 @@ class BaseFigshareProvider(provider.BaseProvider):
     def path_from_metadata(self, parent_path, metadata):
         """Build FigsharePath for child entity given child's metadata and parent's path object.
 
+        **HOWEVER** if ``parent_path`` represents a project root and ``metadata`` represents a
+        non-dataset article (a file from WB's perspective), then `path_from_metadata` needs to
+        skip the intermediate article container and return a path that points directly to the file.
+
         :param FigsharePath parent_path: path obj for child's parent
         :param metadata: Figshare*Metadata object for child
         """
+
+        if parent_path.is_root and metadata.kind != 'folder':
+            intermediate_path = parent_path.child(metadata.article_name,
+                                                  _id=str(metadata.extra['articleId']),
+                                                  folder=True)
+            return intermediate_path.child(metadata.name, _id=str(metadata.extra['fileId']),
+                                           folder=(metadata.kind == 'folder'))
+
         return parent_path.child(metadata.name, _id=str(metadata.id),
                                  folder=(metadata.kind == 'folder'))
 

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -74,16 +74,16 @@ class FigshareProvider:
     API docs: https://docs.figshare.com/
     """
 
-    def __new__(cls, auth, credentials, settings):
+    def __new__(cls, auth, credentials, settings, **kwargs):
 
         if settings['container_type'] == 'project':
             return FigshareProjectProvider(
-                auth, credentials, dict(settings, container_id=settings['container_id'])
+                auth, credentials, dict(settings, container_id=settings['container_id']), **kwargs
             )
 
         if settings['container_type'] in pd_settings.ARTICLE_CONTAINER_TYPES:
             return FigshareArticleProvider(
-                auth, credentials, dict(settings, container_id=settings['container_id'])
+                auth, credentials, dict(settings, container_id=settings['container_id']), **kwargs
             )
 
         raise exceptions.ProviderError(

--- a/waterbutler/providers/figshare/provider.py
+++ b/waterbutler/providers/figshare/provider.py
@@ -628,7 +628,10 @@ class FigshareProjectProvider(BaseFigshareProvider):
                             folder=False,
                             is_public=False)
         metadata = await self.metadata(path, **kwargs)
-        if stream.writers['md5'].hexdigest != metadata.extra['hashes']['md5']:
+        if (
+            (not metadata.extra['hashingInProgress']) and
+            stream.writers['md5'].hexdigest != metadata.extra['hashes']['md5']
+        ):
             raise exceptions.UploadChecksumMismatchError()
 
         return metadata, True
@@ -979,7 +982,10 @@ class FigshareArticleProvider(BaseFigshareProvider):
         # Build new file path and return metadata
         path = FigsharePath('/' + file_id, _ids=('', file_id), folder=False, is_public=False)
         metadata = await self.metadata(path, **kwargs)
-        if stream.writers['md5'].hexdigest != metadata.extra['hashes']['md5']:
+        if (
+            (not metadata.extra['hashingInProgress']) and
+            stream.writers['md5'].hexdigest != metadata.extra['hashes']['md5']
+        ):
             raise exceptions.UploadChecksumMismatchError()
 
         return metadata, True


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-330

## Purpose

Enable and update the figshare provider for `aiohttp3`.

## Changes

### `aiohttp` 0.18 -> 3

The figshare provider directly calls `aiohttp.request()` in `aiohttp` 0.18 for some downloads, which no longer works with `aiohttp-3.5`. Instead, use the updated `super().make_request()`. However, this only partially fix the download issue.

### `Authorization` Header

To fully fix the download issue, the figshare auth header are dropped for published / public files.

* As for the figshare provider: When a file has been published, the figshare download request returns a redirection URL which downloads the file directly from its backend storage S3. The new request does not need any auth at all. More importantly, the default figshare auth header breaks the download since S3 API does not understand figshare API. Thus, the provider must use `no_auth_header=True` to inform `super().make_request()` to drop the header.

* As for the core provider: Instead of modifying how headers are built with `build_headers()`, simply update `make_request()` to drop the `Authorization` header  built into the headers.

### Broken Celery Task (Existing Issue on `staging`)

Move / copy fails for the figshare provider since the `__new__()` in the `FigshareProvider` class does not accept extra arguments such as `is_celery_task` which was recently added for celery tasks. The fix is simply adding the missing `**kwargs`. Here is the related commit: [`add flag to BaseProvider to mark if it's running in celery`](https://github.com/CenterForOpenScience/waterbutler/commit/345b2d8d76a0e7425321624ea50b84831290e366).

### Download Stream Size (Existing Issue on `staging`)

Fixed missing stream size when copy / move private files for figshare.

* Copy / Move private files / datasets from figshare to OSFStorage or any working provider including figshare fails. The problem is that the downloaded stream from the src-provider  has a None size during copy / move, which  breaks the upload-to-dest step which requires the size.

* The root problem: the download response for private files using the figshare API does not provide the `Content-Length` header that is used to build the response stream and to set the stream size. On the contrary, the download response for published / public files using figshare's backend S3 API provides the Content-Length header.

* The fix is to retrieve and save the file size in advance during the metadata request and then create the response stream using his size if the `Content-Length` header is not provided.

## Side effects

Fixed move / copy which is broken on both `staging` and `prod`.

## QA Notes

### About figshare and WB-figshare

* figshare is very different from other providers due to the "article type" concept.
  * From current WB's perspective, a figshare article can be either a folder (type 3 Dataset and deprecated type 3 fileset) or a file (all other types).
  * From figshare's perspective, any article type is a set of files.
  * Articles created directly on figshare must have a type.
  * Files created via WB becomes a figshare article without a type.
  * Folders created via WB becomes a figshare article of type 3 (Dataset).
  * For a folder article, WB shows all its contents.
  * For a file article, WB shows only the first file of the article. 

* WB supports figshare project and dataset as OSF project root but not figshare collection. Both cases have been tested during local regression tests. Please note that a dataset can belong to a project or be of its own.
  * As for figshare project as OSF project root, only one level of folder is allowed, which is the article of file type 3 Dataset.
  * As for figshare dataset as OSF project root, only files are allowed. A WB-figshare folder / figshare dataset cannot contain another folder / dataset.

* Public / published figshare articles (folder and file) can only be read but not modified.

* Uploading a file (no type) or creating a folder (type 3 Dataset) ends up creating a private article of respective type, even if the file is uploaded to a published folder.

### Dev Tests

As usual, no comments indicates a **PASS**. Please test both figshare as root and dataset as root when eligible.

* Getting metadata for a file / folder: tested along folder listing and file rendering

* Downloading
  * Public files are downloaded using the figshare's S3 API without auth
  * Private files are downloaded using the figshare API with auth

* Uploading
  * One file
  * Multiple files
  * Contiguous < 10 MB
  * Chunked >= 10 MB

* DAZ
  * Private dataset
  * Public dataset

* Deleting (not available for published / publish folders and files)
  * One file
  * Multiple files
  * One folder
  * Multiple folders

* Folder
  * Creation (only when figshare project as root)
  * Upload: tested along with **Uploading**
  * Deletion: tested along with **Deleting**

* Rename files and folders: N / A, disabled by the front-end

* Verifying non-root folder access for id-based folders: not necessary but tested anyway

* Intra move / copy: N / A

* Inter move / copy (light testing only)
  * One and multiple files
  * One and multiple folders
  * From OSFStorage to figshare
  * From figshare to OSFStorage: must test both private and published
  * Within figshare (intra disabled, thus test with inter): must test both private and published
  * Trying to move a published file or folder ends up being a copy

* Comments persist with moves (light testing only)

* If enabled, test revisions: only seeing the latest, which is as expected.

* Project root is storage root vs. a subfolder: not necessary but tested

* Updating a file

### Extra Notes for QA Testing

At the time of writing the QA notes, `prod` OSF does not have the figshare article type fix while `staging1` and `staging2` has just been fixed. In short:

* `prod` figshare may be more broken than `staging1` and `staging2`
* `feature/oathpit` (i.e. `staging3` after merge) figshare works almost perfectly

## Deployment Notes

No
