### PR TITLE
[ENG-8404] path is needed to be started with '/' 

### DIFF
--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -302,7 +302,9 @@ class DropboxProvider(provider.BaseProvider):
         :return: A dictionary of the metadata about the file just uploaded
         """
 
-        path_arg = {"path": path.full_path}
+        path_full_path = path.full_path
+        path_arg = {"path": path_full_path if path_full_path.startswith('/') else f'/{path_full_path}'}
+
         if conflict == 'replace':
             path_arg['mode'] = 'overwrite'
 
@@ -526,6 +528,8 @@ class DropboxProvider(provider.BaseProvider):
             self.metrics.add('metadata.folder.pages', page_count)
             return ret
 
+        if not body['path'].startswith('/'):
+            body['path'] = f'/{body['path']}'
         data = await self.dropbox_request(url, body, throws=core_exceptions.MetadataError)
         # Dropbox v2 API will not indicate file/folder if path "deleted"
         if data['.tag'] == 'deleted':

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -531,8 +531,6 @@ class DropboxProvider(provider.BaseProvider):
             self.metrics.add('metadata.folder.pages', page_count)
             return ret
 
-        if not body['path'].startswith('/'):
-            body['path'] = f'/{body['path']}'
         data = await self.dropbox_request(url, body, throws=core_exceptions.MetadataError)
         # Dropbox v2 API will not indicate file/folder if path "deleted"
         if data['.tag'] == 'deleted':

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -305,8 +305,8 @@ class DropboxProvider(provider.BaseProvider):
         :return: A dictionary of the metadata about the file just uploaded
         """
 
-        path_full_path = path.full_path
-        path_arg = {"path": path_full_path if path_full_path.startswith('/') else f'/{path_full_path}'}
+        full_path = path.full_path
+        path_arg = {"path": full_path if full_path.startswith('/') or full_path.startswith('rev:') else f'/{full_path}'}
 
         if conflict == 'replace':
             path_arg['mode'] = 'overwrite'

--- a/waterbutler/providers/dropbox/provider.py
+++ b/waterbutler/providers/dropbox/provider.py
@@ -89,6 +89,9 @@ class DropboxProvider(provider.BaseProvider):
         :param tuple \*args: passed through to BaseProvider.make_request()
         :param dict \*\*kwargs: passed through to BaseProvider.make_request()
         """
+        path = body.get('path')
+        if path and not path.startswith('/') and not path.startswith('rev:'):
+            body['path'] = f'/{path}'
         resp = await self.make_request(
             'POST',
             url,


### PR DESCRIPTION
on coping from bitbucket to dropbox (suppose it may be common for all providers)

<!-- Use the following format for the title of the Pull Request:

    [Status] [Ticket] Title

    - For PR ready for review, no need for status
    - For PR in progress, use [WIP]
    - For PR on hold, use [HOLD]
-->

<!-- Before submit your Pull Request, make sure you picked the right branch:

    - For hotfixes, select "master" as the target branch
    - For new features and improvements, select "develop" as the target branch
-->

<!-- For security related tickets, talk with the team lead before submit your PR -->

## Ticket

https://openscience.atlassian.net/browse/ENG-8404

## Purpose

Fix coping file from bitbucket to dropbox

`waterbutler.core.exceptions.MetadataError: 400, {"response": "Error in call to API function \"files/get_metadata\": request body: path: '.gitignore' did not match pattern '(/(.|[\\r\\n])*|id:.*)|(rev:[0-9a-f]{9,})|(ns:[0-9]+(/.*)?)'"}`

<img width="1331" height="565" alt="image" src="https://github.com/user-attachments/assets/75aaa0bf-a789-4abf-a36e-70d762f15df5" />

<img width="2841" height="1460" alt="image" src="https://github.com/user-attachments/assets/a7b2f5a9-fbc6-441b-b5ba-114208e05971" />



## Changes

adding / at the path beginning if it is not set before `self.make_request` call to avoid possible errors 

<img width="3449" height="1507" alt="image" src="https://github.com/user-attachments/assets/6551fd3e-464b-4535-9536-e0a058a5d21c" />


## Side effects

Maybe there is additional use cases where the condition is needed to be added too or do it more generic all over providers

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->

## Deployment Notes

<!-- Any special configurations for deployment? -->
