### PR TITLE
[ENG-7847] 2.4.4: BE: Fix broken upload reads in WB for python 3.13

### DIFF
--- a/waterbutler/core/utils.py
+++ b/waterbutler/core/utils.py
@@ -69,7 +69,7 @@ def async_retry(retries=5, backoff=1, exceptions_tuple=(Exception, )):
         @functools.wraps(func)
         async def wrapped(*args, __retries=0, **kwargs):
             try:
-                return await asyncio.coroutine(func)(*args, **kwargs)
+                return await func(*args, **kwargs)
             except exceptions_tuple as e:
                 if __retries < retries:
                     wait_time = backoff * __retries

--- a/waterbutler/server/api/v1/provider/create.py
+++ b/waterbutler/server/api/v1/provider/create.py
@@ -109,6 +109,9 @@ class CreateMixin:
         self.metadata, created = await self.uploader
         self.writer.close()
         self.wsock.close()
+        self.rsock.close()
+        self.rfd.close()
+        self.wfd.close()
         if created:
             self.set_status(201)
 

--- a/waterbutler/server/api/v1/provider/create.py
+++ b/waterbutler/server/api/v1/provider/create.py
@@ -109,7 +109,7 @@ class CreateMixin:
         self.metadata, created = await self.uploader
         self.writer.close()
         # Docs: https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamWriter.wait_closed
-        await writer.wait_closed()
+        await self.writer.wait_closed()
         self.wsock.close()
         self.rsock.close()
         self.rfd.close()

--- a/waterbutler/server/api/v1/provider/create.py
+++ b/waterbutler/server/api/v1/provider/create.py
@@ -108,6 +108,8 @@ class CreateMixin:
 
         self.metadata, created = await self.uploader
         self.writer.close()
+        # Docs: https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamWriter.wait_closed
+        await writer.wait_closed()
         self.wsock.close()
         self.rsock.close()
         self.rfd.close()


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

https://openscience.atlassian.net/browse/ENG-7847

## Purpose

WB cant seem to read file uploads from tornado. Fix that!

## Changes

Change  `async def prepare_stream(self):`   `async def data_received(self, chunk)` write/read stream logic to make it possible to work with python 3.13


https://github.com/user-attachments/assets/f3ddb9e3-4f31-41c1-88b2-e4ba2a697e70



## Side effects

It looks like a low level code changings so maybe there is more explicit way to do it to keep it more clear.

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
