### PR TITLE
[ENG-7287] fix onedrive auth headers for download/upload requests

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Cache Build Requirements
         id: pip-cache-step
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'dev-requirements.txt') }}
@@ -44,7 +44,7 @@ jobs:
         with:
           python-version: 3.6
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt', 'dev-requirements.txt') }}

--- a/tests/providers/onedrive/test_provider.py
+++ b/tests/providers/onedrive/test_provider.py
@@ -516,7 +516,6 @@ class TestDownload:
         assert content == b'te'
         assert aiohttpretty.has_call(method='GET', uri=download_url,
                                      headers={'Range': 'bytes=0-1',
-                                              'Authorization': 'bearer wrote harry potter',
                                               'accept-encoding': ''})
 
     @pytest.mark.asyncio

--- a/waterbutler/providers/onedrive/provider.py
+++ b/waterbutler/providers/onedrive/provider.py
@@ -310,6 +310,7 @@ class OneDriveProvider(provider.BaseProvider):
             'GET',
             download_url,
             range=range,
+            no_auth_header=True,  # if download_url is signed, OD will sometimes 401 if auth header is included
             expects=(HTTPStatus.OK, HTTPStatus.PARTIAL_CONTENT),
             headers={'accept-encoding': ''},
             throws=exceptions.DownloadError,
@@ -766,6 +767,7 @@ class OneDriveProvider(provider.BaseProvider):
                                                                      start_range + len(data) - 1,
                                                                      total_size)
             },
+            no_auth_header=True,  # this endpoint will sometimes 401 if the Auth header included
             expects=(HTTPStatus.ACCEPTED, HTTPStatus.CREATED),
             throws=exceptions.UploadError
         )


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-7287

## Purpose

Fix some downloads and uploads to OneDrive. Depending on the host that serves the request, some OD requests get mad if you include an `Authorization` header with a signed request and return a `401`. Stop doing that.

## Changes

* Don't send auth headers for download and chunked upload onedrive requests
* Update WB's GitHub Actions to use `cache@v4`. `cache@v2` is deprecated and will stop working on March 1, 2025.

## Side effects

Hopefully no?

## QA Notes

Dev tested on staging!

## Deployment Notes

Nope.
