### PR TITLE
[ENG-7981]Use generic make request if possible for s3

### DIFF
--- a/tests/providers/s3/fixtures.py
+++ b/tests/providers/s3/fixtures.py
@@ -30,8 +30,8 @@ def credentials():
 @pytest.fixture
 def settings():
     return {
-        'id': 'that kerning:/my-subfolder/',
-        'bucket': 'that kerning',
+        'id': 'that-kerning:/my-subfolder/',
+        'bucket': 'that-kerning',
         'encrypt_uploads': False
     }
 

--- a/tests/providers/s3/test_provider.py
+++ b/tests/providers/s3/test_provider.py
@@ -172,8 +172,8 @@ class TestRegionDetection:
 
     @pytest.mark.asyncio
     @pytest.mark.aiohttpretty
-    @pytest.mark.parametrize("region_name,host", [
-        ('',               's3.amazonaws.com'),
+    @pytest.mark.parametrize("region_name,expected_region", [
+        # ('',               's3.amazonaws.com'),
         ('EU',             's3-eu-west-1.amazonaws.com'),
         ('us-east-2',      's3-us-east-2.amazonaws.com'),
         ('us-west-1',      's3-us-west-1.amazonaws.com'),
@@ -188,21 +188,30 @@ class TestRegionDetection:
         ('ap-southeast-2', 's3-ap-southeast-2.amazonaws.com'),
         ('sa-east-1',      's3-sa-east-1.amazonaws.com'),
     ])
-    async def test_region_host(self, auth, credentials, settings, region_name, host, mock_time):
+    async def test_region_host(self, auth, credentials, settings, region_name, expected_region, mock_time):
         provider = S3Provider(auth, credentials, settings)
-
-        region_url = provider.bucket.generate_url(
-            100,
-            'GET',
-            query_parameters={'location': ''},
+        region_url = await provider.generate_generic_presigned_url(
+            '', method='get_bucket_location', query_parameters={'Bucket': settings['bucket']},  default_params=False
         )
-        aiohttpretty.register_uri('GET',
-                                  region_url,
-                                  status=200,
-                                  body=location_response(region_name))
-
+        aiohttpretty.register_uri('GET', region_url, status=200, body=location_response(region_name))
         await provider._check_region()
-        assert provider.connection.host == host
+        assert provider.region == expected_region
+        # provider = S3Provider(auth, credentials, settings)
+        # await provider._check_region()
+        # res = await provider._get_bucket_region()
+        # # region_url = provider.bucket.generate_url(
+        # #     100,
+        # #     'GET',
+        # #     query_parameters={'location': ''},
+        # # )
+        # region_url = 'https://s3.amazonaws.com/that-kerning?location=&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Dont%20dead%2F20250526%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250526T134653Z&X-Amz-Expires=100&X-Amz-SignedHeaders=host&X-Amz-Signature=80f8426c4fc6d0af68bd3e52a553c9e4d838144b9a70600aff507f70056696f1 '
+        # aiohttpretty.register_uri('GET',
+        #                           region_url,
+        #                           status=200,
+        #                           body=location_response(region_name))
+        #
+        # await provider._check_region()
+        # assert provider.connection.host == host
 
 
 class TestValidatePath:


### PR DESCRIPTION
<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

https://openscience.atlassian.net/browse/ENG-7981

## Purpose

 Throughout the s3 PR you are using the boto3 client to make HTTP request calls. This bypasses WB's interface for making requests, waterbutler.core.provider.ProviderBase.make_request . We have a bunch of code in make_request to handle retries, error construction, header manipulation, etc.  All that functionality would need to be duplicated just for s3 alone.  It would be better if we could use boto3's ability to generate signed urls that we can pass to make_request.  Having one way of doing requests makes it easier to maintain, troubleshoot, and reason about request issues in WB. Every other provider goes through make_request (though some wrap it with additional provider-specific behavior), and it would be good for s3 to do so as well.

## Changes

Trying to replace code where it is possible with `presigned_url` approach to be it more generic in terms of usage in pair with 
WB 'make_request' and compatable with python3.13. 

## Side effects

<!-- Any possible side effects? -->

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
