### PR TITLE
[ENG-7683] migrate aws boto to boto3 for 3.13 python support (test python3 -m pytest tests/providers/s3/)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ setuptools==37.0.0
 stevedore==1.2.0
 tornado==6.0.3
 xmltodict==0.9.0
+aiobotocore==2.3.4

--- a/tests/providers/s3/fixtures.py
+++ b/tests/providers/s3/fixtures.py
@@ -31,7 +31,7 @@ def credentials():
 def settings():
     return {
         'id': 'that kerning:/my-subfolder/',
-        'bucket': 'that kerning',
+        'bucket': 'that-kerning',
         'encrypt_uploads': False
     }
 


### PR DESCRIPTION

<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status

    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

https://openscience.atlassian.net/browse/ENG-7683

## Purpose

Migrate boto to boto3 for aws suppost in python 3.13

## Changes

attempt to integrate it 


## Side effects

No need merge just a draft as an attempt to find a solution for 3.6 and than move to 3.13 and maybe teammates see what may be wrong

got such an error for now on test run

(
E           Exception: No URLs matching HEAD https://that-kerning.s3.amazonaws.com//my-subfolder/foobah?AWSAccessKeyId=Dont%20dead&Signature=iYdOszbQFw%2BFs4xPnPbHlIKWZVo%3D&Expires=1454685030 with params {'AWSAccessKeyId': 'Dont dead', 'Signature': 'iYdOszbQFw+Fs4xPnPbHlIKWZVo=', 'Expires': '1454685030'}. Not making request. Go fix your test.
)



python3 -m pytest tests/providers/s3/

![image](https://github.com/user-attachments/assets/1173e76b-53c7-4c8b-b02d-1a65932fffd1)


## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
