### PR TITLE
[ENG-333] [OATHPIT] Throw GitLab into the Oath Pit

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,8 @@ flake8==3.5.0
 ipdb==0.12.2
 ipython==7.8.0
 mypy==0.580
+mccabe==0.6.1
+pycodestyle==2.3.1
 pydevd==0.0.6
 pyflakes==1.6.0
 pytest==5.2.1

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             'figshare = waterbutler.providers.figshare:FigshareProvider',
             'filesystem = waterbutler.providers.filesystem:FileSystemProvider',
             'github = waterbutler.providers.github:GitHubProvider',
-            # 'gitlab = waterbutler.providers.gitlab:GitLabProvider',
+            'gitlab = waterbutler.providers.gitlab:GitLabProvider',
             'bitbucket = waterbutler.providers.bitbucket:BitbucketProvider',
             'osfstorage = waterbutler.providers.osfstorage:OSFStorageProvider',
             'owncloud = waterbutler.providers.owncloud:OwnCloudProvider',

--- a/tasks.py
+++ b/tasks.py
@@ -73,8 +73,7 @@ def test(ctx, verbose=False, types=False, nocov=False, provider=None, path=None)
     verbose = '-v' if verbose else ''
 
     # TODO: update this ignore list when new providers are added
-    ignored_providers = '--ignore=tests/providers/cloudfiles/ ' \
-                        '--ignore=tests/providers/gitlab/ '
+    ignored_providers = '--ignore=tests/providers/cloudfiles/'
 
     cmd = 'py.test{} {} tests{} {}'.format(coverage, ignored_providers, path, verbose)
     ctx.run(cmd, pty=True)

--- a/tests/providers/gitlab/fixtures.py
+++ b/tests/providers/gitlab/fixtures.py
@@ -163,16 +163,6 @@ def revisions_for_file():
     ]
 
 
-@pytest.fixture
-def weird_ruby_response():
-    """See: https://gitlab.com/gitlab-org/gitlab-ce/issues/31790"""
-    return ('{:file_name=>"file", :file_path=>"file", :size=>5, '
-            ':encoding=>"base64", :content=>"cm9sZgo=", :ref=>"master", '
-            ':blob_id=>"cf37e8f1e80b5747301df4e1557036b37294a716", '
-            ':commit_id=>"8c7b653eab7191dde3aff9e33ddf309c3d1f440f", '
-            ':last_commit_id=>"8c7b653eab7191dde3aff9e33ddf309c3d1f440f"}')
-
-
 # fixtures for testing file revision metadata
 @pytest.fixture()
 def default_branches():

--- a/tests/providers/gitlab/fixtures.py
+++ b/tests/providers/gitlab/fixtures.py
@@ -22,6 +22,7 @@ def simple_tree():
             }
         ]
 
+
 @pytest.fixture
 def gitlab_example_sub_project_tree():
     return [
@@ -40,6 +41,7 @@ def gitlab_example_sub_project_tree():
                 "mode": "040000"
             }
         ]
+
 
 @pytest.fixture
 def subfolder_tree():
@@ -95,6 +97,7 @@ def subfolder_tree():
             }
         ]
 
+
 @pytest.fixture
 def simple_file_metadata():
     return {
@@ -104,6 +107,7 @@ def simple_file_metadata():
         'file_path': '/folder1/folder2/file',
         'size': 123
     }
+
 
 @pytest.fixture
 def revisions_for_file():
@@ -158,6 +162,7 @@ def revisions_for_file():
         }
     ]
 
+
 @pytest.fixture
 def weird_ruby_response():
     """See: https://gitlab.com/gitlab-org/gitlab-ce/issues/31790"""
@@ -167,6 +172,9 @@ def weird_ruby_response():
             ':commit_id=>"8c7b653eab7191dde3aff9e33ddf309c3d1f440f", '
             ':last_commit_id=>"8c7b653eab7191dde3aff9e33ddf309c3d1f440f"}')
 
+
 # fixtures for testing file revision metadata
-with open(os.path.join(os.path.dirname(__file__), 'fixtures/default-branch.json'), 'r') as fp:
-    default_branches = json.load(fp)
+@pytest.fixture()
+def default_branches():
+    with open(os.path.join(os.path.dirname(__file__), 'fixtures/default-branch.json'), 'r') as fp:
+        return json.load(fp)

--- a/tests/providers/gitlab/test_provider.py
+++ b/tests/providers/gitlab/test_provider.py
@@ -3,16 +3,16 @@ import hashlib
 import pytest
 import aiohttpretty
 
-from waterbutler.core import streams
 from waterbutler.core import exceptions
 
 from waterbutler.providers.gitlab import GitLabProvider
 from waterbutler.providers.gitlab.path import GitLabPath
-from waterbutler.providers.gitlab import settings as gitlab_settings
 from waterbutler.providers.gitlab.metadata import GitLabFileMetadata
 from waterbutler.providers.gitlab.metadata import GitLabFolderMetadata
 
-from tests.providers.gitlab import fixtures
+from tests.providers.gitlab.fixtures import (simple_tree, simple_file_metadata,
+                                             subfolder_tree, revisions_for_file,
+                                             weird_ruby_response, default_branches, )
 
 
 @pytest.fixture
@@ -72,14 +72,14 @@ class TestValidatePath:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_validate_v1_root(self, provider):
+    async def test_validate_v1_root(self, provider, default_branches):
         path = '/'
         default_branch_url = 'http://base.url/api/v4/projects/123'
-        body = fixtures.default_branches['default_branch']
+        body = default_branches['default_branch']
         aiohttpretty.register_json_uri('GET', default_branch_url, body=body, status=200)
 
         commit_sha_url = 'http://base.url/api/v4/projects/123/repository/branches/master'
-        commit_sha_body = fixtures.default_branches['get_commit_sha']
+        commit_sha_body = default_branches['get_commit_sha']
         aiohttpretty.register_json_uri('GET', commit_sha_url, body=commit_sha_body, status=200)
 
         root_path = await provider.validate_v1_path(path)
@@ -95,9 +95,9 @@ class TestValidatePath:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_validate_v1_root_by_branch(self, provider):
+    async def test_validate_v1_root_by_branch(self, provider, default_branches):
         commit_sha_url = 'http://base.url/api/v4/projects/123/repository/branches/otherbranch'
-        commit_sha_body = fixtures.default_branches['get_commit_sha']
+        commit_sha_body = default_branches['get_commit_sha']
         aiohttpretty.register_json_uri('GET', commit_sha_url, body=commit_sha_body, status=200)
 
         root_path = await provider.validate_v1_path('/', branch='otherbranch')
@@ -143,9 +143,9 @@ class TestValidatePath:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_validate_v1_root_by_revision_branch(self, provider):
+    async def test_validate_v1_root_by_revision_branch(self, provider, default_branches):
         commit_sha_url = 'http://base.url/api/v4/projects/123/repository/branches/otherbranch'
-        commit_sha_body = fixtures.default_branches['get_commit_sha']
+        commit_sha_body = default_branches['get_commit_sha']
         aiohttpretty.register_json_uri('GET', commit_sha_url, body=commit_sha_body, status=200)
 
         root_path = await provider.validate_v1_path('/', revision='otherbranch')
@@ -161,11 +161,11 @@ class TestValidatePath:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_validate_v1_path_file(self, provider):
+    async def test_validate_v1_path_file(self, provider, simple_tree):
         path = '/folder1/file1'
         url = ('http://base.url/api/v4/projects/123/repository/tree'
                '?path=folder1/&page=1&per_page={}&ref=a1b2c3d4'.format(provider.MAX_PAGE_SIZE))
-        aiohttpretty.register_json_uri('GET', url, body=fixtures.simple_tree())
+        aiohttpretty.register_json_uri('GET', url, body=simple_tree)
 
         try:
             file_path = await provider.validate_v1_path(path, commitSha='a1b2c3d4',
@@ -203,11 +203,11 @@ class TestValidatePath:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_validate_v1_path_folder(self, provider):
+    async def test_validate_v1_path_folder(self, provider, subfolder_tree):
         path = '/files/lfs/'
         url = ('http://base.url/api/v4/projects/123/repository/tree'
                '?path=files/&page=1&per_page={}&ref=a1b2c3d4'.format(provider.MAX_PAGE_SIZE))
-        aiohttpretty.register_json_uri('GET', url, body=fixtures.subfolder_tree())
+        aiohttpretty.register_json_uri('GET', url, body=subfolder_tree)
 
         try:
             folder_path = await provider.validate_v1_path(path, commitSha='a1b2c3d4',
@@ -257,18 +257,19 @@ class TestMetadata:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_metadata_file_with_default_ref(self, provider):
+    async def test_metadata_file_with_default_ref(self, provider, simple_file_metadata,
+                                                  revisions_for_file):
         path = '/folder1/folder2/file'
         gl_path = GitLabPath(path, _ids=([('a1b2c3d4', 'master')] * 4))
 
         url = ('http://base.url/api/v4/projects/123/repository/files/'
                'folder1%2Ffolder2%2Ffile?ref=a1b2c3d4')
-        aiohttpretty.register_json_uri('GET', url, body=fixtures.simple_file_metadata())
+        aiohttpretty.register_json_uri('GET', url, body=simple_file_metadata)
 
         history_url = ('http://base.url/api/v4/projects/123/repository/commits'
                        '?path=folder1/folder2/file&ref_name=a1b2c3d4&page=1'
                        '&per_page={}'.format(provider.MAX_PAGE_SIZE))
-        aiohttpretty.register_json_uri('GET', history_url, body=fixtures.revisions_for_file())
+        aiohttpretty.register_json_uri('GET', history_url, body=revisions_for_file)
 
         etag = hashlib.sha256('{}::{}::{}'.format('gitlab', path, 'a1b2c3d4').encode('utf-8'))\
                       .hexdigest()
@@ -303,18 +304,19 @@ class TestMetadata:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_metadata_file_with_branch(self, provider):
+    async def test_metadata_file_with_branch(self, provider,
+                                             simple_file_metadata, revisions_for_file):
         path = '/folder1/folder2/file'
         gl_path = GitLabPath(path, _ids=([(None, 'my-branch')] * 4))
 
         url = ('http://base.url/api/v4/projects/123/repository/files/'
                'folder1%2Ffolder2%2Ffile?ref=my-branch')
-        aiohttpretty.register_json_uri('GET', url, body=fixtures.simple_file_metadata())
+        aiohttpretty.register_json_uri('GET', url, body=simple_file_metadata)
 
         history_url = ('http://base.url/api/v4/projects/123/repository/commits'
                        '?path=folder1/folder2/file&ref_name=my-branch&page=1'
                        '&per_page={}'.format(provider.MAX_PAGE_SIZE))
-        aiohttpretty.register_json_uri('GET', history_url, body=fixtures.revisions_for_file())
+        aiohttpretty.register_json_uri('GET', history_url, body=revisions_for_file)
 
         result = await provider.metadata(gl_path)
         assert result.json_api_serialized('mst3k')['links'] == {
@@ -328,19 +330,20 @@ class TestMetadata:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_metadata_file_ruby_response(self, provider):
+    async def test_metadata_file_ruby_response(self, provider,
+                                               weird_ruby_response, revisions_for_file):
         """See: https://gitlab.com/gitlab-org/gitlab-ce/issues/31790"""
         path = '/folder1/folder2/file'
         gl_path = GitLabPath(path, _ids=([(None, 'my-branch')] * 4))
 
         url = ('http://base.url/api/v4/projects/123/repository/files/'
                'folder1%2Ffolder2%2Ffile?ref=my-branch')
-        aiohttpretty.register_uri('GET', url, body=fixtures.weird_ruby_response())
+        aiohttpretty.register_uri('GET', url, body=weird_ruby_response)
 
         history_url = ('http://base.url/api/v4/projects/123/repository/commits'
                        '?path=folder1/folder2/file&ref_name=my-branch&page=1'
                        '&per_page={}'.format(provider.MAX_PAGE_SIZE))
-        aiohttpretty.register_json_uri('GET', history_url, body=fixtures.revisions_for_file())
+        aiohttpretty.register_json_uri('GET', history_url, body=revisions_for_file)
 
         result = await provider.metadata(gl_path)
         assert result.name == 'file'
@@ -441,13 +444,13 @@ class TestRevisions:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_revisions(self, provider):
+    async def test_revisions(self, provider, revisions_for_file):
         path = '/folder1/folder2/file'
         gl_path = GitLabPath(path, _ids=([('a1b2c3d4', 'master')] * 4))
 
         url = ('http://base.url/api/v4/projects/123/repository/commits'
                '?path=folder1/folder2/file&ref_name=a1b2c3d4')
-        aiohttpretty.register_json_uri('GET', url, body=fixtures.revisions_for_file())
+        aiohttpretty.register_json_uri('GET', url, body=revisions_for_file)
 
         revisions = await provider.revisions(gl_path)
         assert len(revisions) == 3
@@ -514,28 +517,28 @@ class TestDownload:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_download_file_ruby_response(self, provider):
+    async def test_download_file_ruby_response(self, provider, weird_ruby_response):
         """See: https://gitlab.com/gitlab-org/gitlab-ce/issues/31790"""
         path = '/folder1/folder2/file'
         gl_path = GitLabPath(path, _ids=([(None, 'my-branch')] * 4))
 
         url = ('http://base.url/api/v4/projects/123/repository/files/'
                'folder1%2Ffolder2%2Ffile?ref=my-branch')
-        aiohttpretty.register_uri('GET', url, body=fixtures.weird_ruby_response())
+        aiohttpretty.register_uri('GET', url, body=weird_ruby_response)
 
         result = await provider.download(gl_path)
         assert await result.read() == b'rolf\n'
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    async def test_download_file_ruby_response_range(self, provider):
+    async def test_download_file_ruby_response_range(self, provider, weird_ruby_response):
         """See: https://gitlab.com/gitlab-org/gitlab-ce/issues/31790"""
         path = '/folder1/folder2/file'
         gl_path = GitLabPath(path, _ids=([(None, 'my-branch')] * 4))
 
         url = ('http://base.url/api/v4/projects/123/repository/files/'
                'folder1%2Ffolder2%2Ffile?ref=my-branch')
-        aiohttpretty.register_uri('GET', url, body=fixtures.weird_ruby_response())
+        aiohttpretty.register_uri('GET', url, body=weird_ruby_response)
 
         result = await provider.download(gl_path, range=(0, 1))
         assert result.partial

--- a/tests/providers/gitlab/test_provider.py
+++ b/tests/providers/gitlab/test_provider.py
@@ -10,9 +10,8 @@ from waterbutler.providers.gitlab.path import GitLabPath
 from waterbutler.providers.gitlab.metadata import GitLabFileMetadata
 from waterbutler.providers.gitlab.metadata import GitLabFolderMetadata
 
-from tests.providers.gitlab.fixtures import (simple_tree, simple_file_metadata,
-                                             subfolder_tree, revisions_for_file,
-                                             weird_ruby_response, default_branches, )
+from tests.providers.gitlab.fixtures import (simple_tree, simple_file_metadata, subfolder_tree,
+                                             revisions_for_file, default_branches, )
 
 
 @pytest.fixture
@@ -327,28 +326,6 @@ class TestMetadata:
                          '/folder1/folder2/file?branch=my-branch'),
             'delete': None,
         }
-
-    @pytest.mark.asyncio
-    @pytest.mark.aiohttpretty
-    async def test_metadata_file_ruby_response(self, provider,
-                                               weird_ruby_response, revisions_for_file):
-        """See: https://gitlab.com/gitlab-org/gitlab-ce/issues/31790"""
-        path = '/folder1/folder2/file'
-        gl_path = GitLabPath(path, _ids=([(None, 'my-branch')] * 4))
-
-        url = ('http://base.url/api/v4/projects/123/repository/files/'
-               'folder1%2Ffolder2%2Ffile?ref=my-branch')
-        aiohttpretty.register_uri('GET', url, body=weird_ruby_response)
-
-        history_url = ('http://base.url/api/v4/projects/123/repository/commits'
-                       '?path=folder1/folder2/file&ref_name=my-branch&page=1'
-                       '&per_page={}'.format(provider.MAX_PAGE_SIZE))
-        aiohttpretty.register_json_uri('GET', history_url, body=revisions_for_file)
-
-        result = await provider.metadata(gl_path)
-        assert result.name == 'file'
-        assert result.size == 5
-        assert result.content_type == None
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty

--- a/waterbutler/providers/gitlab/provider.py
+++ b/waterbutler/providers/gitlab/provider.py
@@ -1,7 +1,5 @@
 import json
-import base64
 import typing
-import aiohttp
 import logging
 import mimetypes
 
@@ -200,17 +198,29 @@ class GitLabProvider(provider.BaseProvider):
                        path: GitLabPath, range: typing.Tuple[int, int]=None, **kwargs):
         r"""Return a stream to the specified file on GitLab.
 
-        There is an endpoint for downloading the raw file directly, but we cannot use it because
-        GitLab requires periods in the file path to be encoded.  Python and aiohttp make this
-        difficult, though their behavior is arguably correct. See
-        https://gitlab.com/gitlab-org/gitlab-ce/issues/31470 for details. (Update: this is due to
-        be fixed in the GL 10.0 release)
+        With GitLab CE Files API, there are two options to download a file.
 
-        API docs: https://docs.gitlab.com/ce/api/repository_files.html#get-file-from-repository
+        Option 1: ``GET /projects/:id/repository/files/:file_path/raw?``
 
-        This uses the same endpoint as `_fetch_file_contents`, but relies on the response headers,
-        which are not returned by that method.  It may also be replaced when the above bug is
-        fixed.
+        This is the preferred and currently used option which does exactly what we need.  ``range``
+        requests are handled correctly without any extra tweak.
+
+        API Docs: https://docs.gitlab.com/ce/api/repository_files.html#get-raw-file-from-repository
+
+        Option 2: ``GET /projects/:id/repository/files/:file_path?``
+
+        In this option, the raw response is not the file content by itself but a JSON that contains
+        both the file metadata and the Base64 encoded file content.  WB has to decode the content,
+        recalculate the content size and update the response header for each download.  ``range``
+        requests must be further taken care of.
+
+        API Docs: https://docs.gitlab.com/ce/api/repository_files.html#get-file-from-repository
+
+        This was the only way due to an issue (already fixed in GL API v10.0) in the above option:
+        GitLab requires periods in the file path to be encoded, and Python and aiohttp make this
+        difficult though their behavior is arguably correct.
+
+        Issue Link: https://gitlab.com/gitlab-org/gitlab-ce/issues/31470.
 
         :param str path: The path to the file on GitLab
         :param dict \*\*kwargs: Ignored
@@ -218,47 +228,19 @@ class GitLabProvider(provider.BaseProvider):
         """
 
         logger.debug('requested-range:: {}'.format(range))
-        url = self._build_file_url(path)
+
+        url = self._build_file_url(path, raw=True)
         resp = await self.make_request(
             'GET',
             url,
             range=range,
-            expects=(200,),
+            expects=(200, 206, ),
             throws=exceptions.DownloadError,
         )
+
         logger.debug('download-headers:: {}'.format([(x, resp.headers[x]) for x in resp.headers]))
 
-        raw_data = (await resp.read()).decode("utf-8")
-        data = None
-        try:
-            data = json.loads(raw_data)
-        except json.decoder.JSONDecodeError:
-            # GitLab API sometimes returns ruby hashes instead of json
-            # see: https://gitlab.com/gitlab-org/gitlab-ce/issues/31790
-            # fixed in GL v9.5
-            data = self._convert_ruby_hash_to_dict(raw_data)
-
-        mdict_options = {}
-
-        raw = base64.b64decode(data['content'])
-        if range is not None:
-            start, end = range
-            orig_len = len(raw)
-            if start is not None and end is not None:
-                raw = raw[start:end + 1]
-                mdict_options['Content-Range'] = 'bytes {}-{}/{}'.format(start, end, orig_len)
-                resp.status = 206
-
-        mimetype = mimetypes.guess_type(path.full_path)[0]
-        if mimetype is not None:
-            mdict_options['CONTENT-TYPE'] = mimetype
-
-        mdict = aiohttp.multidict.MultiDict(resp.headers)
-        mdict.update(mdict_options)
-        resp.headers = mdict
-        resp.content = streams.StringStream(raw)
-
-        return streams.ResponseStreamReader(resp, size=len(raw))
+        return streams.ResponseStreamReader(resp)
 
     def can_duplicate_names(self):
         return False
@@ -297,26 +279,50 @@ class GitLabProvider(provider.BaseProvider):
         segments = ('projects', self.repo_id) + segments
         return self.build_url(*segments, **query)
 
-    def _build_file_url(self, path: GitLabPath) -> str:
-        """Build a url to GitLab's files endpoint.  This is done separately because the files
-        endpoint requires unusual quoting of the path.  GL requires that the directory-separating
-        slashes in the full path of the file be url encoded.  Ex. a file called ``foo/bar/baz``
-        would be encoded as ``foo%2Fbar%2Fbaz``.  WB's default url-building methods would split the
-        path, encode each segment, then rejoin them with literal slashes.  If we were to try to
-        pre-encode the path, any encoded characters will be double-encoded
+    def _build_file_url(self, path: GitLabPath, raw: bool=False) -> str:
+        """Build a url to GitLab's files endpoint.
+
+        Quirk 1:
+
+        This is done separately because the files endpoint requires unusual quoting of the path.
+        GL requires that the directory-separating slashes in the full path of the file be url
+        encoded.  Ex. a file called ``foo/bar/baz`` would be encoded as ``foo%2Fbar%2Fbaz``.  WB's
+        default url-building methods would split the path, encode each segment, then rejoin them
+        with literal slashes.  If we were to try to pre-encode the path, any encoded characters
+        will be double-encoded
+
+        Quirk 2:
+
+        GitLab CE File API takes care of file operations.  Most of them share the same endpoint /
+        URL format, and the specific action is determined by the HTTP method.
+
+            CRUD: ``POST | GET | PUT | DELETE /projects/:id/repository/files/:file_path?``
+
+        However, one issue with ``GET`` (i.e. read / download) is that the request returns a JSON
+        response containing both the file metadata and the Base64 encoded file content.  Replacing
+        ``GET`` with ``HEAD`` just returns the file metadata via response headers.
+
+        Alternatively, WB now uses the dedicated endpoint for downloading the raw content of a file
+        directly at ``GET /projects/:id/repository/files/:file_path/raw?``.  Set the optional param
+        ``raw`` to ``True`` to use this endpoint in download.
 
         API docs:
 
         * https://docs.gitlab.com/ce/api/repository_files.html#get-file-from-repository
 
+        * https://docs.gitlab.com/ce/api/repository_files.html#get-raw-file-from-repository
+
         * https://docs.gitlab.com/ce/api/README.html#namespaced-path-encoding
 
         :param GitLabPath path: path to a file
+        :param bool raw: get raw file content
         :rtype: str
         :return: url to the GitLab files endpoint for the given file
         """
         file_base = self._build_repo_url('repository', 'files')
-        return '{}/{}?ref={}'.format(file_base, path.raw_path.replace('/', '%2F'), path.ref)
+        suffix = '/raw' if raw else ''
+        return '{}/{}{}?ref={}'.format(file_base, path.raw_path.replace('/', '%2F'), suffix,
+                                       path.ref)
 
     async def _metadata_folder(self, path: GitLabPath) -> typing.List[BaseGitLabMetadata]:
         """Fetch metadata for the contents of the folder at ``path`` and return a `list` of


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-333

## Purpose

Enable and update the GitLab provider for `aiohttp3`.

## Changes

* Fixed download and its tests
  * This provider has been using a complicated hack for download due to [GL-Issue#31470](https://gitlab.com/gitlab-org/gitlab-ce/issues/31470) which breaks the dedicated endpoint for direct raw file download. Fortunately, the bug was fixed in GL API 10.0 so that download has been re-written to use the preferred and intuitive approach.
  * Another reason for the re-writing is that the work-around would not work with `aiohttp3` even if we kept it for backward compatibility. It needs to modify response headers directly within the object before passing it to the response stream reader. However, `aiohttp3` makes it impossible: the `headers` is defined as a `@reify` property. Neither does using `_headers` instead of `headers` work due to the cache effect of `@reify` property.
  * Please see the [Flow Dock discussion](https://www.flowdock.com/app/cos/integration-grants/threads/yOVvuItpKniuBtUwSq_rQWEQiT4) for details.
  * Default and range download tests are rewritten and work-around tests has been removed.

* Removed another work-around for GitLab file API's [ruby hash bug](https://gitlab.com/gitlab-org/gitlab-foss/issues/31790).

* Fixed and update fixture usage in tests

* Added missing dependencies
  * I ran into a weird issue where flake8 fails with library import failure. I tried the following three but none of them solves the problem: 1) install and reinstall flake8 inside the container, 2) re-install requirements with `docker-compose` and 3) `invoke install -d` inside container. However, removing and re-installing some of it's dependencies works. This may be just a glitch but I decided to add the missing dependencies with the default (most recent) compatible version for `flake8==3.5.0`.

## Side effects

In the following [commit](https://github.com/CenterForOpenScience/waterbutler/commit/d4aad52e5fdc961e299bca1bbbe02df1cd664975) message, the fix for download may break GL instances that uses an API older than 10.0. The ruby hash bug has been removed as well given it is even older (fixed in 9.5).

> update comments about outstanding GL bugs
> * Some have been fixed in subsequent releases.  Update the comments to reflect this, but do not yet remove the workarounds.  Need to evaluate the popularity of old versions in the wild before removing workarounds.

## QA Notes

### Dev Tests

As usual, no comments indicates a **PASS**.

* Getting metadata for a file / folder: tested along folder listing and file rendering

* Downloading

* Uploading: N / A

* DAZ

* Deleting: N / A

* Folder
  * Creation: N / A
  * Upload: N / A
  * Deletion: N / A

* Rename files and folders: N / A

* Verifying non-root folder access for id-based folders: N / A

* Intra move / copy: N / A

* Inter move / copy (light testing only)
  * One and multiple files
  * One and multiple folders
  * From GitLab to OSFStorage only

* Comments persist with moves (light testing only)

* If enabled, test revisions: enabled and tested

* Project root is storage root vs. a subfolder: N / A

* Updating a file: N / A

## Deployment Notes

No
