### PR TITLE
[ENG-8229] Address warning re: AsyncMockMixin not being awaited

### DIFF
--- a/tests/server/api/v1/test_create_mixin.py
+++ b/tests/server/api/v1/test_create_mixin.py
@@ -235,7 +235,9 @@ class TestCreateFolder:
         handler.provider.create_folder.assert_called_once_with(WaterButlerPath('/apath/'))
 
 def create_upload_handler(http_request, mock_file_metadata, created):
-    obj = mock_handler(http_request, upload_retval=(mock_file_metadata, created))
+    obj = mock_handler(http_request)
+    upload_mock = mock.AsyncMock(return_value=(mock_file_metadata, created))
+    obj.uploader = upload_mock()
     obj.rsock = mock.Mock()
     obj.rfd = mock.Mock()
     obj.wfd = mock.Mock()

--- a/tests/server/api/v1/utils.py
+++ b/tests/server/api/v1/utils.py
@@ -36,7 +36,7 @@ class ServerTestCase(testing.AsyncHTTPTestCase):
         return make_app(debug=False)
 
 
-def mock_handler(http_request, upload_retval=None):
+def mock_handler(http_request):
     """
     Mock WB Provider Handler.
 
@@ -63,8 +63,6 @@ def mock_handler(http_request, upload_retval=None):
     handler.write = Mock()
     handler.write_stream = MockCoroutine()
     handler.redirect = Mock()
-    upload_mock = AsyncMock(return_value=upload_retval)
-    handler.uploader = upload_mock()
     handler.wsock = Mock()
     handler.writer = Mock()
     return handler


### PR DESCRIPTION
## Ticket
[ENG-8229]

## Purpose
- Address warning that is gumming up the test logs

## Changes
- Remove `mock_handler.uploader` which uses `AsyncMock` from generic `mock_handler` util
- Add back `uploader` only to test that needs it

## Side effects
- `mock_handler.uploader` is no longer accessible in other tests that are using `mock_handler`

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->


[ENG-8229]: https://openscience.atlassian.net/browse/ENG-8229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ