### PR TITLE
[ENG-336] [OATHPIT] Throw OneDrive into the Oath Pit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
             'dataverse = waterbutler.providers.dataverse:DataverseProvider',
             'box = waterbutler.providers.box:BoxProvider',
             'googledrive = waterbutler.providers.googledrive:GoogleDriveProvider',
-            # 'onedrive = waterbutler.providers.onedrive:OneDriveProvider',
+            'onedrive = waterbutler.providers.onedrive:OneDriveProvider',
             'googlecloud = waterbutler.providers.googlecloud:GoogleCloudProvider',
         ],
     },

--- a/tasks.py
+++ b/tasks.py
@@ -75,8 +75,7 @@ def test(ctx, verbose=False, types=False, nocov=False, provider=None, path=None)
     # TODO: update this ignore list when new providers are added
     ignored_providers = '--ignore=tests/providers/cloudfiles/ ' \
                         '--ignore=tests/providers/figshare/ ' \
-                        '--ignore=tests/providers/gitlab/ ' \
-                        '--ignore=tests/providers/onedrive '
+                        '--ignore=tests/providers/gitlab/ '
 
     cmd = 'py.test{} {} tests{} {}'.format(coverage, ignored_providers, path, verbose)
     ctx.run(cmd, pty=True)


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-336

## Purpose

Enable and update the OneDrive provider for `aiohttp3`.

## Changes

No changes 🔥 🔥 🔥 

## Side effects

N / A

Fixed move / copy which is broken on both `staging` and `prod`.

## QA Notes

### Dev Tests

As usual, no comments indicates a **PASS**. Please test both **OneDrive root** and **OneDrive folder** as OSF project root.

* Getting metadata for a file / folder: tested along folder listing and file rendering

* Downloading

* Uploading: N / A

* DAZ

* Deleting: N / A

* Folder
  * Creation: N / A
  * Upload: tested along with **Uploading**
  * Deletion: N / A

* Rename files and folders: N / A

* Verifying non-root folder access for id-based folders: Yes and tested

* Intra move / copy: N / A

* Inter move / copy (light testing only)
  * One and multiple files
  * One and multiple folders
  * From OneDrive to OSFStorage only

* Comments persist with moves (light testing only)

* If enabled, test revisions: enabled and tested

* Project root is storage root vs. a subfolder: Yes and tested

* Updating a file: N / A

## Deployment Notes

No
