### PR TITLE
[ENG-1393] Fix Sentry events due to `raven-python` -> `sentry-sdk`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pyjwe==1.0.0
 pyjwt==1.4.0
 python-dateutil==2.5.3
 pytz==2017.2
-sentry-sdk==0.13.2
+sentry-sdk==0.14.0
 setuptools==37.0.0
 stevedore==1.2.0
 tornado==6.0.3

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -10,36 +10,58 @@ class TestAsyncRetry:
 
     @pytest.mark.asyncio
     async def test_returns_success(self):
+        """Test the scenario where a function succeeds on first attempt.
+        """
         mock_func = mock.Mock(return_value='Foo')
         retryable = utils.async_retry(5, 0)(mock_func)
+
         x = await retryable()
+
+        # `mock_func` succeeds on first attempt; thus it should be called only once
         assert x == 'Foo'
         assert mock_func.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_retries_until(self):
-        mock_func = mock.Mock(side_effect=[Exception(), 'Foo'])
+    async def test_retries_success(self):
+        """Test a scenario where a function fails first but succeeds after retrying.
+        """
+        mock_func = mock.Mock(side_effect=[Exception(), Exception(), 'Foo'])
         retryable = utils.async_retry(5, 0)(mock_func)
 
         x = await retryable()
 
+        # `mock_func` fails on the first two attempts but succeeds on the third one; thus it should
+        # be called exactly three times.
         assert x == 'Foo'
-        assert mock_func.call_count == 2
+        assert mock_func.call_count == 3
 
     @pytest.mark.asyncio
-    async def test_retries_then_raises(self):
+    async def test_retries_failed(self):
+        """Test a scenario where a function keeps failing / retrying until it reaches retry limit.
+        """
         mock_func = mock.Mock(side_effect=Exception('Foo'))
-        retryable = utils.async_retry(5, 0)(mock_func)
+        retryable = utils.async_retry(8, 0)(mock_func)
 
         with pytest.raises(Exception) as e:
-            coro = await retryable()
+            await retryable()
 
+        # `mock_func` keeps failing until it reaches the maximum retry limit which is 8; thus it
+        # should have been called 1 (initial) + 8 (retries) = 9 times before throwing an exception.
         assert e.type == Exception
         assert e.value.args == ('Foo',)
-        assert mock_func.call_count == 6
+        assert mock_func.call_count == 9
 
     @pytest.mark.asyncio
-    async def test_retries_by_its_self(self):
+    async def test_retries_by_itself(self):
+        """Test ``async_retry`` decorated coroutine itself.
+
+        This test takes care of the case where ``retryable()`` is called w/o ``await``, in which
+        case it returns a future that can run as long as nothing else forces it to yield in the
+        meantime.  The following ``await asyncio.sleep(.1)`` does exactly that.  As long as the
+        number of retries is low, ``retryable()`` can execute them all before the sleep is done.
+        However, if you remove the sleep or bump the number of retries up to a ludicrously high
+        number, the test fails b/c it starts asserting before all the retries have been exhausted.
+        """
         mock_func = mock.Mock(side_effect=Exception())
         retryable = utils.async_retry(8, 0)(mock_func)
 
@@ -47,19 +69,50 @@ class TestAsyncRetry:
 
         await asyncio.sleep(.1)
 
+        # `mock_func` keeps failing until it reaches the maximum retry limit which is 8; thus it
+        # should be called 1 (initial) + 8 (retries) = 9 times
         assert mock_func.call_count == 9
 
+    @pytest.mark.asyncio
+    async def test_all_retry(self):
+        """Test multiple ``async_retry`` decorated coroutines being called at the same time.
+
+        This test is similar to ``test_retries_by_itself()`` where it calls ``retryable()`` w/o
+        ``await``. The only difference is that it tests multiple coroutines with multiple calls to
+        better mimic the scenario in ``waterbutler.core.remote_logging.log_file_action()``.
+        """
+
+        mock_func_a = mock.Mock(side_effect=Exception())
+        mock_func_b = mock.Mock(side_effect=Exception())
+        retryable_a = utils.async_retry(4, 0)(mock_func_a)
+        retryable_b = utils.async_retry(4, 0)(mock_func_b)
+
+        retryable_a()
+        retryable_b()
+        retryable_a()
+        retryable_b()
+
+        await asyncio.sleep(.1)
+
+        # Each call of `mock_func_a` or `mock_func_b` keeps failing until it reaches the maximum
+        # retry limit which is 4; thus for either of the two, the total call count should be the
+        # same: 2 (each has been called twice) * (1 (initial) + 4 (retries)) = 10 times.
+        assert mock_func_a.call_count == 10
+        assert mock_func_b.call_count == 10
+
     def test_docstring_survives(self):
-        async def mytest():
-            '''This is a docstring'''
+
+        async def my_test():
+            """This is a docstring"""
             pass
 
-        retryable = utils.async_retry(8, 0)(mytest)
+        retryable = utils.async_retry(8, 0)(my_test)
 
-        assert retryable.__doc__ == '''This is a docstring'''
+        assert retryable.__doc__ == """This is a docstring"""
 
     @pytest.mark.asyncio
     async def test_kwargs_work(self):
+
         async def mytest(mack, *args, **kwargs):
             mack()
             assert args == ('test', 'Foo')
@@ -73,18 +126,6 @@ class TestAsyncRetry:
         assert await fut
 
         assert merk.call_count == 2
-
-    @pytest.mark.asyncio
-    async def test_all_retry(self):
-        mock_func = mock.Mock(side_effect=Exception())
-        retryable = utils.async_retry(8, 0)(mock_func)
-
-        retryable()
-        retryable()
-
-        await asyncio.sleep(.1)
-
-        assert mock_func.call_count == 18
 
 
 class TestContentDisposition:

--- a/waterbutler/core/utils.py
+++ b/waterbutler/core/utils.py
@@ -12,11 +12,8 @@ from urllib import parse
 import aiohttp
 import sentry_sdk
 from stevedore import driver
-from sentry_sdk.integrations.logging import LoggingIntegration
 
 from waterbutler.core import exceptions
-from waterbutler.settings import config
-from waterbutler.version import __version__
 from waterbutler.core.signing import Signer
 from waterbutler.core.streams import EmptyStream
 from waterbutler.server import settings as server_settings
@@ -24,14 +21,6 @@ from waterbutler.server import settings as server_settings
 logger = logging.getLogger(__name__)
 
 signer = Signer(server_settings.HMAC_SECRET, server_settings.HMAC_ALGORITHM)
-
-sentry_dsn = config.get_nullable('SENTRY_DSN', None)
-if sentry_dsn:
-    sentry_logging = LoggingIntegration(
-        level=logging.INFO,  # Capture INFO level and above as breadcrumbs
-        event_level=None,   # Do not send logs of any level as events
-    )
-    sentry_sdk.init(sentry_dsn, release=__version__, integrations=[sentry_logging, ])
 
 
 def make_provider(name: str, auth: dict, credentials: dict, settings: dict, **kwargs):

--- a/waterbutler/server/app.py
+++ b/waterbutler/server/app.py
@@ -9,6 +9,7 @@ import tornado.platform.asyncio
 
 import sentry_sdk
 from sentry_sdk.integrations.tornado import TornadoIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
 
 from waterbutler import settings
 from waterbutler.server.api import v0
@@ -40,10 +41,15 @@ def api_to_handlers(api):
 
 
 def make_app(debug):
+
+    sentry_logging = LoggingIntegration(
+        level=logging.INFO,  # Capture INFO level and above as breadcrumbs
+        event_level=None,   # Do not send logs of any level as events
+    )
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
         release=__version__,
-        integrations=[TornadoIntegration()],
+        integrations=[TornadoIntegration(), sentry_logging, ],
     )
 
     app = tornado.web.Application(


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-1393

## Purpose

Ticket [ENG-481](https://openscience.atlassian.net/browse/ENG-481) with [PR #387](https://github.com/CenterForOpenScience/waterbutler/pull/387) introduced a slight side-effect when `raven-python` was replaced by `sentry-sdk`. Logging messages at error level and above are now sent to Sentry as events by default. We’d love to change this back to it’s original behavior: only exceptions are sent.

## Changes

* Disabled any level of logs being sent as event 
* Bumped the `sentry-sdk` from version `0.13.2` to `0.14.0`.
* Improved tests for `async_retry`
* Improved `import` style on touched files

## Side effects

N / A

## QA Notes

N / A

### Dev QA

Monitor COS Sentry on staging3 (OATHPIT) after merge

## Deployment Notes

N / A
