### PR TITLE
[ENG-327] [OATHPIT] Throw CloudFiles into the Oath Pit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
             'osf = waterbutler.auth.osf:OsfAuthHandler',
         ],
         'waterbutler.providers': [
-            # 'cloudfiles = waterbutler.providers.cloudfiles:CloudFilesProvider',
+            'cloudfiles = waterbutler.providers.cloudfiles:CloudFilesProvider',
             'dropbox = waterbutler.providers.dropbox:DropboxProvider',
             'figshare = waterbutler.providers.figshare:FigshareProvider',
             'filesystem = waterbutler.providers.filesystem:FileSystemProvider',

--- a/tasks.py
+++ b/tasks.py
@@ -72,10 +72,7 @@ def test(ctx, verbose=False, types=False, nocov=False, provider=None, path=None)
     coverage = ' --cov-report term-missing --cov waterbutler' if not nocov else ''
     verbose = '-v' if verbose else ''
 
-    # TODO: update this ignore list when new providers are added
-    ignored_providers = '--ignore=tests/providers/cloudfiles/'
-
-    cmd = 'py.test{} {} tests{} {}'.format(coverage, ignored_providers, path, verbose)
+    cmd = 'py.test{} tests{} {}'.format(coverage, path, verbose)
     ctx.run(cmd, pty=True)
 
 

--- a/tests/providers/cloudfiles/test_metadata.py
+++ b/tests/providers/cloudfiles/test_metadata.py
@@ -1,15 +1,15 @@
 import pytest
-import aiohttp
+import multidict
 
 from waterbutler.core.path import WaterButlerPath
 from waterbutler.providers.cloudfiles.metadata import (CloudFilesFileMetadata,
                                                        CloudFilesHeaderMetadata,
-                                                       CloudFilesFolderMetadata)
+                                                       CloudFilesFolderMetadata, )
 
 
 @pytest.fixture
 def file_header_metadata_txt():
-    return aiohttp.multidict.CIMultiDict([
+    return multidict.CIMultiDict([
         ('ORIGIN', 'https://mycloud.rackspace.com'),
         ('CONTENT-LENGTH', '216945'),
         ('ACCEPT-RANGES', 'bytes'),

--- a/waterbutler/providers/cloudfiles/provider.py
+++ b/waterbutler/providers/cloudfiles/provider.py
@@ -8,15 +8,13 @@ import functools
 
 import furl
 
-from waterbutler.core import streams
-from waterbutler.core import provider
-from waterbutler.core import exceptions
 from waterbutler.core.path import WaterButlerPath
+from waterbutler.core import streams, provider, exceptions
 
 from waterbutler.providers.cloudfiles import settings
-from waterbutler.providers.cloudfiles.metadata import CloudFilesFileMetadata
-from waterbutler.providers.cloudfiles.metadata import CloudFilesFolderMetadata
-from waterbutler.providers.cloudfiles.metadata import CloudFilesHeaderMetadata
+from waterbutler.providers.cloudfiles.metadata import (CloudFilesFileMetadata,
+                                                       CloudFilesFolderMetadata,
+                                                       CloudFilesHeaderMetadata, )
 
 
 def ensure_connection(func):
@@ -253,11 +251,11 @@ class CloudFilesProvider(provider.BaseProvider):
                 self.public_endpoint, self.endpoint = self._extract_endpoints(data)
         if not self.temp_url_key:
             self.metrics.add('ensure_connection.has_temp_url_key', False)
-            async with self.request('HEAD', self.endpoint, expects=(204, )) as resp:
-                try:
-                    self.temp_url_key = resp.headers['X-Account-Meta-Temp-URL-Key'].encode()
-                except KeyError:
-                    raise exceptions.ProviderError('No temp url key is available', code=503)
+            resp = await self.make_request('HEAD', self.endpoint, expects=(204, ))
+            try:
+                self.temp_url_key = resp.headers['X-Account-Meta-Temp-URL-Key'].encode()
+            except KeyError:
+                raise exceptions.ProviderError('No temp url key is available', code=503)
 
     def _extract_endpoints(self, data):
         """Pulls both the public and internal cloudfiles urls,

--- a/waterbutler/providers/cloudfiles/provider.py
+++ b/waterbutler/providers/cloudfiles/provider.py
@@ -43,7 +43,19 @@ class CloudFilesProvider(provider.BaseProvider):
         self.region = self.credentials['region']
         self.og_token = self.credentials['token']
         self.username = self.credentials['username']
-        self.container = self.settings['container']
+
+        # osfstorage used to store the bucket name under the "container" key but switched to using
+        # the "bucket" key during the googlecloud transistion.  Prefer "container" for backcompat,
+        # but if running with a recent OSF you may need to migrate your osfstorage version tables
+        # to use "bucket" instead.
+        if 'container' in self.settings:
+            self.container = self.settings['container']
+        elif 'bucket' in self.settings:
+            self.container = self.settings['bucket']
+        else:
+            raise exceptions.WaterButlerException('No "container" or "bucket" key in '
+                                                  'osfstorage settings')
+
         self.use_public = self.settings.get('use_public', True)
         self.metrics.add('region', self.region)
 


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-327

## Purpose

Enable and update the CloudFiles provider for `aiohttp3`.

## Changes

### Code

* Removed context manager when making request
* Improved import style

### Tests

* Fixed import and usage for `multidict`
* Remove unused imports and improve style
* Fixed JSON response parsing
* Removed `--ignore` for `pytest` since all providers have been converted

## Side effects

N / A

## QA Notes

N / A

CloudFiles was the original storage provider for OSFStorage which has been deprecated since early 2018. It is only not testable by QA.

## Deployment Notes

No
