### PR TITLE
[ENG-4624] [S3 Improvements] Project PR - Waterbutler Part

### DIFF
--- a/tests/providers/s3/fixtures.py
+++ b/tests/providers/s3/fixtures.py
@@ -30,6 +30,7 @@ def credentials():
 @pytest.fixture
 def settings():
     return {
+        'id': 'that kerning:/my-subfolder/',
         'bucket': 'that kerning',
         'encrypt_uploads': False
     }

--- a/waterbutler/providers/s3/metadata.py
+++ b/waterbutler/providers/s3/metadata.py
@@ -3,6 +3,12 @@ import os
 from waterbutler.core import metadata
 
 
+def strip_char(str, chars):
+    if str.startswith(chars):
+        return str[len(chars):]
+    return str
+
+
 class S3Metadata(metadata.BaseMetadata):
 
     @property
@@ -24,7 +30,7 @@ class S3FileMetadataHeaders(S3Metadata, metadata.BaseFileMetadata):
 
     @property
     def path(self):
-        return '/' + self._path
+        return '/' + strip_char(self._path, self.raw.get('base_folder', ''))
 
     @property
     def size(self):
@@ -62,7 +68,7 @@ class S3FileMetadata(S3Metadata, metadata.BaseFileMetadata):
 
     @property
     def path(self):
-        return '/' + self.raw['Key']
+        return '/' + strip_char(self.raw['Key'], self.raw.get('base_folder', ''))
 
     @property
     def size(self):
@@ -103,7 +109,7 @@ class S3FolderKeyMetadata(S3Metadata, metadata.BaseFolderMetadata):
 
     @property
     def path(self):
-        return '/' + self.raw['Key']
+        return '/' + strip_char(self.raw['Key'], self.raw.get('base_folder', ''))
 
 
 class S3FolderMetadata(S3Metadata, metadata.BaseFolderMetadata):
@@ -114,6 +120,8 @@ class S3FolderMetadata(S3Metadata, metadata.BaseFolderMetadata):
 
     @property
     def path(self):
+        if self.raw.get('base_folder', ''):
+            return '/' + strip_char(self.raw['Prefix'], self.raw.get('base_folder', ''))
         return '/' + self.raw['Prefix']
 
 

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -69,7 +69,10 @@ class S3Provider(provider.BaseProvider):
         await self._check_region()
 
         if path == '/':
-            return WaterButlerPath(path)
+            # adjust path using base folder to include the buckets root, so just the `/` translates to just
+            # the `/base_folder/` path
+            base_folder = self.settings.get('id', ':/').split(':/')[1]
+            return WaterButlerPath(f'/{base_folder}')
 
         implicit_folder = path.endswith('/')
 
@@ -685,12 +688,10 @@ class S3Provider(provider.BaseProvider):
     async def _metadata_folder(self, path):
         await self._check_region()
 
-        if path._orig_path == '/' and self.settings.get('id'):
-            base_folder = self.settings['id'].split(':/')[1]
-            params = {'prefix': base_folder, 'delimiter': '/'}
-        else:
-            base_folder = None
-            params = {'prefix': path.path, 'delimiter': '/'}
+        # The user selected base folder, the root of the where that user's node is connected.
+        prefix = self.settings['id'].split(':/')[1] if path == '/' and self.settings.get('id') else path.path
+
+        params = {'prefix': prefix, 'delimiter': '/'}
 
         resp = await self.make_request(
             'GET',
@@ -731,10 +732,7 @@ class S3Provider(provider.BaseProvider):
         ]
 
         for content in contents:
-            if content['Key'] == path.path:
-                continue
-
-            if base_folder and content['Key'] == base_folder:
+            if content['Key'] == params['prefix']:
                 continue
 
             if content['Key'].endswith('/'):

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -686,8 +686,10 @@ class S3Provider(provider.BaseProvider):
         await self._check_region()
 
         if path._orig_path == '/' and self.settings.get('id'):
-            params = {'prefix': self.settings['id'], 'delimiter': '/'}
+            base_folder = self.settings['id'].split(':/')[1]
+            params = {'prefix': base_folder, 'delimiter': '/'}
         else:
+            base_folder = None
             params = {'prefix': path.path, 'delimiter': '/'}
 
         resp = await self.make_request(
@@ -732,7 +734,6 @@ class S3Provider(provider.BaseProvider):
             if content['Key'] == path.path:
                 continue
 
-            base_folder = self.settings.get('id')
             if base_folder and content['Key'] == base_folder:
                 continue
 

--- a/waterbutler/providers/s3/provider.py
+++ b/waterbutler/providers/s3/provider.py
@@ -62,17 +62,15 @@ class S3Provider(provider.BaseProvider):
         self.connection = S3Connection(credentials['access_key'],
                 credentials['secret_key'], calling_format=OrdinaryCallingFormat())
         self.bucket = self.connection.get_bucket(settings['bucket'], validate=False)
+        self.base_folder = self.settings.get('id', ':/').split(':/')[1]
         self.encrypt_uploads = self.settings.get('encrypt_uploads', False)
         self.region = None
 
     async def validate_v1_path(self, path, **kwargs):
         await self._check_region()
 
-        if path == '/':
-            # adjust path using base folder to include the buckets root, so just the `/` translates to just
-            # the `/base_folder/` path
-            base_folder = self.settings.get('id', ':/').split(':/')[1]
-            return WaterButlerPath(f'/{base_folder}')
+        # The user selected base folder, the root of the where that user's node is connected.
+        path = f"/{self.base_folder + path.lstrip('/')}"
 
         implicit_folder = path.endswith('/')
 
@@ -101,7 +99,8 @@ class S3Provider(provider.BaseProvider):
         return WaterButlerPath(path)
 
     async def validate_path(self, path, **kwargs):
-        return WaterButlerPath(path)
+        # The user selected base folder, the root of the where that user's node is connected.
+        return WaterButlerPath(f"/{self.base_folder + path.lstrip('/')}")
 
     def can_duplicate_names(self):
         return True
@@ -640,9 +639,14 @@ class S3Provider(provider.BaseProvider):
         await self._check_region()
 
         if path.is_dir:
-            return (await self._metadata_folder(path))
+            metadata = await self._metadata_folder(path)
+            for item in metadata:
+                item.raw['base_folder'] = self.base_folder
+        else:
+            metadata = await self._metadata_file(path, revision=revision)
+            metadata.raw['base_folder'] = self.base_folder
 
-        return (await self._metadata_file(path, revision=revision))
+        return metadata
 
     async def create_folder(self, path, folder_precheck=True, **kwargs):
         """
@@ -664,7 +668,9 @@ class S3Provider(provider.BaseProvider):
             throws=exceptions.CreateFolderError
         )
 
-        return S3FolderMetadata({'Prefix': path.path})
+        metadata = S3FolderMetadata({'Prefix': path.path})
+        metadata.raw['base_folder'] = self.base_folder
+        return metadata
 
     async def _metadata_file(self, path, revision=None):
         await self._check_region()
@@ -688,10 +694,7 @@ class S3Provider(provider.BaseProvider):
     async def _metadata_folder(self, path):
         await self._check_region()
 
-        # The user selected base folder, the root of the where that user's node is connected.
-        prefix = self.settings['id'].split(':/')[1] if path == '/' and self.settings.get('id') else path.path
-
-        params = {'prefix': prefix, 'delimiter': '/'}
+        params = {'prefix': path.path, 'delimiter': '/'}
 
         resp = await self.make_request(
             'GET',


### PR DESCRIPTION
## Purpose

Enables WB to support both bucket-root and subfolder-root configuration for S3.

Credit @Johnetordoff for all the work 👍 

Project notion: https://www.notion.so/cos/S3-improvements-476a5b07cb7e4f458e9cd4c77cfa03ec
OSF Part: https://github.com/CenterForOpenScience/osf.io/pull/10416

## Changes

* Enables WB to support both bucket-root and subfolder-root configuration for S3
* Updated WB to support `:/` as the new delimiter for S3 bucket
* Added/Updated unit tests

## DevOps Notes

* Deployment requires downtime, must be deployed at the same time as [OSF](https://github.com/CenterForOpenScience/osf.io/pull/10416)
* For details, see our release playbook (TBD)

## Dev Notes

Here are all child PRs that have been merged into this feature branch.

- Unit tests: https://github.com/CenterForOpenScience/waterbutler/pull/408
- Clean-up: https://github.com/CenterForOpenScience/waterbutler/pull/407
- Path fix: https://github.com/CenterForOpenScience/waterbutler/pull/405
- Delimiter: https://github.com/CenterForOpenScience/waterbutler/pull/404 (Use `:/`)
- Prototype Subfolder: https://github.com/CenterForOpenScience/waterbutler/pull/403

## QA Notes

See QA docs in the [project notion page](https://www.notion.so/cos/S3-improvements-476a5b07cb7e4f458e9cd4c77cfa03ec)

## Documentation

Update our developers doc for S3 (if any)

## Side Effects

* WB still uses `boto` and thus won't support new regions added by `boto3`.

## Ticket

https://openscience.atlassian.net/browse/ENG-4624
