### PR TITLE
Use colon delineation for s3 buckets

### DIFF
--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -686,8 +686,10 @@ class S3Provider(provider.BaseProvider):
         await self._check_region()
 
         if path._orig_path == '/' and self.settings.get('id'):
-            params = {'prefix': self.settings['id'], 'delimiter': '/'}
+            base_folder = self.settings['id'].split(':/')[1]
+            params = {'prefix': base_folder, 'delimiter': '/'}
         else:
+            base_folder = None
             params = {'prefix': path.path, 'delimiter': '/'}
 
         resp = await self.make_request(
@@ -732,7 +734,6 @@ class S3Provider(provider.BaseProvider):
             if content['Key'] == path.path:
                 continue
 
-            base_folder = self.settings.get('id')
             if base_folder and content['Key'] == base_folder:
                 continue
 


### PR DESCRIPTION
## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/SVCS-1234 -->

## Purpose

We decided to move away from using parent directory names as bucket identifiers to delineating them with a colon. This is for two reasons:
- It looks better
- It allows the folder_id received to always be the same as the one sent.

## Changes

- simply parses the settings `id` with a colon.

## Side effects

None that I know of.

## QA Notes

- was discovered by QA test: https://github.com/CenterForOpenScience/osf-selenium-tests/blob/f9089d5b3db7673cf961e2874e955ddd93631936/api/osf_api.py#L406
- here's a script I ran to replicate that test locally:
```python
attributes = requests.get(
    f'http://0.0.0.0:8000/v2/nodes/{node_id}/addons/s3/folders/',
    headers={'Authorization': f'Bearer {token}'}
).json()['data'][0]['attributes']

raw_payload = {
    'data': {
        'type': 'node_addons',
        'id': 's3',
        'attributes': {
            'folder_id': attributes['folder_id'],
        },
    },
}

print(
    requests.patch(
        url=f'http://0.0.0.0:8000/v2/nodes/{node_id}/addons/s3/',
        json=raw_payload,
        headers={'Authorization': f'Bearer {token}'}
    ).json()
)
```


## Deployment Notes

OSF side
https://github.com/CenterForOpenScience/osf.io/pull/10415