### PR TITLE
[ENG-7523] Pin versions in doc-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,6 +11,6 @@ mccabe==0.7.0
 pycodestyle==2.12.1
 pydevd==3.3.0
 pyflakes==3.2.0
-pytest==8.1.1
-pytest-asyncio==0.23.5
+pytest==8.3.5
+pytest-asyncio==0.26.0
 pytest-cov==4.1.0

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,3 +1,3 @@
-sphinx-rtd-theme
-sphinx
-sphinx-autobuild
+sphinx-rtd-theme>=3.0.2
+sphinx>=8.2.3
+sphinx-autobuild>=2024.10.3


### PR DESCRIPTION
## Ticket
[ENG-7523]

## Purpose
- Pin dependencies in doc-requirements.txt to specific versions compatible with python3.13
- Pin test related dependencies in dev-requirements.txt to newer versions where applicable

## Changes
- Add version numbers to doc-requirements.txt
- Bump versions for pytest, pytest-asyncio

## Side effects

<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->


[ENG-7523]: https://openscience.atlassian.net/browse/ENG-7523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ